### PR TITLE
feat: move note-transcript links to frontmatter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,23 @@
 4. Add tests for new functionality
 5. Submit a pull request
 
+## Project Philosophy
+
+When contributing to this plugin, please keep these core principles in mind:
+
+1. **Keep the codebase minimal:**
+   - We don't add features for uncommon or edge use-cases
+   - Feel free to fork the project for specialized use cases!
+
+2. **Preserve content integrity:**
+   - Content of notes and transcripts should match what is stored in Granola
+   - Don't add extra information to the body of notes or transcripts
+   - Use frontmatter to store additional metadata (e.g. links between notes and transcripts)
+
+3. **Maintain code quality:**
+   - PRs should never reduce test coverage
+   - New functionality should come with new tests
+
 ## Testing Strategy
 
 The plugin uses a combination of unit and integration tests:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ title: "Meeting Title"
 type: note
 created_at: 2024-01-15T10:00:00Z
 updated_at: 2024-01-15T12:00:00Z
+attendees:
+  - John Doe
+  - Jane Smith
+transcript: <Transcripts/Meeting Title-transcript.md>
 ---
 ```
 
@@ -58,10 +62,27 @@ title: "Meeting Title - Transcript"
 type: transcript
 created_at: 2024-01-15T10:00:00Z
 updated_at: 2024-01-15T12:00:00Z
+attendees:
+  - John Doe
+  - Jane Smith
+note: <Granola/Meeting Title.md>
 ---
 ```
 
 The `granola_id` is consistent across both note and transcript files for the same source document, while the `type` field distinguishes between them. This allows both file types to coexist with proper duplicate detection.
+
+### Frontmatter Fields
+
+- `granola_id`: Unique identifier from Granola, consistent across note and transcript files
+- `title`: Document title (with "- Transcript" suffix for transcripts)
+- `type`: Either `note` or `transcript`
+- `created_at`: ISO timestamp when the document was created (optional)
+- `updated_at`: ISO timestamp when the document was last updated (optional)
+- `attendees`: Array of attendee names from the meeting (optional)
+- `transcript`: Path to the transcript file (only in notes, when linking is enabled, for individual note files only)
+- `note`: Path to the note file (only in transcripts, when linking is enabled)
+
+The `transcript` and `note` fields use Obsidian-style paths with angle brackets (`< >`) to handle spaces in filenames. These fields are only added when the "Create link from Granola note to transcript" setting is enabled.
 
 ### Legacy Format Migration
 

--- a/src/services/dailyNoteBuilder.ts
+++ b/src/services/dailyNoteBuilder.ts
@@ -113,19 +113,6 @@ export class DailyNoteBuilder {
         content += `**Updated:** ${note.updatedAt}\n`;
       }
 
-      if (
-        this.settings.syncTranscripts &&
-        this.settings.createLinkFromNoteToTranscript
-      ) {
-        const noteDate = this.getNoteDateFromNote(note, dateKey);
-        const transcriptPath = this.pathResolver.computeTranscriptPath(
-          note.title,
-          noteDate
-        );
-
-        content += `**Transcript:** [[<${transcriptPath}>]]\n`;
-      }
-
       content += `\n${note.markdown}\n`;
     }
 

--- a/src/services/transcriptFormatter.ts
+++ b/src/services/transcriptFormatter.ts
@@ -9,6 +9,8 @@ import { TranscriptEntry } from "./granolaApi";
  * @param createdAt - Optional creation timestamp
  * @param updatedAt - Optional update timestamp
  * @param attendees - Optional array of attendee names
+ * @param notePath - Optional resolved note path (with collision detection) to include in frontmatter
+ * @param createLinkFromNoteToTranscript - Whether to add note link to frontmatter
  * @returns Formatted markdown string with frontmatter and speaker-grouped content
  */
 export function formatTranscriptBySpeaker(
@@ -17,7 +19,9 @@ export function formatTranscriptBySpeaker(
   granolaId: string,
   createdAt?: string,
   updatedAt?: string,
-  attendees?: string[]
+  attendees?: string[],
+  notePath?: string,
+  createLinkFromNoteToTranscript: boolean = false
 ): string {
   // Add frontmatter with granola_id for transcript deduplication
   const escapedTitleForYaml = title.replace(/"/g, '\\"');
@@ -36,6 +40,13 @@ export function formatTranscriptBySpeaker(
   } else {
     frontmatterLines.push(`attendees: []`);
   }
+  
+  // Add note link to frontmatter if enabled and path provided
+  if (createLinkFromNoteToTranscript && notePath) {
+    // Paths should use < > brackets for spaces (Obsidian-style)
+    frontmatterLines.push(`note: <${notePath}>`);
+  }
+  
   frontmatterLines.push("---", "");
 
   let transcriptMd = frontmatterLines.join("\n") + "\n";

--- a/tests/unit/dailyNoteBuilder.test.ts
+++ b/tests/unit/dailyNoteBuilder.test.ts
@@ -230,7 +230,7 @@ describe("DailyNoteBuilder", () => {
       expect(result).toContain("**Granola ID:** doc-123");
     });
 
-    it("should add transcript link when enabled", () => {
+    it("should not add transcript link to daily note sections", () => {
       dailyNoteBuilder = new DailyNoteBuilder(
         mockApp,
         mockDocumentProcessor,
@@ -242,26 +242,6 @@ describe("DailyNoteBuilder", () => {
         }
       );
 
-      (mockPathResolver.computeTranscriptPath as jest.Mock).mockReturnValue(
-        "Transcripts/Test Note-transcript.md"
-      );
-
-      const result = dailyNoteBuilder.buildDailyNoteSectionContent(
-        [noteData],
-        "## Granola Notes",
-        "2024-01-15"
-      );
-
-      expect(result).toContain(
-        "**Transcript:** [[<Transcripts/Test Note-transcript.md>]]"
-      );
-      expect(mockPathResolver.computeTranscriptPath).toHaveBeenCalledWith(
-        "Test Note",
-        expect.any(Date)
-      );
-    });
-
-    it("should not add transcript link when disabled", () => {
       const result = dailyNoteBuilder.buildDailyNoteSectionContent(
         [noteData],
         "## Granola Notes",
@@ -269,61 +249,8 @@ describe("DailyNoteBuilder", () => {
       );
 
       expect(result).not.toContain("**Transcript:**");
+      expect(result).not.toContain("[[<");
       expect(mockPathResolver.computeTranscriptPath).not.toHaveBeenCalled();
-    });
-
-    it("should wrap transcript paths with spaces in angle brackets", () => {
-      dailyNoteBuilder = new DailyNoteBuilder(
-        mockApp,
-        mockDocumentProcessor,
-        mockPathResolver,
-        {
-          syncTranscripts: true,
-          createLinkFromNoteToTranscript: true,
-          dailyNoteSectionHeading: "## Granola Notes",
-        }
-      );
-
-      (mockPathResolver.computeTranscriptPath as jest.Mock).mockReturnValue(
-        "Transcripts/My Meeting Transcript.md"
-      );
-
-      const result = dailyNoteBuilder.buildDailyNoteSectionContent(
-        [noteData],
-        "## Granola Notes",
-        "2024-01-15"
-      );
-
-      expect(result).toContain(
-        "**Transcript:** [[<Transcripts/My Meeting Transcript.md>]]"
-      );
-    });
-
-    it("should wrap transcript paths without spaces in angle brackets", () => {
-      dailyNoteBuilder = new DailyNoteBuilder(
-        mockApp,
-        mockDocumentProcessor,
-        mockPathResolver,
-        {
-          syncTranscripts: true,
-          createLinkFromNoteToTranscript: true,
-          dailyNoteSectionHeading: "## Granola Notes",
-        }
-      );
-
-      (mockPathResolver.computeTranscriptPath as jest.Mock).mockReturnValue(
-        "Transcripts/TestNote-transcript.md"
-      );
-
-      const result = dailyNoteBuilder.buildDailyNoteSectionContent(
-        [noteData],
-        "## Granola Notes",
-        "2024-01-15"
-      );
-
-      expect(result).toContain(
-        "**Transcript:** [[<Transcripts/TestNote-transcript.md>]]"
-      );
     });
 
     it("should handle multiple notes", () => {

--- a/tests/unit/transcriptFormatter.test.ts
+++ b/tests/unit/transcriptFormatter.test.ts
@@ -297,4 +297,112 @@ describe("formatTranscriptBySpeaker", () => {
     expect(result).not.toContain("updated_at:");
     expect(result).toContain("---");
   });
+
+  it("should add note field to frontmatter when enabled and path provided", () => {
+    const transcriptData: TranscriptEntry[] = [
+      {
+        document_id: "doc1",
+        start_timestamp: "00:00:01",
+        end_timestamp: "00:00:05",
+        text: "Test text",
+        source: "microphone",
+        id: "entry1",
+        is_final: true,
+      },
+    ];
+
+    const result = formatTranscriptBySpeaker(
+      transcriptData,
+      "Test Meeting",
+      "test-id",
+      undefined,
+      undefined,
+      undefined,
+      "Granola/Test Meeting.md",
+      true
+    );
+
+    expect(result).toContain("note: <Granola/Test Meeting.md>");
+  });
+
+  it("should not add note field when path not provided", () => {
+    const transcriptData: TranscriptEntry[] = [
+      {
+        document_id: "doc1",
+        start_timestamp: "00:00:01",
+        end_timestamp: "00:00:05",
+        text: "Test text",
+        source: "microphone",
+        id: "entry1",
+        is_final: true,
+      },
+    ];
+
+    const result = formatTranscriptBySpeaker(
+      transcriptData,
+      "Test Meeting",
+      "test-id",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true
+    );
+
+    expect(result).not.toContain("note:");
+  });
+
+  it("should not add note field when linking disabled", () => {
+    const transcriptData: TranscriptEntry[] = [
+      {
+        document_id: "doc1",
+        start_timestamp: "00:00:01",
+        end_timestamp: "00:00:05",
+        text: "Test text",
+        source: "microphone",
+        id: "entry1",
+        is_final: true,
+      },
+    ];
+
+    const result = formatTranscriptBySpeaker(
+      transcriptData,
+      "Test Meeting",
+      "test-id",
+      undefined,
+      undefined,
+      undefined,
+      "Granola/Test Meeting.md",
+      false
+    );
+
+    expect(result).not.toContain("note:");
+  });
+
+  it("should wrap note paths with spaces in angle brackets", () => {
+    const transcriptData: TranscriptEntry[] = [
+      {
+        document_id: "doc1",
+        start_timestamp: "00:00:01",
+        end_timestamp: "00:00:05",
+        text: "Test text",
+        source: "microphone",
+        id: "entry1",
+        is_final: true,
+      },
+    ];
+
+    const result = formatTranscriptBySpeaker(
+      transcriptData,
+      "Test Meeting",
+      "test-id",
+      undefined,
+      undefined,
+      undefined,
+      "Granola/My Meeting Note.md",
+      true
+    );
+
+    expect(result).toContain("note: <Granola/My Meeting Note.md>");
+  });
 });


### PR DESCRIPTION
## Bidirectional frontmatter linking
- Notes now include `transcript` field in frontmatter linking to transcript files (when syncing to individual files)
- Transcripts include `note` field in frontmatter linking back to their source note
- Removed "Create link from Granola note to transcript" setting
- Added project philosophy section to CONTRIBUTING.md
- Updated all unit tests to reflect frontmatter-based linking behavior

Closes https://github.com/tomelliot/obsidian-granola-sync/pull/45