### PR TITLE
feat: add attendees frontmatter to notes and transcripts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -267,6 +267,15 @@ export default class GranolaSync extends Plugin {
   private async syncNotesToDailyNotes(
     documents: GranolaDoc[]
   ): Promise<number> {
+    // Extract attendees from people.attendees for all documents before processing
+    for (const doc of documents) {
+      if (doc.people?.attendees && doc.people.attendees.length > 0) {
+        doc.attendees = doc.people.attendees
+          .map((attendee) => attendee.name || attendee.email || "Unknown")
+          .filter((name) => name !== "Unknown");
+      }
+    }
+    
     const dailyNotesMap = this.dailyNoteBuilder.buildDailyNotesMap(documents);
     const sectionHeadingSetting = this.settings.dailyNoteSectionHeading.trim();
     let processedCount = 0;
@@ -299,6 +308,15 @@ export default class GranolaSync extends Plugin {
   private async syncNotesToIndividualFiles(
     documents: GranolaDoc[]
   ): Promise<number> {
+    // Extract attendees from people.attendees for all documents before processing
+    for (const doc of documents) {
+      if (doc.people?.attendees && doc.people.attendees.length > 0) {
+        doc.attendees = doc.people.attendees
+          .map((attendee) => attendee.name || attendee.email || "Unknown")
+          .filter((name) => name !== "Unknown");
+      }
+    }
+    
     let processedCount = 0;
     let syncedCount = 0;
 
@@ -328,6 +346,15 @@ export default class GranolaSync extends Plugin {
     documents: GranolaDoc[],
     accessToken: string
   ): Promise<void> {
+    // Extract attendees from people.attendees for all documents before processing transcripts
+    for (const doc of documents) {
+      if (doc.people?.attendees && doc.people.attendees.length > 0) {
+        doc.attendees = doc.people.attendees
+          .map((attendee) => attendee.name || attendee.email || "Unknown")
+          .filter((name) => name !== "Unknown");
+      }
+    }
+    
     let processedCount = 0;
     let syncedCount = 0;
     for (const doc of documents) {
@@ -347,7 +374,8 @@ export default class GranolaSync extends Plugin {
           title,
           docId,
           doc.created_at,
-          doc.updated_at
+          doc.updated_at,
+          doc.attendees
         );
         processedCount++;
         this.updateSyncStatus("Transcript", processedCount, documents.length);

--- a/src/main.ts
+++ b/src/main.ts
@@ -267,14 +267,7 @@ export default class GranolaSync extends Plugin {
   private async syncNotesToDailyNotes(
     documents: GranolaDoc[]
   ): Promise<number> {
-    // Extract attendees from people.attendees for all documents before processing
-    for (const doc of documents) {
-      if (doc.people?.attendees && doc.people.attendees.length > 0) {
-        doc.attendees = doc.people.attendees
-          .map((attendee) => attendee.name || attendee.email || "Unknown")
-          .filter((name) => name !== "Unknown");
-      }
-    }
+
     
     const dailyNotesMap = this.dailyNoteBuilder.buildDailyNotesMap(documents);
     const sectionHeadingSetting = this.settings.dailyNoteSectionHeading.trim();
@@ -308,14 +301,7 @@ export default class GranolaSync extends Plugin {
   private async syncNotesToIndividualFiles(
     documents: GranolaDoc[]
   ): Promise<number> {
-    // Extract attendees from people.attendees for all documents before processing
-    for (const doc of documents) {
-      if (doc.people?.attendees && doc.people.attendees.length > 0) {
-        doc.attendees = doc.people.attendees
-          .map((attendee) => attendee.name || attendee.email || "Unknown")
-          .filter((name) => name !== "Unknown");
-      }
-    }
+
     
     let processedCount = 0;
     let syncedCount = 0;
@@ -346,15 +332,7 @@ export default class GranolaSync extends Plugin {
     documents: GranolaDoc[],
     accessToken: string
   ): Promise<void> {
-    // Extract attendees from people.attendees for all documents before processing transcripts
-    for (const doc of documents) {
-      if (doc.people?.attendees && doc.people.attendees.length > 0) {
-        doc.attendees = doc.people.attendees
-          .map((attendee) => attendee.name || attendee.email || "Unknown")
-          .filter((name) => name !== "Unknown");
-      }
-    }
-    
+
     let processedCount = 0;
     let syncedCount = 0;
     for (const doc of documents) {
@@ -375,7 +353,9 @@ export default class GranolaSync extends Plugin {
           docId,
           doc.created_at,
           doc.updated_at,
-          doc.attendees
+          doc.people?.attendees
+            ?.map((attendee) => attendee.name || attendee.email || "Unknown")
+            .filter((name) => name !== "Unknown")
         );
         processedCount++;
         this.updateSyncStatus("Transcript", processedCount, documents.length);

--- a/src/services/documentProcessor.ts
+++ b/src/services/documentProcessor.ts
@@ -48,10 +48,14 @@ export class DocumentProcessor {
     ];
     if (doc.created_at) frontmatterLines.push(`created_at: ${doc.created_at}`);
     if (doc.updated_at) frontmatterLines.push(`updated_at: ${doc.updated_at}`);
-    if (doc.attendees && doc.attendees.length > 0) {
-      // Format attendees as YAML array with lowercase field name
-      const attendeesYaml = doc.attendees.map(name => `  - ${name}`).join("\n");
+    const attendees = doc.people?.attendees
+      ?.map((attendee) => attendee.name || attendee.email || "Unknown")
+      .filter((name) => name !== "Unknown") || [];
+    if (attendees.length > 0) {
+      const attendeesYaml = attendees.map(name => `  - ${name}`).join("\n");
       frontmatterLines.push(`attendees:\n${attendeesYaml}`);
+    } else {
+      frontmatterLines.push(`attendees: []`);
     }
     frontmatterLines.push("---", "");
 

--- a/src/services/documentProcessor.ts
+++ b/src/services/documentProcessor.ts
@@ -48,6 +48,11 @@ export class DocumentProcessor {
     ];
     if (doc.created_at) frontmatterLines.push(`created_at: ${doc.created_at}`);
     if (doc.updated_at) frontmatterLines.push(`updated_at: ${doc.updated_at}`);
+    if (doc.attendees && doc.attendees.length > 0) {
+      // Format attendees as YAML array with lowercase field name
+      const attendeesYaml = doc.attendees.map(name => `  - ${name}`).join("\n");
+      frontmatterLines.push(`attendees:\n${attendeesYaml}`);
+    }
     frontmatterLines.push("---", "");
 
     let finalMarkdown = frontmatterLines.join("\n");

--- a/src/services/granolaApi.ts
+++ b/src/services/granolaApi.ts
@@ -25,6 +25,13 @@ export interface GranolaDoc {
   title: string | null;
   created_at?: string;
   updated_at?: string;
+  attendees?: string[];
+  people?: {
+    attendees?: Array<{
+      name?: string;
+      email?: string;
+    }>;
+  };
   last_viewed_panel?: {
     content?: ProseMirrorDoc | string | null;
   } | null;

--- a/src/services/transcriptFormatter.ts
+++ b/src/services/transcriptFormatter.ts
@@ -29,10 +29,12 @@ export function formatTranscriptBySpeaker(
   ];
   if (createdAt) frontmatterLines.push(`created_at: ${createdAt}`);
   if (updatedAt) frontmatterLines.push(`updated_at: ${updatedAt}`);
-  if (attendees && attendees.length > 0) {
-    // Format attendees as YAML array with lowercase field name
-    const attendeesYaml = attendees.map(name => `  - ${name}`).join("\n");
+  const attendeesArray = attendees || [];
+  if (attendeesArray.length > 0) {
+    const attendeesYaml = attendeesArray.map(name => `  - ${name}`).join("\n");
     frontmatterLines.push(`attendees:\n${attendeesYaml}`);
+  } else {
+    frontmatterLines.push(`attendees: []`);
   }
   frontmatterLines.push("---", "");
 

--- a/src/services/transcriptFormatter.ts
+++ b/src/services/transcriptFormatter.ts
@@ -8,6 +8,7 @@ import { TranscriptEntry } from "./granolaApi";
  * @param granolaId - Granola document ID
  * @param createdAt - Optional creation timestamp
  * @param updatedAt - Optional update timestamp
+ * @param attendees - Optional array of attendee names
  * @returns Formatted markdown string with frontmatter and speaker-grouped content
  */
 export function formatTranscriptBySpeaker(
@@ -15,7 +16,8 @@ export function formatTranscriptBySpeaker(
   title: string,
   granolaId: string,
   createdAt?: string,
-  updatedAt?: string
+  updatedAt?: string,
+  attendees?: string[]
 ): string {
   // Add frontmatter with granola_id for transcript deduplication
   const escapedTitleForYaml = title.replace(/"/g, '\\"');
@@ -27,6 +29,11 @@ export function formatTranscriptBySpeaker(
   ];
   if (createdAt) frontmatterLines.push(`created_at: ${createdAt}`);
   if (updatedAt) frontmatterLines.push(`updated_at: ${updatedAt}`);
+  if (attendees && attendees.length > 0) {
+    // Format attendees as YAML array with lowercase field name
+    const attendeesYaml = attendees.map(name => `  - ${name}`).join("\n");
+    frontmatterLines.push(`attendees:\n${attendeesYaml}`);
+  }
   frontmatterLines.push("---", "");
 
   let transcriptMd = frontmatterLines.join("\n") + "\n";

--- a/src/services/validationSchemas.ts
+++ b/src/services/validationSchemas.ts
@@ -21,6 +21,19 @@ export const GranolaDocSchema = v.object({
   title: v.nullish(v.string()),
   created_at: v.optional(v.string()),
   updated_at: v.optional(v.string()),
+  attendees: v.optional(v.array(v.string())),
+  people: v.optional(
+    v.object({
+      attendees: v.optional(
+        v.array(
+          v.object({
+            name: v.optional(v.string()),
+            email: v.optional(v.string()),
+          })
+        )
+      ),
+    })
+  ),
   last_viewed_panel: v.nullish(
     v.object({
       // Content can be either a ProseMirrorDoc object or an HTML string

--- a/src/services/validationSchemas.ts
+++ b/src/services/validationSchemas.ts
@@ -21,7 +21,6 @@ export const GranolaDocSchema = v.object({
   title: v.nullish(v.string()),
   created_at: v.optional(v.string()),
   updated_at: v.optional(v.string()),
-  attendees: v.optional(v.array(v.string())),
   people: v.optional(
     v.object({
       attendees: v.optional(

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -11,3 +11,4 @@ export const log = {
     }
   },
 };
+


### PR DESCRIPTION
## Summary
Adds attendees information to the frontmatter of both synced notes and transcripts from Granola.

## Changes
- Extract attendees from `people.attendees` nested structure in Granola API response
- Add `attendees` field to frontmatter for both notes and transcripts
- Use lowercase `attendees:` field name (as per review feedback)
- Always include attendees when available from API (no settings toggle)

## Implementation Details
- Extracts attendee names from `doc.people.attendees` array
- Maps attendees to string array using `name` or `email` field (fallback to "Unknown" if neither exists)
- Filters out "Unknown" entries
- Formats attendees as YAML array in frontmatter:
  
  attendees:
    - John Doe
    - Jane Smith
  ## Files Changed
- `src/main.ts` - Added extraction logic in sync methods (daily notes, individual files, transcripts)
- `src/services/documentProcessor.ts` - Added attendees to note frontmatter
- `src/services/transcriptFormatter.ts` - Added attendees parameter and frontmatter support
- `src/services/granolaApi.ts` - Added `attendees` field to `GranolaDoc` interface
- `src/services/validationSchemas.ts` - Already had attendees validation schema
<img width="462" height="223" alt="Screenshot 2025-11-10 at 11 25 41 AM" src="https://github.com/user-attachments/assets/55f68410-8d63-440e-b72f-6c6c50882807" />

## Testing
- Attendees are extracted from API response and added to frontmatter when available
- Works for both notes and transcripts
- Only includes attendees when `people.attendees` exists in API response