### PR TITLE
Feature/transcript link location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # vscode
 .vscode 
+.windsurf
 
 # Intellij
 *.iml

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This plugin allows you to synchronize your notes and transcripts from Granola (h
    - Choose whether to sync notes
    - Select the destination: a specific folder, daily notes, or daily note folder structure
    - Optionally set a section heading for daily notes
+   - Enable automatic first-level headings to insert `# <Title>` after frontmatter
 2. Configure transcript syncing:
    - Choose whether to sync transcripts
    - Select the destination: a dedicated transcripts folder or daily note folder structure

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This plugin allows you to synchronize your notes and transcripts from Granola (h
 - Sync Granola notes to your Obsidian vault
 - Sync Granola transcripts to your vault, with flexible destination options
 - Support for syncing to daily notes, a dedicated folder, or a daily note folder structure
-- Option to create links between notes and their transcripts
+- Option to create links between notes and their transcripts, either at the top of the note or in frontmatter properties
 - Periodic automatic syncing with customizable interval
 - Granular settings for notes and transcripts
 - Customizable sync settings and destinations
@@ -33,7 +33,7 @@ This plugin allows you to synchronize your notes and transcripts from Granola (h
 2. Configure transcript syncing:
    - Choose whether to sync transcripts
    - Select the destination: a dedicated transcripts folder or daily note folder structure
-   - Optionally enable linking from notes to their transcripts
+   - Choose how to link from notes to their transcripts: add a link at the top of the note or store it as a frontmatter property
 3. Set up periodic sync and adjust the interval as desired
 
 ## Frontmatter Structure

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,6 +59,7 @@ export default class GranolaSync extends Plugin {
         syncTranscripts: this.settings.syncTranscripts,
         createLinkFromNoteToTranscript:
           this.settings.createLinkFromNoteToTranscript,
+        createNoteHeading: this.settings.createNoteHeading,
       },
       this.pathResolver
     );

--- a/src/services/dailyNoteBuilder.ts
+++ b/src/services/dailyNoteBuilder.ts
@@ -10,7 +10,11 @@ import { getNoteDate } from "../utils/dateUtils";
 import { DocumentProcessor } from "./documentProcessor";
 import { PathResolver } from "./pathResolver";
 import { updateSection } from "../utils/textUtils";
-import { TranscriptSettings, NoteSettings } from "../settings";
+import {
+  TranscriptSettings,
+  NoteSettings,
+  TranscriptLinkLocation,
+} from "../settings";
 import { log } from "../utils/logger";
 
 export interface NoteData {
@@ -33,7 +37,7 @@ export class DailyNoteBuilder {
     private settings: Pick<
       TranscriptSettings & NoteSettings,
       | "syncTranscripts"
-      | "createLinkFromNoteToTranscript"
+      | "transcriptLinkLocation"
       | "dailyNoteSectionHeading"
     >
   ) {}
@@ -115,7 +119,7 @@ export class DailyNoteBuilder {
 
       if (
         this.settings.syncTranscripts &&
-        this.settings.createLinkFromNoteToTranscript
+        this.settings.transcriptLinkLocation === TranscriptLinkLocation.LINK_AT_TOP
       ) {
         const noteDate = this.getNoteDateFromNote(note, dateKey);
         const transcriptPath = this.pathResolver.computeTranscriptPath(

--- a/src/services/documentProcessor.ts
+++ b/src/services/documentProcessor.ts
@@ -3,7 +3,7 @@ import { convertProsemirrorToMarkdown } from "./prosemirrorMarkdown";
 import { sanitizeFilename, getTitleOrDefault } from "../utils/filenameUtils";
 import { getNoteDate } from "../utils/dateUtils";
 import { PathResolver } from "./pathResolver";
-import { TranscriptSettings } from "../settings";
+import { TranscriptSettings, NoteSettings } from "../settings";
 
 /**
  * Service for processing Granola documents into Obsidian-ready markdown.
@@ -12,8 +12,8 @@ import { TranscriptSettings } from "../settings";
 export class DocumentProcessor {
   constructor(
     private settings: Pick<
-      TranscriptSettings,
-      "syncTranscripts" | "createLinkFromNoteToTranscript"
+      TranscriptSettings & NoteSettings,
+      "syncTranscripts" | "createLinkFromNoteToTranscript" | "createNoteHeading"
     >,
     private pathResolver: PathResolver
   ) {}
@@ -61,6 +61,10 @@ export class DocumentProcessor {
     frontmatterLines.push("---", "");
 
     let finalMarkdown = frontmatterLines.join("\n");
+
+    if (this.settings.createNoteHeading) {
+      finalMarkdown += `# ${title}\n\n`;
+    }
 
     // Add transcript link if enabled
     if (

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -17,6 +17,7 @@ export interface NoteSettings {
   syncDestination: SyncDestination;
   dailyNoteSectionHeading: string;
   granolaFolder: string;
+  createNoteHeading: boolean;
 }
 
 export interface TranscriptSettings {
@@ -48,6 +49,7 @@ export const DEFAULT_SETTINGS: GranolaSyncSettings = {
   syncDestination: SyncDestination.DAILY_NOTES,
   dailyNoteSectionHeading: "## Granola Notes",
   granolaFolder: "Granola",
+  createNoteHeading: false,
   // TranscriptSettings
   syncTranscripts: false,
   transcriptDestination: TranscriptDestination.GRANOLA_TRANSCRIPTS_FOLDER,
@@ -230,6 +232,19 @@ export class GranolaSyncSettingTab extends PluginSettingTab {
           );
       }
       // For DAILY_NOTE_FOLDER_STRUCTURE, no additional settings are needed
+      new Setting(containerEl)
+        .setName("Create title")
+        .setDesc(
+          "Enable this if you want to automatically create a first level heading in notes files."
+        )
+        .addToggle((toggle) =>
+          toggle
+            .setValue(this.plugin.settings.createNoteHeading)
+            .onChange(async (value) => {
+              this.plugin.settings.createNoteHeading = value;
+              await this.plugin.saveSettings();
+            })
+        );
     }
 
     // Transcripts Section

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -12,6 +12,11 @@ export enum TranscriptDestination {
   DAILY_NOTE_FOLDER_STRUCTURE = "daily_note_folder_structure",
 }
 
+export enum TranscriptLinkLocation {
+  LINK_AT_TOP = "link_at_top",
+  LINK_AT_PROPERTIES = "link_at_properties",
+}
+
 export interface NoteSettings {
   syncNotes: boolean;
   syncDestination: SyncDestination;
@@ -24,7 +29,7 @@ export interface TranscriptSettings {
   syncTranscripts: boolean;
   transcriptDestination: TranscriptDestination;
   granolaTranscriptsFolder: string;
-  createLinkFromNoteToTranscript: boolean;
+  transcriptLinkLocation: TranscriptLinkLocation;
 }
 
 export interface AutomaticSyncSettings {
@@ -54,7 +59,7 @@ export const DEFAULT_SETTINGS: GranolaSyncSettings = {
   syncTranscripts: false,
   transcriptDestination: TranscriptDestination.GRANOLA_TRANSCRIPTS_FOLDER,
   granolaTranscriptsFolder: "Granola/Transcripts",
-  createLinkFromNoteToTranscript: false,
+  transcriptLinkLocation: TranscriptLinkLocation.LINK_AT_TOP,
 };
 
 export class GranolaSyncSettingTab extends PluginSettingTab {
@@ -338,13 +343,22 @@ export class GranolaSyncSettingTab extends PluginSettingTab {
         new Setting(containerEl)
           .setName("Create link from Granola note to transcript")
           .setDesc(
-            "Automatically add a link to the transcript file at the top of each Granola note. This requires both notes and transcripts to be synced."
+            "Choose how to link to the transcript file in each Granola note. This requires both notes and transcripts to be synced."
           )
-          .addToggle((toggle) =>
-            toggle
-              .setValue(this.plugin.settings.createLinkFromNoteToTranscript)
+          .addDropdown((dropdown) =>
+            dropdown
+              .addOption(
+                TranscriptLinkLocation.LINK_AT_TOP,
+                "Link at Top"
+              )
+              .addOption(
+                TranscriptLinkLocation.LINK_AT_PROPERTIES,
+                "Link at Properties"
+              )
+              .setValue(this.plugin.settings.transcriptLinkLocation)
               .onChange(async (value) => {
-                this.plugin.settings.createLinkFromNoteToTranscript = value;
+                this.plugin.settings.transcriptLinkLocation =
+                  value as TranscriptLinkLocation;
                 await this.plugin.saveSettings();
               })
           );


### PR DESCRIPTION
## Context
The plugin previously offered only a boolean toggle to insert a transcript link at the top of each synced note. Users who prefer storing relationships in metadata or who rely on frontmatter-driven workflows (queries, dataview, properties-based navigation) could not capture the transcript reference in a structured way. The new feature introduces a configurable transcript link location—either at the top of the note or inside the frontmatter properties—so teams can align the transcript link with their preferred organization strategy without losing automatic linking.

## Modified
- replace the createLinkFromNoteToTranscript boolean with a TranscriptLinkLocation enum
- migrate existing settings data and expose a dropdown in the UI for choosing link placement
- add support for frontmatter transcript links when configured
- update documentation to reflect the new options