### PR TITLE
feat: add paginated sync flow with full sync option

### DIFF
--- a/scripts/test-api-response.js
+++ b/scripts/test-api-response.js
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+const verbose = args.includes("--verbose") || args.includes("-v");
+
+// Find non-flag arguments
+const nonFlagArgs = args.filter(
+  (arg) => !arg.startsWith("--") && !arg.startsWith("-")
+);
+
+// Parse --output or -o flag for output file
+let outputFile = null;
+const outputIndex = args.findIndex((arg) => arg === "--output" || arg === "-o");
+if (outputIndex !== -1 && args[outputIndex + 1]) {
+  outputFile = args[outputIndex + 1];
+}
+
+// Parse --body or -b flag for body JSON
+let bodyJson = null;
+const bodyIndex = args.findIndex((arg) => arg === "--body" || arg === "-b");
+if (bodyIndex !== -1 && args[bodyIndex + 1]) {
+  bodyJson = args[bodyIndex + 1];
+}
+
+const defaultPath = path.join(
+  os.homedir(),
+  "Library/Application Support/Granola/supabase.json"
+);
+const credentialsPath = defaultPath;
+
+// Read and parse credentials file
+let accessToken;
+try {
+  const credentialsData = fs.readFileSync(credentialsPath, "utf8");
+  const tokenData = JSON.parse(credentialsData);
+  const workosTokens = JSON.parse(tokenData.workos_tokens);
+  accessToken = workosTokens.access_token;
+
+  if (!accessToken) {
+    console.error("Error: No access token found in credentials file");
+    process.exit(1);
+  }
+
+  if (verbose) {
+    console.log("✓ Successfully loaded access token");
+  }
+} catch (error) {
+  console.error(`Error reading credentials file: ${error.message}`);
+  process.exit(1);
+}
+
+// Make API request
+async function fetchApiResponse() {
+  try {
+    const url = "https://api.granola.ai/v2/get-documents";
+
+    // Build body - merge default with CLI-provided body
+    const defaultBody = {
+      limit: 3,
+      include_last_viewed_panel: true,
+    };
+
+    let body;
+    if (bodyJson) {
+      try {
+        const cliBody = JSON.parse(bodyJson);
+        body = JSON.stringify({ ...defaultBody, ...cliBody });
+        if (verbose) {
+          console.log("Using body:", body);
+        }
+      } catch (error) {
+        console.error(`Error parsing --body JSON: ${error.message}`);
+        process.exit(1);
+      }
+    } else {
+      body = JSON.stringify(defaultBody);
+    }
+
+    if (verbose) {
+      console.log(`\nMaking API request to ${url}...`);
+      console.log(`Request body: ${body}`);
+    }
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+        Accept: "*/*",
+        "User-Agent": "Undefined",
+        "X-Client-Version": "1.0.0",
+      },
+      body: body,
+    });
+
+    if (verbose) {
+      console.log(
+        `\nResponse status: ${response.status} ${response.statusText}`
+      );
+    }
+
+    const responseData = await response.json();
+
+    // Save to file if output file specified
+    if (outputFile) {
+      const outputPath = path.resolve(outputFile);
+      fs.writeFileSync(outputPath, JSON.stringify(responseData, null, 2));
+      console.log(`\n✓ Response saved to: ${outputPath}`);
+    } else {
+      console.log(JSON.stringify(responseData, null, 2));
+    }
+  } catch (error) {
+    console.error(`\nError making API request: ${error.message}`);
+    if (error.stack) {
+      console.error(error.stack);
+    }
+    process.exit(1);
+  }
+}
+
+fetchApiResponse();

--- a/src/main.ts
+++ b/src/main.ts
@@ -292,7 +292,7 @@ export default class GranolaSync extends Plugin {
     // Build the Granola ID cache before syncing
     await this.fileSyncService.buildCache();
 
-    // Fetch documents (now handles credentials)
+    // Fetch documents
     const documents = await this.fetchDocuments(accessToken);
     if (!documents || documents.length === 0) {
       log.debug("No documents fetched from Granola API");

--- a/src/main.ts
+++ b/src/main.ts
@@ -181,8 +181,8 @@ export default class GranolaSync extends Plugin {
     filename: string,
     content: string,
     noteDate: Date,
-    isTranscript: boolean = false,
-    granolaId?: string
+    granolaId: string,
+    isTranscript: boolean = false
   ): Promise<boolean> {
     // Resolve the folder path
     const folderPath = this.resolveFolderPath(noteDate, isTranscript);
@@ -207,11 +207,14 @@ export default class GranolaSync extends Plugin {
 
   // Save a note to disk based on the sync destination setting
   private async saveNoteToDisk(doc: GranolaDoc): Promise<boolean> {
+    if (!doc.id) {
+      console.error("Document missing required id field:", doc);
+      return false;
+    }
     const { filename, content } = this.documentProcessor.prepareNote(doc);
-    const docId = doc.id || "unknown_id";
     const noteDate = getNoteDate(doc);
 
-    return this.saveToDisk(filename, content, noteDate, false, docId);
+    return this.saveToDisk(filename, content, noteDate, doc.id, false);
   }
 
   // Save a transcript to disk based on the transcript destination setting
@@ -219,15 +222,18 @@ export default class GranolaSync extends Plugin {
     doc: GranolaDoc,
     transcriptContent: string
   ): Promise<boolean> {
+    if (!doc.id) {
+      console.error("Document missing required id field:", doc);
+      return false;
+    }
     const { filename, content } = this.documentProcessor.prepareTranscript(
       doc,
       transcriptContent
     );
-    const docId = doc.id || "unknown_id";
     const noteDate = getNoteDate(doc);
 
     // Use the original docId - transcripts now distinguished by type field in frontmatter
-    return this.saveToDisk(filename, content, noteDate, true, docId);
+    return this.saveToDisk(filename, content, noteDate, doc.id, true);
   }
 
   private async fetchDocuments(accessToken: string): Promise<GranolaDoc[]> {

--- a/src/services/granolaApi.ts
+++ b/src/services/granolaApi.ts
@@ -33,9 +33,17 @@ export interface GranolaDoc {
 // Infer TypeScript type from validation schema
 export type TranscriptEntry = v.InferOutput<typeof TranscriptEntrySchema>;
 
+/**
+ * Fetches documents from the Granola API.
+ *
+ * Pagination: The API supports offset-based pagination via the `offset` parameter.
+ * No pagination metadata is returned in responses.
+ * Use `offset` to skip documents: offset=0 for first page, offset=limit for second page, etc.
+ */
 export async function fetchGranolaDocuments(
   accessToken: string,
-  limit: number = 100
+  limit: number = 100,
+  offset: number = 0
 ): Promise<GranolaDoc[]> {
   const response = await requestUrl({
     url: "https://api.granola.ai/v2/get-documents",
@@ -47,8 +55,8 @@ export async function fetchGranolaDocuments(
       "User-Agent": `GranolaObsidianPlugin/${PLUGIN_VERSION}`,
     },
     body: JSON.stringify({
-      limit: limit,
-      offset: 0,
+      limit,
+      offset,
       include_last_viewed_panel: true,
     }),
   });
@@ -64,6 +72,83 @@ export async function fetchGranolaDocuments(
   }
 }
 
+export async function fetchAllGranolaDocuments(
+  accessToken: string,
+  pageSize: number = 100
+): Promise<GranolaDoc[]> {
+  const documents: GranolaDoc[] = [];
+  let offset = 0;
+
+  while (true) {
+    const page = await fetchGranolaDocuments(accessToken, pageSize, offset);
+    if (page.length === 0) {
+      break;
+    }
+
+    documents.push(...page);
+
+    if (page.length < pageSize) {
+      break;
+    }
+
+    offset += pageSize;
+  }
+
+  return documents;
+}
+
+export async function fetchGranolaDocumentsByDaysBack(
+  accessToken: string,
+  daysBack: number,
+  pageSize: number = 100
+): Promise<GranolaDoc[]> {
+  if (daysBack === 0) {
+    return fetchAllGranolaDocuments(accessToken, pageSize);
+  }
+
+  const cutoffDate = new Date();
+  cutoffDate.setDate(cutoffDate.getDate() - daysBack);
+
+  const documents: GranolaDoc[] = [];
+  let offset = 0;
+
+  while (true) {
+    const page = await fetchGranolaDocuments(accessToken, pageSize, offset);
+    if (page.length === 0) {
+      break;
+    }
+
+    documents.push(...page);
+
+    const hasOlderThanCutoff = page.some((doc) => {
+      const docDate = doc.created_at
+        ? new Date(doc.created_at)
+        : doc.updated_at
+        ? new Date(doc.updated_at)
+        : new Date();
+      return docDate < cutoffDate;
+    });
+
+    if (hasOlderThanCutoff || page.length < pageSize) {
+      break;
+    }
+
+    offset += pageSize;
+  }
+
+  return documents.filter((doc) => {
+    const docDate = doc.created_at
+      ? new Date(doc.created_at)
+      : doc.updated_at
+      ? new Date(doc.updated_at)
+      : new Date();
+    return docDate >= cutoffDate;
+  });
+}
+
+/**
+ * Fetches the transcript for a specific Granola document.
+ */
 export async function fetchGranolaTranscript(
   accessToken: string,
   docId: string

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,5 @@
 import { App, PluginSettingTab, Setting, Notice } from "obsidian";
 import type GranolaSync from "./main";
-import os from "os";
 
 export enum SyncDestination {
   GRANOLA_FOLDER = "granola_folder",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -331,5 +331,19 @@ export class GranolaSyncSettingTab extends PluginSettingTab {
           );
       }
     }
+
+    new Setting(containerEl)
+      .setName("Full sync")
+      .setDesc("Fetch all available documents from Granola right now.")
+      .addButton((button) =>
+        button
+          .setButtonText("Full sync")
+          .setCta()
+          .onClick(async () => {
+            new Notice("Granola sync: Starting full sync.");
+            await this.plugin.sync({ mode: "full" });
+            new Notice("Granola sync: Full sync complete.");
+          })
+      );
   }
 }


### PR DESCRIPTION
## Improve sync pipeline and UI feedback
- allow standard vs full sync runs and surface progress in the status bar
- add a full sync button in settings and validate document ids before saving

## Support paginated document retrieval
- paginate requests via offset so full datasets can be fetched when required
- expose helpers to fetch all documents or limit by recent days

## Streamline file deduplication
- rely solely on the granolaId cache to detect existing files before writes
- require granolaId for saves and update unit tests for the stricter contract

Closes https://github.com/tomelliot/obsidian-granola-sync/issues/18