### PR TITLE
refactor: standardize logging

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -253,7 +253,10 @@ export default class GranolaSync extends Plugin {
     showStatusBarTemporary(this, "Granola sync: Complete");
   }
 
-  private async syncNotes(documents: GranolaDoc[], forceOverwrite: boolean = false): Promise<void> {
+  private async syncNotes(
+    documents: GranolaDoc[],
+    forceOverwrite: boolean = false
+  ): Promise<void> {
     const syncedCount =
       this.settings.syncDestination === SyncDestination.DAILY_NOTES
         ? await this.syncNotesToDailyNotes(documents, forceOverwrite)
@@ -319,7 +322,11 @@ export default class GranolaSync extends Plugin {
       this.updateSyncStatus("Note", processedCount, documents.length);
 
       if (
-        await this.fileSyncService.saveNoteToDisk(doc, this.documentProcessor, forceOverwrite)
+        await this.fileSyncService.saveNoteToDisk(
+          doc,
+          this.documentProcessor,
+          forceOverwrite
+        )
       ) {
         syncedCount++;
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -77,7 +77,7 @@ export default class GranolaSync extends Plugin {
     // Run silent migration for legacy frontmatter formats
     const migrationService = new FrontmatterMigrationService(this.app);
     migrationService.migrateLegacyFrontmatter().catch((error) => {
-      console.error("Error during frontmatter migration:", error);
+      log.error("Error during frontmatter migration:", error);
     });
 
     // This adds a simple command that can be triggered anywhere
@@ -166,7 +166,7 @@ export default class GranolaSync extends Plugin {
     // Load credentials at the start of each sync
     const { accessToken, error } = await loadGranolaCredentials();
     if (!accessToken || error) {
-      console.error("Error loading Granola credentials:", error);
+      log.error("Error loading Granola credentials:", error);
       new Notice(
         `Granola sync error: ${error || "No access token loaded."}`,
         10000
@@ -193,7 +193,7 @@ export default class GranolaSync extends Plugin {
       const errorStatus = (error as { status?: number })?.status;
       if (errorStatus === 401) {
         new Notice(
-          "Granola sync error: Authentication failed. Your access token may have expired. Please update your credentials file.",
+          "Granola sync error: Authentication failed. Your access token may have expired. Please reload Granola to update your credentials file.",
           10000
         );
       } else if (errorStatus === 403) {
@@ -217,7 +217,7 @@ export default class GranolaSync extends Plugin {
           10000
         );
       }
-      console.error("Error fetching Granola documents: ", error);
+      log.error("Error fetching Granola documents:", error);
       hideStatusBar(this);
       return;
     }
@@ -332,6 +332,9 @@ export default class GranolaSync extends Plugin {
       }
     }
 
+    log.debug(
+      `syncNotesToIndividualFiles - Completed: ${syncedCount} saved out of ${processedCount} processed`
+    );
     return syncedCount;
   }
 
@@ -392,12 +395,11 @@ export default class GranolaSync extends Plugin {
           `Error fetching transcript for document: ${title}. Check console.`,
           7000
         );
-        console.error(`Transcript fetch error for doc ${docId}:`, e);
+        log.error(`Transcript fetch error for doc ${docId}:`, e);
       }
     }
-
     log.debug(
-      `Saved ${syncedCount} transcript(s), skipped ${skippedCount} existing`
+      `syncTranscripts - Completed: ${syncedCount} saved out of ${processedCount} processed`
     );
   }
 }

--- a/src/services/credentials.ts
+++ b/src/services/credentials.ts
@@ -43,7 +43,7 @@ export async function startCredentialsServer(): Promise<void> {
         fs.readFile(filePath, (err, data) => {
           if (err) {
             const errorMessage = `Failed to read credentials file at ${filePath}: ${err.message}`;
-            console.error(`[GranolaCredentials] ${errorMessage}`);
+            log.error("startCredentialsServer", errorMessage);
             res.writeHead(404, { "Content-Type": "text/plain" });
             res.end(errorMessage);
           } else {
@@ -58,14 +58,14 @@ export async function startCredentialsServer(): Promise<void> {
         const message = `Unsupported credentials server route: ${
           req.url ?? "unknown"
         }`;
-        console.error(`[GranolaCredentials] ${message}`);
+        log.error("startCredentialsServer", message);
         res.writeHead(400, { "Content-Type": "text/plain" });
         res.end(message);
       }
     });
 
     server.on("error", (err) => {
-      console.error("[GranolaCredentials] Server startup error:", err);
+      log.error("Server startup error:", err);
       reject(err);
     });
 
@@ -103,7 +103,7 @@ export async function loadCredentials(): Promise<{
     const errorMessage =
       serverError instanceof Error ? serverError.message : String(serverError);
     tokenLoadError = `Failed to start credentials server: ${errorMessage}`;
-    console.error("Server startup error:", serverError);
+    log.error("Server startup error:", serverError);
     return { accessToken, error: tokenLoadError };
   }
 
@@ -127,16 +127,16 @@ export async function loadCredentials(): Promise<{
           "No access token found in credentials file. The token may have expired.";
       }
     } catch (parseError) {
-      console.error(`Failed to parse response: `, response);
-      console.error(`Failed to parse response: `, response.json);
-      console.error("Token response parse error:", parseError);
+      log.error("Failed to parse response:", response);
+      log.error("Response JSON:", response.json);
+      log.error("Token response parse error:", parseError);
       tokenLoadError =
         "Invalid JSON format in credentials response. Please ensure the server returns valid JSON.";
     }
   } catch (error) {
     tokenLoadError =
       "Failed to load credentials from http://127.0.0.1:2590/. Please check if the credentials server is running.";
-    console.error("Credentials loading error:", error);
+    log.error("Credentials loading error:", error);
   } finally {
     stopCredentialsServer();
   }

--- a/src/services/dailyNoteBuilder.ts
+++ b/src/services/dailyNoteBuilder.ts
@@ -10,7 +10,6 @@ import { getNoteDate } from "../utils/dateUtils";
 import { DocumentProcessor } from "./documentProcessor";
 import { PathResolver } from "./pathResolver";
 import { updateSection } from "../utils/textUtils";
-import { formatWikilinkPath } from "../utils/filenameUtils";
 import { TranscriptSettings, NoteSettings } from "../settings";
 
 export interface NoteData {

--- a/src/services/dailyNoteBuilder.ts
+++ b/src/services/dailyNoteBuilder.ts
@@ -11,6 +11,7 @@ import { DocumentProcessor } from "./documentProcessor";
 import { PathResolver } from "./pathResolver";
 import { updateSection } from "../utils/textUtils";
 import { TranscriptSettings, NoteSettings } from "../settings";
+import { log } from "../utils/logger";
 
 export interface NoteData {
   title: string;
@@ -158,7 +159,7 @@ export class DailyNoteBuilder {
         `Error updating section in ${dailyNoteFile.path}. Check console.`,
         7000
       );
-      console.error("Error updating daily note section:", error);
+      log.error("Error updating daily note section:", error);
     }
   }
 

--- a/src/services/dailyNoteBuilder.ts
+++ b/src/services/dailyNoteBuilder.ts
@@ -32,7 +32,9 @@ export class DailyNoteBuilder {
     private pathResolver: PathResolver,
     private settings: Pick<
       TranscriptSettings & NoteSettings,
-      "syncTranscripts" | "createLinkFromNoteToTranscript" | "dailyNoteSectionHeading"
+      | "syncTranscripts"
+      | "createLinkFromNoteToTranscript"
+      | "dailyNoteSectionHeading"
     >
   ) {}
 

--- a/src/services/dailyNoteBuilder.ts
+++ b/src/services/dailyNoteBuilder.ts
@@ -10,6 +10,7 @@ import { getNoteDate } from "../utils/dateUtils";
 import { DocumentProcessor } from "./documentProcessor";
 import { PathResolver } from "./pathResolver";
 import { updateSection } from "../utils/textUtils";
+import { formatWikilinkPath } from "../utils/filenameUtils";
 import { TranscriptSettings, NoteSettings } from "../settings";
 
 export interface NoteData {
@@ -119,7 +120,8 @@ export class DailyNoteBuilder {
           note.title,
           noteDate
         );
-        content += `**Transcript:** [[${transcriptPath}]]\n`;
+        const formattedPath = formatWikilinkPath(transcriptPath);
+        content += `**Transcript:** [[${formattedPath}]]\n`;
       }
 
       content += `\n${note.markdown}\n`;

--- a/src/services/dailyNoteBuilder.ts
+++ b/src/services/dailyNoteBuilder.ts
@@ -122,8 +122,8 @@ export class DailyNoteBuilder {
           note.title,
           noteDate
         );
-        const formattedPath = formatWikilinkPath(transcriptPath);
-        content += `**Transcript:** [[${formattedPath}]]\n`;
+
+        content += `**Transcript:** [[<${transcriptPath}>]]\n`;
       }
 
       content += `\n${note.markdown}\n`;

--- a/src/services/documentProcessor.ts
+++ b/src/services/documentProcessor.ts
@@ -75,8 +75,8 @@ export class DocumentProcessor {
         title,
         noteDate
       );
-      const formattedPath = formatWikilinkPath(transcriptPath);
-      finalMarkdown += `[[${formattedPath}|Transcript]]\n\n`;
+
+      finalMarkdown += `[Transcript](<${transcriptPath}>)\n\n`;
     }
 
     // Add the actual note content

--- a/src/services/documentProcessor.ts
+++ b/src/services/documentProcessor.ts
@@ -1,6 +1,10 @@
 import { GranolaDoc } from "./granolaApi";
 import { convertProsemirrorToMarkdown } from "./prosemirrorMarkdown";
-import { sanitizeFilename, getTitleOrDefault } from "../utils/filenameUtils";
+import {
+  sanitizeFilename,
+  getTitleOrDefault,
+  formatWikilinkPath,
+} from "../utils/filenameUtils";
 import { getNoteDate } from "../utils/dateUtils";
 import { PathResolver } from "./pathResolver";
 import { TranscriptSettings } from "../settings";
@@ -71,7 +75,8 @@ export class DocumentProcessor {
         title,
         noteDate
       );
-      finalMarkdown += `[Transcript](${transcriptPath})\n\n`;
+      const formattedPath = formatWikilinkPath(transcriptPath);
+      finalMarkdown += `[[${formattedPath}|Transcript]]\n\n`;
     }
 
     // Add the actual note content

--- a/src/services/documentProcessor.ts
+++ b/src/services/documentProcessor.ts
@@ -1,10 +1,6 @@
 import { GranolaDoc } from "./granolaApi";
 import { convertProsemirrorToMarkdown } from "./prosemirrorMarkdown";
-import {
-  sanitizeFilename,
-  getTitleOrDefault,
-  formatWikilinkPath,
-} from "../utils/filenameUtils";
+import { sanitizeFilename, getTitleOrDefault } from "../utils/filenameUtils";
 import { getNoteDate } from "../utils/dateUtils";
 import { PathResolver } from "./pathResolver";
 import { TranscriptSettings } from "../settings";
@@ -52,11 +48,12 @@ export class DocumentProcessor {
     ];
     if (doc.created_at) frontmatterLines.push(`created_at: ${doc.created_at}`);
     if (doc.updated_at) frontmatterLines.push(`updated_at: ${doc.updated_at}`);
-    const attendees = doc.people?.attendees
-      ?.map((attendee) => attendee.name || attendee.email || "Unknown")
-      .filter((name) => name !== "Unknown") || [];
+    const attendees =
+      doc.people?.attendees
+        ?.map((attendee) => attendee.name || attendee.email || "Unknown")
+        .filter((name) => name !== "Unknown") || [];
     if (attendees.length > 0) {
-      const attendeesYaml = attendees.map(name => `  - ${name}`).join("\n");
+      const attendeesYaml = attendees.map((name) => `  - ${name}`).join("\n");
       frontmatterLines.push(`attendees:\n${attendeesYaml}`);
     } else {
       frontmatterLines.push(`attendees: []`);

--- a/src/services/fileSyncService.ts
+++ b/src/services/fileSyncService.ts
@@ -8,6 +8,7 @@ import {
   TranscriptDestination,
 } from "../settings";
 import { getNoteDate, formatDateForFilename } from "../utils/dateUtils";
+import { log } from "../utils/logger";
 
 /**
  * Service for handling file synchronization operations including
@@ -42,7 +43,7 @@ export class FileSyncService {
           this.granolaIdCache.set(cacheKey, file);
         }
       } catch (e) {
-        console.error(`Error reading frontmatter for ${file.path}:`, e);
+        log.error(`Error reading frontmatter for ${file.path}:`, e);
       }
     }
   }
@@ -98,7 +99,7 @@ export class FileSyncService {
         `Granola sync error: Could not create folder '${folderPath}'. Check console.`,
         10000
       );
-      console.error("Folder creation error:", error);
+      log.error("Folder creation error:", error);
       return false;
     }
   }
@@ -139,7 +140,7 @@ export class FileSyncService {
               this.updateCache(granolaId, existingFile, type);
             } catch (renameError) {
               // If rename fails (e.g., file already exists at new path), just update content
-              console.warn(
+              log.warn(
                 `Could not rename file from ${existingFile.path} to ${normalizedPath}:`,
                 renameError
               );
@@ -159,7 +160,7 @@ export class FileSyncService {
       }
     } catch (e) {
       new Notice(`Error saving file: ${filePath}. Check console.`, 7000);
-      console.error("Error saving file to disk:", e);
+      log.error("Error saving file to disk:", e);
       return false;
     }
   }
@@ -250,13 +251,20 @@ export class FileSyncService {
     forceOverwrite: boolean = false
   ): Promise<boolean> {
     if (!doc.id) {
-      console.error("Document missing required id field:", doc);
+      log.error("Document missing required id field:", doc);
       return false;
     }
     const { filename, content } = documentProcessor.prepareNote(doc);
     const noteDate = getNoteDate(doc);
 
-    return this.saveToDisk(filename, content, noteDate, doc.id, false, forceOverwrite);
+    return this.saveToDisk(
+      filename,
+      content,
+      noteDate,
+      doc.id,
+      false,
+      forceOverwrite
+    );
   }
 
   /**
@@ -269,7 +277,7 @@ export class FileSyncService {
     forceOverwrite: boolean = false
   ): Promise<boolean> {
     if (!doc.id) {
-      console.error("Document missing required id field:", doc);
+      log.error("Document missing required id field:", doc);
       return false;
     }
     const { filename, content } = documentProcessor.prepareTranscript(
@@ -278,7 +286,14 @@ export class FileSyncService {
     );
     const noteDate = getNoteDate(doc);
 
-    return this.saveToDisk(filename, content, noteDate, doc.id, true, forceOverwrite);
+    return this.saveToDisk(
+      filename,
+      content,
+      noteDate,
+      doc.id,
+      true,
+      forceOverwrite
+    );
   }
 
   /**

--- a/src/services/granolaApi.ts
+++ b/src/services/granolaApi.ts
@@ -5,6 +5,7 @@ import {
   TranscriptEntrySchema,
   TranscriptResponseSchema,
 } from "./validationSchemas";
+import { log } from "../utils/logger";
 
 // ProseMirror types (defined explicitly due to recursive nature)
 export interface ProseMirrorNode {
@@ -73,8 +74,8 @@ export async function fetchGranolaDocuments(
 
   const result = v.safeParse(GranolaApiResponseSchema, jsonResponse);
   if (!result.success) {
-    console.error("Validation failed for GranolaApiResponseSchema:");
-    console.error(JSON.stringify(result.issues, null, 2));
+    log.error("Validation failed for GranolaApiResponseSchema:");
+    log.error(JSON.stringify(result.issues, null, 2));
 
     throw new Error(
       `Invalid response from Granola API (GranolaApiResponseSchema)`
@@ -179,8 +180,8 @@ export async function fetchGranolaTranscript(
 
   const result = v.safeParse(TranscriptResponseSchema, transcriptResp.json);
   if (!result.success) {
-    console.error("Validation failed for TranscriptResponseSchema:");
-    console.error(JSON.stringify(result.issues, null, 2));
+    log.error("Validation failed for TranscriptResponseSchema:");
+    log.error(JSON.stringify(result.issues, null, 2));
 
     throw new Error(
       `Invalid transcript response from Granola API (TranscriptResponseSchema)`

--- a/src/utils/filenameUtils.ts
+++ b/src/utils/filenameUtils.ts
@@ -32,18 +32,3 @@ export function getTitleOrDefault(doc: GranolaDoc): string {
   const formattedDate = formatDateForFilename(noteDate);
   return `Untitled Granola Note at ${formattedDate}`;
 }
-
-/**
- * Formats a file path for use in Obsidian wikilinks.
- * Always wraps the path in angle brackets for proper linking in Obsidian.
- *
- * @param path - The file path to format
- * @returns The path formatted for wikilink usage (with angle brackets)
- */
-export function formatWikilinkPath(path: string): string {
-  // Always wrap paths in angle brackets for Obsidian wikilinks
-  if (path === "") {
-    return "";
-  }
-  return `<${path}>`;
-}

--- a/src/utils/filenameUtils.ts
+++ b/src/utils/filenameUtils.ts
@@ -35,17 +35,15 @@ export function getTitleOrDefault(doc: GranolaDoc): string {
 
 /**
  * Formats a file path for use in Obsidian wikilinks.
- * Wraps the path in angle brackets if it contains spaces or special characters
- * that require them for proper linking in Obsidian.
+ * Always wraps the path in angle brackets for proper linking in Obsidian.
  *
  * @param path - The file path to format
- * @returns The path formatted for wikilink usage (with angle brackets if needed)
+ * @returns The path formatted for wikilink usage (with angle brackets)
  */
 export function formatWikilinkPath(path: string): string {
-  // Obsidian requires angle brackets for paths with spaces or special characters
-  // Check if path contains spaces or characters that need angle brackets
-  if (/\s|[<>:"|?*]/.test(path)) {
-    return `<${path}>`;
+  // Always wrap paths in angle brackets for Obsidian wikilinks
+  if (path === "") {
+    return "";
   }
-  return path;
+  return `<${path}>`;
 }

--- a/src/utils/filenameUtils.ts
+++ b/src/utils/filenameUtils.ts
@@ -32,3 +32,20 @@ export function getTitleOrDefault(doc: GranolaDoc): string {
   const formattedDate = formatDateForFilename(noteDate);
   return `Untitled Granola Note at ${formattedDate}`;
 }
+
+/**
+ * Formats a file path for use in Obsidian wikilinks.
+ * Wraps the path in angle brackets if it contains spaces or special characters
+ * that require them for proper linking in Obsidian.
+ *
+ * @param path - The file path to format
+ * @returns The path formatted for wikilink usage (with angle brackets if needed)
+ */
+export function formatWikilinkPath(path: string): string {
+  // Obsidian requires angle brackets for paths with spaces or special characters
+  // Check if path contains spaces or characters that need angle brackets
+  if (/\s|[<>:"|?*]/.test(path)) {
+    return `<${path}>`;
+  }
+  return path;
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,13 +1,40 @@
-// Simple logger utility for development mode debugging
-// Uses console.debug which is typically filtered in production browser dev tools
+// Logger utility for consistent logging throughout the application
+// Uses console methods with consistent "[Granola Sync]" prefix
+// Debug and info messages are only shown in development mode
 
 const isDevelopment =
   !process.env.NODE_ENV || process.env.NODE_ENV === "development";
 
 export const log = {
+  /**
+   * Logs debug messages (only in development mode)
+   */
   debug: (...args: unknown[]) => {
     if (isDevelopment) {
       console.debug("[Granola Sync]", ...args);
     }
+  },
+
+  /**
+   * Logs informational messages (only in development mode)
+   */
+  info: (...args: unknown[]) => {
+    if (isDevelopment) {
+      console.info("[Granola Sync]", ...args);
+    }
+  },
+
+  /**
+   * Logs warning messages
+   */
+  warn: (...args: unknown[]) => {
+    console.warn("[Granola Sync]", ...args);
+  },
+
+  /**
+   * Logs error messages (always shown, not filtered by development mode)
+   */
+  error: (...args: unknown[]) => {
+    console.error("[Granola Sync]", ...args);
   },
 };

--- a/tests/unit/dailyNoteBuilder.test.ts
+++ b/tests/unit/dailyNoteBuilder.test.ts
@@ -394,6 +394,7 @@ describe("DailyNoteBuilder", () => {
       );
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[Granola Sync]",
         "Error updating daily note section:",
         error
       );

--- a/tests/unit/dailyNoteBuilder.test.ts
+++ b/tests/unit/dailyNoteBuilder.test.ts
@@ -248,7 +248,7 @@ describe("DailyNoteBuilder", () => {
       );
 
       expect(result).toContain(
-        "**Transcript:** [[Transcripts/Test Note-transcript.md]]"
+        "**Transcript:** [[<Transcripts/Test Note-transcript.md>]]"
       );
       expect(mockPathResolver.computeTranscriptPath).toHaveBeenCalledWith(
         "Test Note",
@@ -265,6 +265,60 @@ describe("DailyNoteBuilder", () => {
 
       expect(result).not.toContain("**Transcript:**");
       expect(mockPathResolver.computeTranscriptPath).not.toHaveBeenCalled();
+    });
+
+    it("should wrap transcript paths with spaces in angle brackets", () => {
+      dailyNoteBuilder = new DailyNoteBuilder(
+        mockApp,
+        mockDocumentProcessor,
+        mockPathResolver,
+        {
+          syncTranscripts: true,
+          createLinkFromNoteToTranscript: true,
+          dailyNoteSectionHeading: "## Granola Notes",
+        }
+      );
+
+      (mockPathResolver.computeTranscriptPath as jest.Mock).mockReturnValue(
+        "Transcripts/My Meeting Transcript.md"
+      );
+
+      const result = dailyNoteBuilder.buildDailyNoteSectionContent(
+        [noteData],
+        "## Granola Notes",
+        "2024-01-15"
+      );
+
+      expect(result).toContain(
+        "**Transcript:** [[<Transcripts/My Meeting Transcript.md>]]"
+      );
+    });
+
+    it("should not wrap transcript paths without spaces in angle brackets", () => {
+      dailyNoteBuilder = new DailyNoteBuilder(
+        mockApp,
+        mockDocumentProcessor,
+        mockPathResolver,
+        {
+          syncTranscripts: true,
+          createLinkFromNoteToTranscript: true,
+          dailyNoteSectionHeading: "## Granola Notes",
+        }
+      );
+
+      (mockPathResolver.computeTranscriptPath as jest.Mock).mockReturnValue(
+        "Transcripts/TestNote-transcript.md"
+      );
+
+      const result = dailyNoteBuilder.buildDailyNoteSectionContent(
+        [noteData],
+        "## Granola Notes",
+        "2024-01-15"
+      );
+
+      expect(result).toContain(
+        "**Transcript:** [[Transcripts/TestNote-transcript.md]]"
+      );
     });
 
     it("should handle multiple notes", () => {

--- a/tests/unit/dailyNoteBuilder.test.ts
+++ b/tests/unit/dailyNoteBuilder.test.ts
@@ -1,4 +1,7 @@
-import { DailyNoteBuilder, NoteData } from "../../src/services/dailyNoteBuilder";
+import {
+  DailyNoteBuilder,
+  NoteData,
+} from "../../src/services/dailyNoteBuilder";
 import { GranolaDoc } from "../../src/services/granolaApi";
 import { DocumentProcessor } from "../../src/services/documentProcessor";
 import { PathResolver } from "../../src/services/pathResolver";
@@ -33,7 +36,9 @@ describe("DailyNoteBuilder", () => {
       computeTranscriptPath: jest.fn(),
     } as unknown as PathResolver;
 
-    (getNoteDate as jest.Mock).mockReturnValue(new Date("2024-01-15T10:00:00Z"));
+    (getNoteDate as jest.Mock).mockReturnValue(
+      new Date("2024-01-15T10:00:00Z")
+    );
 
     dailyNoteBuilder = new DailyNoteBuilder(
       mockApp,
@@ -135,9 +140,9 @@ describe("DailyNoteBuilder", () => {
     });
 
     it("should return empty map when no valid documents", () => {
-      (mockDocumentProcessor.extractNoteForDailyNote as jest.Mock).mockReturnValue(
-        null
-      );
+      (
+        mockDocumentProcessor.extractNoteForDailyNote as jest.Mock
+      ).mockReturnValue(null);
 
       const result = dailyNoteBuilder.buildDailyNotesMap([
         { id: "doc-1" } as GranolaDoc,
@@ -294,7 +299,7 @@ describe("DailyNoteBuilder", () => {
       );
     });
 
-    it("should not wrap transcript paths without spaces in angle brackets", () => {
+    it("should wrap transcript paths without spaces in angle brackets", () => {
       dailyNoteBuilder = new DailyNoteBuilder(
         mockApp,
         mockDocumentProcessor,
@@ -317,7 +322,7 @@ describe("DailyNoteBuilder", () => {
       );
 
       expect(result).toContain(
-        "**Transcript:** [[Transcripts/TestNote-transcript.md]]"
+        "**Transcript:** [[<Transcripts/TestNote-transcript.md>]]"
       );
     });
 

--- a/tests/unit/documentProcessor.test.ts
+++ b/tests/unit/documentProcessor.test.ts
@@ -28,8 +28,9 @@ describe("DocumentProcessor", () => {
     (sanitizeFilename as jest.Mock).mockImplementation((title: string) =>
       title.replace(/[^a-zA-Z0-9\s\-_]/g, "").trim()
     );
-    (getTitleOrDefault as jest.Mock).mockImplementation((doc: GranolaDoc) =>
-      doc.title || "Untitled Granola Note at 2024-01-15 00-00"
+    (getTitleOrDefault as jest.Mock).mockImplementation(
+      (doc: GranolaDoc) =>
+        doc.title || "Untitled Granola Note at 2024-01-15 00-00"
     );
     (formatWikilinkPath as jest.Mock).mockImplementation((path: string) => {
       // Real implementation for testing - always wrap in angle brackets
@@ -154,7 +155,7 @@ describe("DocumentProcessor", () => {
       const result = documentProcessor.prepareNote(doc);
 
       expect(result.content).toContain(
-        "[[<Transcripts/Test Note-transcript.md>|Transcript]]"
+        "[Transcript](<Transcripts/Test Note-transcript.md>)"
       );
       expect(mockPathResolver.computeTranscriptPath).toHaveBeenCalledWith(
         "Test Note",
@@ -209,7 +210,7 @@ describe("DocumentProcessor", () => {
       const result = documentProcessor.prepareNote(doc);
 
       expect(result.content).toContain(
-        "[[<Transcripts/My Meeting Transcript.md>|Transcript]]"
+        "[Transcript](<Transcripts/My Meeting Transcript.md>)"
       );
     });
 
@@ -241,7 +242,7 @@ describe("DocumentProcessor", () => {
       const result = documentProcessor.prepareNote(doc);
 
       expect(result.content).toContain(
-        "[[<Transcripts/TestNote-transcript.md>|Transcript]]"
+        "[Transcript](<Transcripts/TestNote-transcript.md>)"
       );
     });
 
@@ -258,7 +259,9 @@ describe("DocumentProcessor", () => {
 
       const result = documentProcessor.prepareNote(doc);
 
-      expect(result.content).toContain('title: "Untitled Granola Note at 2024-01-15 00-00"');
+      expect(result.content).toContain(
+        'title: "Untitled Granola Note at 2024-01-15 00-00"'
+      );
     });
 
     it("should throw error when document has no valid content", () => {
@@ -298,7 +301,10 @@ describe("DocumentProcessor", () => {
       };
       const transcriptContent = "Speaker 1: Hello\nSpeaker 2: World";
 
-      const result = documentProcessor.prepareTranscript(doc, transcriptContent);
+      const result = documentProcessor.prepareTranscript(
+        doc,
+        transcriptContent
+      );
 
       expect(result.filename).toBe("Test Note-transcript.md");
       expect(result.content).toBe(transcriptContent);
@@ -310,9 +316,14 @@ describe("DocumentProcessor", () => {
       };
       const transcriptContent = "Speaker 1: Hello";
 
-      const result = documentProcessor.prepareTranscript(doc, transcriptContent);
+      const result = documentProcessor.prepareTranscript(
+        doc,
+        transcriptContent
+      );
 
-      expect(result.filename).toBe("Untitled Granola Note at 2024-01-15 00-00-transcript.md");
+      expect(result.filename).toBe(
+        "Untitled Granola Note at 2024-01-15 00-00-transcript.md"
+      );
     });
   });
 

--- a/tests/unit/documentProcessor.test.ts
+++ b/tests/unit/documentProcessor.test.ts
@@ -12,7 +12,6 @@ import { convertProsemirrorToMarkdown } from "../../src/services/prosemirrorMark
 import {
   sanitizeFilename,
   getTitleOrDefault,
-  formatWikilinkPath,
 } from "../../src/utils/filenameUtils";
 import { getNoteDate } from "../../src/utils/dateUtils";
 
@@ -32,13 +31,6 @@ describe("DocumentProcessor", () => {
       (doc: GranolaDoc) =>
         doc.title || "Untitled Granola Note at 2024-01-15 00-00"
     );
-    (formatWikilinkPath as jest.Mock).mockImplementation((path: string) => {
-      // Real implementation for testing - always wrap in angle brackets
-      if (path === "") {
-        return "";
-      }
-      return `<${path}>`;
-    });
     (getNoteDate as jest.Mock).mockReturnValue(new Date("2024-01-15"));
 
     mockPathResolver = new PathResolver({

--- a/tests/unit/documentProcessor.test.ts
+++ b/tests/unit/documentProcessor.test.ts
@@ -32,11 +32,11 @@ describe("DocumentProcessor", () => {
       doc.title || "Untitled Granola Note at 2024-01-15 00-00"
     );
     (formatWikilinkPath as jest.Mock).mockImplementation((path: string) => {
-      // Real implementation for testing
-      if (/\s|[<>:"|?*]/.test(path)) {
-        return `<${path}>`;
+      // Real implementation for testing - always wrap in angle brackets
+      if (path === "") {
+        return "";
       }
-      return path;
+      return `<${path}>`;
     });
     (getNoteDate as jest.Mock).mockReturnValue(new Date("2024-01-15"));
 
@@ -213,7 +213,7 @@ describe("DocumentProcessor", () => {
       );
     });
 
-    it("should not wrap transcript paths without spaces in angle brackets", () => {
+    it("should wrap transcript paths without spaces in angle brackets", () => {
       (mockPathResolver.computeTranscriptPath as jest.Mock).mockReturnValue(
         "Transcripts/TestNote-transcript.md"
       );
@@ -241,7 +241,7 @@ describe("DocumentProcessor", () => {
       const result = documentProcessor.prepareNote(doc);
 
       expect(result.content).toContain(
-        "[[Transcripts/TestNote-transcript.md|Transcript]]"
+        "[[<Transcripts/TestNote-transcript.md>|Transcript]]"
       );
     });
 

--- a/tests/unit/filenameUtils.test.ts
+++ b/tests/unit/filenameUtils.test.ts
@@ -1,7 +1,6 @@
 import {
   sanitizeFilename,
   getTitleOrDefault,
-  formatWikilinkPath,
 } from "../../src/utils/filenameUtils";
 import { GranolaDoc } from "../../src/services/granolaApi";
 
@@ -87,62 +86,8 @@ describe("getTitleOrDefault", () => {
     };
 
     const result = getTitleOrDefault(doc);
-    expect(result).toMatch(/^Untitled Granola Note at \d{4}-\d{2}-\d{2} \d{2}-\d{2}$/);
-  });
-});
-
-describe("formatWikilinkPath", () => {
-  it("should always wrap paths in angle brackets", () => {
-    const path = "Transcripts/My Meeting Transcript.md";
-    const result = formatWikilinkPath(path);
-    expect(result).toBe("<Transcripts/My Meeting Transcript.md>");
-  });
-
-  it("should wrap paths without spaces in angle brackets", () => {
-    const path = "Transcripts/TestNote-transcript.md";
-    const result = formatWikilinkPath(path);
-    expect(result).toBe("<Transcripts/TestNote-transcript.md>");
-  });
-
-  it("should wrap paths with special characters in angle brackets", () => {
-    const path = "Transcripts/Meeting: Q1 Planning.md";
-    const result = formatWikilinkPath(path);
-    expect(result).toBe("<Transcripts/Meeting: Q1 Planning.md>");
-  });
-
-  it("should wrap paths with pipe characters in angle brackets", () => {
-    const path = "Transcripts/Meeting|Notes.md";
-    const result = formatWikilinkPath(path);
-    expect(result).toBe("<Transcripts/Meeting|Notes.md>");
-  });
-
-  it("should wrap paths with question marks in angle brackets", () => {
-    const path = "Transcripts/What? Meeting.md";
-    const result = formatWikilinkPath(path);
-    expect(result).toBe("<Transcripts/What? Meeting.md>");
-  });
-
-  it("should wrap paths with asterisks in angle brackets", () => {
-    const path = "Transcripts/Important*Meeting.md";
-    const result = formatWikilinkPath(path);
-    expect(result).toBe("<Transcripts/Important*Meeting.md>");
-  });
-
-  it("should handle paths with multiple spaces", () => {
-    const path = "Folder/My Very Long Meeting Name.md";
-    const result = formatWikilinkPath(path);
-    expect(result).toBe("<Folder/My Very Long Meeting Name.md>");
-  });
-
-  it("should wrap paths with no special characters in angle brackets", () => {
-    const path = "folder/file-name.md";
-    const result = formatWikilinkPath(path);
-    expect(result).toBe("<folder/file-name.md>");
-  });
-
-  it("should handle empty paths", () => {
-    const path = "";
-    const result = formatWikilinkPath(path);
-    expect(result).toBe("");
+    expect(result).toMatch(
+      /^Untitled Granola Note at \d{4}-\d{2}-\d{2} \d{2}-\d{2}$/
+    );
   });
 });

--- a/tests/unit/filenameUtils.test.ts
+++ b/tests/unit/filenameUtils.test.ts
@@ -92,16 +92,16 @@ describe("getTitleOrDefault", () => {
 });
 
 describe("formatWikilinkPath", () => {
-  it("should wrap paths with spaces in angle brackets", () => {
+  it("should always wrap paths in angle brackets", () => {
     const path = "Transcripts/My Meeting Transcript.md";
     const result = formatWikilinkPath(path);
     expect(result).toBe("<Transcripts/My Meeting Transcript.md>");
   });
 
-  it("should not wrap paths without spaces in angle brackets", () => {
+  it("should wrap paths without spaces in angle brackets", () => {
     const path = "Transcripts/TestNote-transcript.md";
     const result = formatWikilinkPath(path);
-    expect(result).toBe("Transcripts/TestNote-transcript.md");
+    expect(result).toBe("<Transcripts/TestNote-transcript.md>");
   });
 
   it("should wrap paths with special characters in angle brackets", () => {
@@ -134,10 +134,10 @@ describe("formatWikilinkPath", () => {
     expect(result).toBe("<Folder/My Very Long Meeting Name.md>");
   });
 
-  it("should handle paths with no special characters", () => {
+  it("should wrap paths with no special characters in angle brackets", () => {
     const path = "folder/file-name.md";
     const result = formatWikilinkPath(path);
-    expect(result).toBe("folder/file-name.md");
+    expect(result).toBe("<folder/file-name.md>");
   });
 
   it("should handle empty paths", () => {

--- a/tests/unit/filenameUtils.test.ts
+++ b/tests/unit/filenameUtils.test.ts
@@ -1,4 +1,8 @@
-import { sanitizeFilename, getTitleOrDefault } from "../../src/utils/filenameUtils";
+import {
+  sanitizeFilename,
+  getTitleOrDefault,
+  formatWikilinkPath,
+} from "../../src/utils/filenameUtils";
 import { GranolaDoc } from "../../src/services/granolaApi";
 
 describe("sanitizeFilename", () => {
@@ -84,5 +88,61 @@ describe("getTitleOrDefault", () => {
 
     const result = getTitleOrDefault(doc);
     expect(result).toMatch(/^Untitled Granola Note at \d{4}-\d{2}-\d{2} \d{2}-\d{2}$/);
+  });
+});
+
+describe("formatWikilinkPath", () => {
+  it("should wrap paths with spaces in angle brackets", () => {
+    const path = "Transcripts/My Meeting Transcript.md";
+    const result = formatWikilinkPath(path);
+    expect(result).toBe("<Transcripts/My Meeting Transcript.md>");
+  });
+
+  it("should not wrap paths without spaces in angle brackets", () => {
+    const path = "Transcripts/TestNote-transcript.md";
+    const result = formatWikilinkPath(path);
+    expect(result).toBe("Transcripts/TestNote-transcript.md");
+  });
+
+  it("should wrap paths with special characters in angle brackets", () => {
+    const path = "Transcripts/Meeting: Q1 Planning.md";
+    const result = formatWikilinkPath(path);
+    expect(result).toBe("<Transcripts/Meeting: Q1 Planning.md>");
+  });
+
+  it("should wrap paths with pipe characters in angle brackets", () => {
+    const path = "Transcripts/Meeting|Notes.md";
+    const result = formatWikilinkPath(path);
+    expect(result).toBe("<Transcripts/Meeting|Notes.md>");
+  });
+
+  it("should wrap paths with question marks in angle brackets", () => {
+    const path = "Transcripts/What? Meeting.md";
+    const result = formatWikilinkPath(path);
+    expect(result).toBe("<Transcripts/What? Meeting.md>");
+  });
+
+  it("should wrap paths with asterisks in angle brackets", () => {
+    const path = "Transcripts/Important*Meeting.md";
+    const result = formatWikilinkPath(path);
+    expect(result).toBe("<Transcripts/Important*Meeting.md>");
+  });
+
+  it("should handle paths with multiple spaces", () => {
+    const path = "Folder/My Very Long Meeting Name.md";
+    const result = formatWikilinkPath(path);
+    expect(result).toBe("<Folder/My Very Long Meeting Name.md>");
+  });
+
+  it("should handle paths with no special characters", () => {
+    const path = "folder/file-name.md";
+    const result = formatWikilinkPath(path);
+    expect(result).toBe("folder/file-name.md");
+  });
+
+  it("should handle empty paths", () => {
+    const path = "";
+    const result = formatWikilinkPath(path);
+    expect(result).toBe("");
   });
 });

--- a/tests/unit/frontmatterMigration.test.ts
+++ b/tests/unit/frontmatterMigration.test.ts
@@ -216,6 +216,7 @@ Content`);
       await migrationService.migrateLegacyFrontmatter();
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[Granola Sync]",
         "Error migrating frontmatter for file1.md:",
         expect.any(Error)
       );


### PR DESCRIPTION
## Logger standardization

- Replace direct console.error, console.warn, etc. with a centralized log utility
- Add consistent [Granola Sync] prefix to all log messages
- Filter debug and info messages in development mode only
