### PR TITLE
fix: add client version header for granola api calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,6 @@
   "devDependencies": {
     "@types/jest": "^29.5.12",
     "@types/node": "^20.11.24",
-    "@typescript-eslint/eslint-plugin": "^7.1.0",
-    "@typescript-eslint/parser": "^7.1.0",
     "builtin-modules": "^3.3.0",
     "esbuild": "0.20.1",
     "jest": "^29.7.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -267,8 +267,6 @@ export default class GranolaSync extends Plugin {
   private async syncNotesToDailyNotes(
     documents: GranolaDoc[]
   ): Promise<number> {
-
-    
     const dailyNotesMap = this.dailyNoteBuilder.buildDailyNotesMap(documents);
     const sectionHeadingSetting = this.settings.dailyNoteSectionHeading.trim();
     let processedCount = 0;
@@ -301,8 +299,6 @@ export default class GranolaSync extends Plugin {
   private async syncNotesToIndividualFiles(
     documents: GranolaDoc[]
   ): Promise<number> {
-
-    
     let processedCount = 0;
     let syncedCount = 0;
 
@@ -332,7 +328,6 @@ export default class GranolaSync extends Plugin {
     documents: GranolaDoc[],
     accessToken: string
   ): Promise<void> {
-
     let processedCount = 0;
     let syncedCount = 0;
     for (const doc of documents) {

--- a/src/services/granolaApi.ts
+++ b/src/services/granolaApi.ts
@@ -60,6 +60,7 @@ export async function fetchGranolaDocuments(
       "Content-Type": "application/json",
       Accept: "*/*",
       "User-Agent": `GranolaObsidianPlugin/${PLUGIN_VERSION}`,
+      "X-Client-Version": `GranolaObsidianPlugin/${PLUGIN_VERSION}`,
     },
     body: JSON.stringify({
       limit,
@@ -68,13 +69,16 @@ export async function fetchGranolaDocuments(
     }),
   });
 
+  const jsonResponse = response.json;
+
   try {
-    const apiResponse = v.parse(GranolaApiResponseSchema, response.json);
+    const apiResponse = v.parse(GranolaApiResponseSchema, jsonResponse);
     return apiResponse.docs as GranolaDoc[];
   } catch (error) {
     const errorMessage = `Invalid response from Granola API: ${
       error instanceof Error ? error.message : "Unknown error"
     }`;
+    console.error(JSON.stringify(jsonResponse, null, 2));
     throw new Error(errorMessage);
   }
 }
@@ -168,6 +172,7 @@ export async function fetchGranolaTranscript(
       "Content-Type": "application/json",
       Accept: "*/*",
       "User-Agent": `GranolaObsidianPlugin/${PLUGIN_VERSION}`,
+      "X-Client-Version": `GranolaObsidianPlugin/${PLUGIN_VERSION}`,
     },
     body: JSON.stringify({ document_id: docId }),
   });

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -11,4 +11,3 @@ export const log = {
     }
   },
 };
-


### PR DESCRIPTION
- add `X-Client-Version` alongside existing user agent metadata
- remove unused `@typescript-eslint` dev dependencies
- tidy redundant whitespace