### PR TITLE
Print path

### DIFF
--- a/scripts/test-valibot-issues.ts
+++ b/scripts/test-valibot-issues.ts
@@ -1,0 +1,78 @@
+import * as v from "valibot";
+
+// Define a schema with a required key
+const TestSchema = v.object({
+  id: v.string(),
+  name: v.string(),
+  email: v.optional(v.string()),
+});
+
+// Test data: missing required 'name' key
+const invalidData = {
+  id: "123",
+  // name is missing!
+};
+
+console.log("=== Testing valibot safeParse with missing required key ===\n");
+console.log("Schema:");
+console.log("- id: string (required)");
+console.log("- name: string (required)");
+console.log("- email: string (optional)");
+console.log("\nTest data:");
+console.log(JSON.stringify(invalidData, null, 2));
+
+const result = v.safeParse(TestSchema, invalidData);
+
+console.log("\n=== safeParse result ===");
+console.log("success:", result.success);
+
+if (!result.success) {
+  console.log("\n=== Issues details ===");
+  console.log(`Total issues: ${result.issues.length}\n`);
+
+  result.issues.forEach((issue, index) => {
+    console.log(`Issue ${index + 1}:`);
+    console.log("  - type:", issue.type);
+    console.log("  - input:", issue.input);
+    console.log("  - expected:", issue.expected);
+    console.log("  - received:", issue.received);
+    console.log("  - message:", issue.message);
+
+    // Path information
+    if (issue.path) {
+      console.log("  - path:");
+      issue.path.forEach((pathItem, pathIndex) => {
+        console.log(`      [${pathIndex}] type: ${pathItem.type}`);
+        console.log(`            origin: ${pathItem.origin}`);
+        console.log(`            input: ${JSON.stringify(pathItem.input)}`);
+        if ("key" in pathItem) {
+          console.log(`            key: ${pathItem.key}`);
+        }
+        if ("value" in pathItem) {
+          console.log(`            value: ${JSON.stringify(pathItem.value)}`);
+        }
+      });
+    }
+
+    // Additional issue-specific fields
+    if ("requirement" in issue) {
+      console.log("  - requirement:", issue.requirement);
+    }
+    if ("kind" in issue) {
+      console.log("  - kind:", issue.kind);
+    }
+
+    // Full issue object for inspection
+    console.log("\n  - Full issue object:");
+    console.log(JSON.stringify(issue, null, 4));
+    console.log("\n" + "=".repeat(50) + "\n");
+  });
+
+  // Summary
+  console.log("\n=== Summary ===");
+  console.log("All issues as JSON:");
+  console.log(JSON.stringify(result.issues, null, 2));
+} else {
+  console.log("\nParse succeeded (unexpected!)");
+  console.log("Output:", JSON.stringify(result.output, null, 2));
+}

--- a/src/services/granolaApi.ts
+++ b/src/services/granolaApi.ts
@@ -69,9 +69,17 @@ export function printValidationIssuePaths(
             return "";
           })
           .join("");
-        log.error(`  Issue ${index + 1}: ${issue.message}\nPath: ${pathStr}`);
+        log.error(`  Issue ${index + 1}: `);
+        log.error(`  - expected: ${issue.expected}`);
+        log.error(`  - received: ${issue.received}`);
+        log.error(`  - message: ${issue.message}`);
+        log.error(`  - path: ${pathStr}`);
       } else {
-        log.error(`  Issue ${index + 1}: ${issue.message}\nPath: (root)`);
+        log.error(`  Issue ${index + 1}: `);
+        log.error(`  - expected: ${issue.expected}`);
+        log.error(`  - received: ${issue.received}`);
+        log.error(`  - message: ${issue.message}`);
+        log.error(`  - path: (root)`);
       }
     });
   }

--- a/src/services/granolaApi.ts
+++ b/src/services/granolaApi.ts
@@ -42,6 +42,40 @@ export interface GranolaDoc {
 export type TranscriptEntry = v.InferOutput<typeof TranscriptEntrySchema>;
 
 /**
+ * Helper function to print validation issue paths from a Valibot safeParse result.
+ * Prints the path of each issue to the console if validation failed.
+ */
+function printValidationIssuePaths(
+  result: { success: false; issues: unknown[] } | { success: true }
+): void {
+  if (result.success) {
+    return;
+  }
+
+  if (result.issues && result.issues.length > 0) {
+    console.log("Validation issues:");
+    result.issues.forEach((issue: unknown, index) => {
+      const issueObj = issue as {
+        path?: Array<{ key?: string | number | unknown }>;
+      };
+      if (issueObj.path && issueObj.path.length > 0) {
+        const pathStr = issueObj.path
+          .map((p: { key?: string | number | unknown }) => {
+            if (typeof p.key === "number") return `[${p.key}]`;
+            if (typeof p.key === "string") return `.${p.key}`;
+            if (p.key) return `.${String(p.key)}`;
+            return "";
+          })
+          .join("");
+        console.log(`  Issue ${index + 1}: ${pathStr}`);
+      } else {
+        console.log(`  Issue ${index + 1}: (root)`);
+      }
+    });
+  }
+}
+
+/**
  * Fetches documents from the Granola API.
  *
  * Pagination: The API supports offset-based pagination via the `offset` parameter.
@@ -75,6 +109,7 @@ export async function fetchGranolaDocuments(
   const result = v.safeParse(GranolaApiResponseSchema, jsonResponse);
   if (!result.success) {
     log.error("Validation failed for GranolaApiResponseSchema:");
+    printValidationIssuePaths(result);
     log.error(JSON.stringify(result.issues, null, 2));
 
     throw new Error(
@@ -181,6 +216,7 @@ export async function fetchGranolaTranscript(
   const result = v.safeParse(TranscriptResponseSchema, transcriptResp.json);
   if (!result.success) {
     log.error("Validation failed for TranscriptResponseSchema:");
+    printValidationIssuePaths(result);
     log.error(JSON.stringify(result.issues, null, 2));
 
     throw new Error(

--- a/src/services/granolaApi.ts
+++ b/src/services/granolaApi.ts
@@ -45,16 +45,18 @@ export type TranscriptEntry = v.InferOutput<typeof TranscriptEntrySchema>;
  * Helper function to print validation issue paths from a Valibot safeParse result.
  * Prints the path of each issue to the console if validation failed.
  */
-function printValidationIssuePaths(
-  result: { success: false; issues: unknown[] } | { success: true }
+export function printValidationIssuePaths(
+  result:
+    | v.SafeParseResult<typeof GranolaApiResponseSchema>
+    | v.SafeParseResult<typeof TranscriptResponseSchema>
 ): void {
   if (result.success) {
     return;
   }
 
   if (result.issues && result.issues.length > 0) {
-    console.log("Validation issues:");
-    result.issues.forEach((issue: unknown, index) => {
+    log.error("Validation issues:");
+    result.issues.forEach((issue, index) => {
       const issueObj = issue as {
         path?: Array<{ key?: string | number | unknown }>;
       };
@@ -67,9 +69,9 @@ function printValidationIssuePaths(
             return "";
           })
           .join("");
-        console.log(`  Issue ${index + 1}: ${pathStr}`);
+        log.error(`  Issue ${index + 1}: ${issue.message}\nPath: ${pathStr}`);
       } else {
-        console.log(`  Issue ${index + 1}: (root)`);
+        log.error(`  Issue ${index + 1}: ${issue.message}\nPath: (root)`);
       }
     });
   }

--- a/src/services/validationSchemas.ts
+++ b/src/services/validationSchemas.ts
@@ -19,8 +19,8 @@ export const ProseMirrorDocSchema = v.object({
 export const GranolaDocSchema = v.object({
   id: v.string(),
   title: v.nullish(v.string()),
-  created_at: v.optional(v.string()),
-  updated_at: v.optional(v.string()),
+  created_at: v.nullish(v.string()),
+  updated_at: v.nullish(v.string()),
   people: v.nullish(
     v.object({
       attendees: v.optional(

--- a/src/services/validationSchemas.ts
+++ b/src/services/validationSchemas.ts
@@ -21,7 +21,7 @@ export const GranolaDocSchema = v.object({
   title: v.nullish(v.string()),
   created_at: v.optional(v.string()),
   updated_at: v.optional(v.string()),
-  people: v.optional(
+  people: v.nullish(
     v.object({
       attendees: v.optional(
         v.array(
@@ -56,4 +56,3 @@ export const TranscriptEntrySchema = v.object({
 });
 
 export const TranscriptResponseSchema = v.array(TranscriptEntrySchema);
-

--- a/tests/unit/granolaApi.test.ts
+++ b/tests/unit/granolaApi.test.ts
@@ -1,0 +1,237 @@
+import * as v from "valibot";
+import { printValidationIssuePaths } from "../../src/services/granolaApi";
+import {
+  GranolaApiResponseSchema,
+  TranscriptResponseSchema,
+} from "../../src/services/validationSchemas";
+
+describe("printValidationIssuePaths", () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("should not print anything when validation succeeds", () => {
+    const validData = { docs: [] };
+    const result = v.safeParse(GranolaApiResponseSchema, validData);
+
+    printValidationIssuePaths(result);
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("should print validation issues with paths for GranolaApiResponseSchema", () => {
+    // Create invalid data that will fail validation
+    const invalidData = {
+      docs: [
+        {
+          id: 123, // Should be string, not number
+          title: null,
+        },
+      ],
+    };
+    const result = v.safeParse(GranolaApiResponseSchema, invalidData);
+
+    expect(result.success).toBe(false);
+    printValidationIssuePaths(result);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[Granola Sync]",
+      "Validation issues:"
+    );
+    // Should have at least one issue logged (header + at least one issue)
+    expect(consoleErrorSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+    // Check that issue messages are logged
+    const logCalls = consoleErrorSpy.mock.calls;
+    const issueLogs = logCalls.filter((call) =>
+      call[1]?.toString().startsWith("  Issue")
+    );
+    expect(issueLogs.length).toBeGreaterThan(0);
+  });
+
+  it("should print root path when issue has no path", () => {
+    // Create invalid data at root level
+    const invalidData = "not an object";
+    const result = v.safeParse(GranolaApiResponseSchema, invalidData);
+
+    expect(result.success).toBe(false);
+    printValidationIssuePaths(result);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[Granola Sync]",
+      "Validation issues:"
+    );
+    // Should log issue with root path
+    const logCalls = consoleErrorSpy.mock.calls;
+    const rootPathLog = logCalls.find((call) =>
+      call[1]?.toString().includes("Path: (root)")
+    );
+    expect(rootPathLog).toBeDefined();
+  });
+
+  it("should print nested paths correctly", () => {
+    // Create invalid data with nested path issues
+    const invalidData = {
+      docs: [
+        {
+          id: "valid-id",
+          title: "Valid Title",
+          people: {
+            attendees: [
+              {
+                name: 123, // Should be string, not number
+                email: "test@example.com",
+              },
+            ],
+          },
+        },
+      ],
+    };
+    const result = v.safeParse(GranolaApiResponseSchema, invalidData);
+
+    expect(result.success).toBe(false);
+    printValidationIssuePaths(result);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[Granola Sync]",
+      "Validation issues:"
+    );
+    // Should have path information in the logs
+    const logCalls = consoleErrorSpy.mock.calls;
+    const pathLogs = logCalls.filter((call) =>
+      call[1]?.toString().includes("Path:")
+    );
+    expect(pathLogs.length).toBeGreaterThan(0);
+  });
+
+  it("should handle array index paths correctly", () => {
+    // Create invalid data with array index issues
+    const invalidData = {
+      docs: [
+        {
+          id: "valid-id-1",
+          title: null,
+        },
+        {
+          id: 456, // Should be string, not number
+          title: null,
+        },
+      ],
+    };
+    const result = v.safeParse(GranolaApiResponseSchema, invalidData);
+
+    expect(result.success).toBe(false);
+    printValidationIssuePaths(result);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[Granola Sync]",
+      "Validation issues:"
+    );
+    // Check that paths are formatted correctly
+    const logCalls = consoleErrorSpy.mock.calls;
+    const allLogs = logCalls
+      .map((call) => call[1]?.toString() || "")
+      .join("\n");
+    // Should contain array index notation like [1] or [0]
+    expect(allLogs).toMatch(/\[[0-9]+\]/);
+  });
+
+  it("should handle TranscriptResponseSchema validation failures", () => {
+    // Create invalid transcript data
+    const invalidData = [
+      {
+        document_id: "doc-123",
+        start_timestamp: "invalid", // Should be valid timestamp
+        text: "Some text",
+        source: "source",
+        id: "transcript-1",
+        is_final: "not a boolean", // Should be boolean
+        end_timestamp: "invalid",
+      },
+    ];
+    const result = v.safeParse(TranscriptResponseSchema, invalidData);
+
+    expect(result.success).toBe(false);
+    printValidationIssuePaths(result);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[Granola Sync]",
+      "Validation issues:"
+    );
+    // Should have logged issues
+    const logCalls = consoleErrorSpy.mock.calls;
+    const issueLogs = logCalls.filter((call) =>
+      call[1]?.toString().startsWith("  Issue")
+    );
+    expect(issueLogs.length).toBeGreaterThan(0);
+  });
+
+  it("should format string paths with dot notation", () => {
+    // Create invalid data with string key paths
+    const invalidData = {
+      docs: [
+        {
+          id: "valid-id",
+          title: null,
+          people: {
+            attendees: [
+              {
+                name: "Valid Name",
+                email: 123, // Should be string, not number
+              },
+            ],
+          },
+        },
+      ],
+    };
+    const result = v.safeParse(GranolaApiResponseSchema, invalidData);
+
+    expect(result.success).toBe(false);
+    printValidationIssuePaths(result);
+
+    const logCalls = consoleErrorSpy.mock.calls;
+    const allLogs = logCalls
+      .map((call) => call[1]?.toString() || "")
+      .join("\n");
+    // Should contain dot notation like .email or .people
+    expect(allLogs).toMatch(/\.[a-zA-Z_][a-zA-Z0-9_]*/);
+  });
+
+  it("should handle multiple issues correctly", () => {
+    // Create invalid data with multiple issues
+    const invalidData = {
+      docs: [
+        {
+          id: 123, // Invalid type
+          title: null,
+          created_at: 456, // Invalid type
+        },
+      ],
+    };
+    const result = v.safeParse(GranolaApiResponseSchema, invalidData);
+    expect(result.success).toBe(false);
+    printValidationIssuePaths(result);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[Granola Sync]",
+      "Validation issues:"
+    );
+    // Should log multiple issues
+    const logCalls = consoleErrorSpy.mock.calls;
+    const issueLogs = logCalls.filter((call) =>
+      call[1]?.toString().startsWith("  Issue")
+    );
+    expect(issueLogs.length).toBeGreaterThan(0);
+    // Check that issue numbers are sequential
+    const issueNumbers = issueLogs.map((call) => {
+      const match = call[1]?.toString().match(/Issue (\d+):/);
+      return match ? parseInt(match[1], 10) : null;
+    });
+    expect(issueNumbers[0]).toBe(1);
+  });
+});

--- a/tests/unit/granolaApi.test.ts
+++ b/tests/unit/granolaApi.test.ts
@@ -69,7 +69,7 @@ describe("printValidationIssuePaths", () => {
     // Should log issue with root path
     const logCalls = consoleErrorSpy.mock.calls;
     const rootPathLog = logCalls.find((call) =>
-      call[1]?.toString().includes("Path: (root)")
+      call[1]?.toString().includes("path: (root)")
     );
     expect(rootPathLog).toBeDefined();
   });
@@ -104,7 +104,7 @@ describe("printValidationIssuePaths", () => {
     // Should have path information in the logs
     const logCalls = consoleErrorSpy.mock.calls;
     const pathLogs = logCalls.filter((call) =>
-      call[1]?.toString().includes("Path:")
+      call[1]?.toString().includes("path:")
     );
     expect(pathLogs.length).toBeGreaterThan(0);
   });


### PR DESCRIPTION
## Update validation schemas to use nullish
- Change `created_at`, `updated_at`, and `people` from `v.optional()` to `v.nullish()` in `GranolaDocSchema`
- Supports both `null` and `undefined` values for these fields
- Add test suite for `printValidationIssuePaths` covering success cases, nested paths, array indices, root paths, and multiple issues