### PR TITLE
refactor: update frontmatter properties to use Obsidian defacto-standard field names

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,18 @@
+codecov:
+  notify:
+    wait_for_ci: true
+  require_ci_to_pass: true
+comment: false
+coverage:
+  precision: 2
+  range:
+  - 60.0
+  - 80.0
+  round: down
+  status:
+    changes: false
+    default_rules:
+      flag_coverage_not_uploaded_behavior: include
+    patch: true
+    project: true
+slack_app: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,69 @@
+name: 'Close stale issues and PRs'
+
+on:
+  schedule:
+    # Run daily at 1:30 AM UTC
+    - cron: '30 1 * * *'
+  workflow_dispatch: # Allow manual triggering
+
+permissions:
+  actions: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          # Messages to post when marking as stale
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has had no activity for 15 days. 
+            It will be closed in 5 days if no further activity occurs. 
+            Please comment if this issue is still relevant or needs attention.
+          
+          stale-pr-message: |
+            This pull request has been automatically marked as stale because it has had no activity for 15 days. 
+            It will be closed in 5 days if no further activity occurs. 
+            Please comment or push new commits if this PR should remain open.
+          
+          # Messages to post when closing
+          close-issue-message: |
+            This issue has been automatically closed due to inactivity. 
+            If you believe this issue is still relevant, please reopen it or create a new issue with updated information.
+          
+          close-pr-message: |
+            This pull request has been automatically closed due to inactivity. 
+            If you would like to continue working on this PR, please reopen it or create a new one.
+          
+          # Days before marking as stale
+          days-before-stale: 15
+          
+          # Days before closing after marked as stale
+          days-before-close: 5
+          
+          # Labels
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          
+          # Exempt labels (issues/PRs with these labels will never be marked as stale)
+          exempt-issue-labels: 'pinned,security,bug,enhancement,good-first-issue'
+          exempt-pr-labels: 'pinned,work-in-progress,do-not-close'
+          
+          # Exempt all issues/PRs with any milestone
+          exempt-all-issue-milestones: true
+          exempt-all-pr-milestones: true
+          
+          # Exempt all PRs with assignees
+          exempt-all-pr-assignees: true
+          
+          # Reason for closing issues (not_planned, completed, or obsolete)
+          close-issue-reason: 'not_planned'
+          
+          # Maximum operations per run (helps avoid rate limits)
+          operations-per-run: 100
+          
+          # Enable statistics in logs
+          enable-statistics: true
+

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ All synced files include structured frontmatter for tracking and identification:
 granola_id: doc-123
 title: "Meeting Title"
 type: note
-created_at: 2024-01-15T10:00:00Z
-updated_at: 2024-01-15T12:00:00Z
+created: 2024-01-15T10:00:00Z
+updated: 2024-01-15T12:00:00Z
 attendees:
   - John Doe
   - Jane Smith
@@ -59,8 +59,8 @@ transcript: "[[Transcripts/Meeting Title-transcript.md]]"
 granola_id: doc-123
 title: "Meeting Title - Transcript"
 type: transcript
-created_at: 2024-01-15T10:00:00Z
-updated_at: 2024-01-15T12:00:00Z
+created: 2024-01-15T10:00:00Z
+updated: 2024-01-15T12:00:00Z
 attendees:
   - John Doe
   - Jane Smith
@@ -75,8 +75,8 @@ The `granola_id` is consistent across both note and transcript files for the sam
 - `granola_id`: Unique identifier from Granola, consistent across note and transcript files
 - `title`: Document title (with "- Transcript" suffix for transcripts)
 - `type`: Either `note` or `transcript`
-- `created_at`: ISO timestamp when the document was created
-- `updated_at`: ISO timestamp when the document was last updated
+- `created`: ISO timestamp when the document was created
+- `updated`: ISO timestamp when the document was last updated
 - `attendees`: Array of attendee names from the meeting
 - `transcript`: Wiki-style link to the transcript file (only in notes saved as individual files, not in daily notes)
 - `note`: Wiki-style link to the note (in transcripts, links to individual files or daily notes with heading anchors)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Obsidian Granola Sync
 
-[![Tests](https://github.com/tomelliot/obsidian-granola-sync/actions/workflows/release.yml/badge.svg?branch=main)](https://github.com/tomelliot/obsidian-granola-sync/actions/workflows/release.yml)
+[![Release](https://github.com/tomelliot/obsidian-granola-sync/actions/workflows/release.yml/badge.svg?branch=main)](https://github.com/tomelliot/obsidian-granola-sync/actions/workflows/release.yml)
+[![codecov](https://codecov.io/gh/tomelliot/obsidian-granola-sync/graph/badge.svg?token=UALN2224PQ)](https://codecov.io/gh/tomelliot/obsidian-granola-sync)
 
 This plugin allows you to synchronize your notes and transcripts from Granola (https://granola.ai) directly into your Obsidian vault. It fetches documents from Granola, converts them from ProseMirror JSON format to Markdown, and saves them as `.md` files.
 
@@ -13,13 +14,12 @@ This plugin allows you to synchronize your notes and transcripts from Granola (h
 - Periodic automatic syncing with customizable interval
 - Granular settings for notes and transcripts
 - Customizable sync settings and destinations
-- **Platform support:** This plugin only works on **macOS**. It is **not supported on iOS**.
+- **Platform support:** This plugin only works on desktop. It is not supported on mobile.
 
 ## Installation
 
-1. Download the latest release from the releases page
-2. Extract the zip file into your Obsidian plugins folder
-3. Enable the plugin in Obsidian settings
+1. Go to [https://obsidian.md/plugins?search=granola](https://obsidian.md/plugins?search=granola)
+2. Click Install
 
 ## Configuration
 
@@ -75,9 +75,9 @@ The `granola_id` is consistent across both note and transcript files for the sam
 - `granola_id`: Unique identifier from Granola, consistent across note and transcript files
 - `title`: Document title (with "- Transcript" suffix for transcripts)
 - `type`: Either `note` or `transcript`
-- `created_at`: ISO timestamp when the document was created (optional)
-- `updated_at`: ISO timestamp when the document was last updated (optional)
-- `attendees`: Array of attendee names from the meeting (optional)
+- `created_at`: ISO timestamp when the document was created
+- `updated_at`: ISO timestamp when the document was last updated
+- `attendees`: Array of attendee names from the meeting
 - `transcript`: Wiki-style link to the transcript file (only in notes saved as individual files, not in daily notes)
 - `note`: Wiki-style link to the note (in transcripts, links to individual files or daily notes with heading anchors)
 

--- a/docs/sync-process.md
+++ b/docs/sync-process.md
@@ -142,8 +142,8 @@ All synced files include frontmatter with metadata for tracking and identificati
 granola_id: doc-123
 title: "Meeting Title"
 type: note
-created_at: 2024-01-15T10:00:00Z
-updated_at: 2024-01-15T12:00:00Z
+created: 2024-01-15T10:00:00Z
+updated: 2024-01-15T12:00:00Z
 ---
 ```
 
@@ -154,8 +154,8 @@ updated_at: 2024-01-15T12:00:00Z
 granola_id: doc-123
 title: "Meeting Title - Transcript"
 type: transcript
-created_at: 2024-01-15T10:00:00Z
-updated_at: 2024-01-15T12:00:00Z
+created: 2024-01-15T10:00:00Z
+updated: 2024-01-15T12:00:00Z
 ---
 ```
 
@@ -163,7 +163,7 @@ updated_at: 2024-01-15T12:00:00Z
 
 - `granola_id`: Consistent across both note and transcript for the same source document
 - `type`: Distinguishes between 'note' and 'transcript' files
-- `created_at` and `updated_at`: Timestamps from Granola API (when available)
+- `created` and `updated`: Timestamps from Granola API (when available)
 - Both file types can share the same `granola_id` while being uniquely identified by `type`
 
 ### Legacy Frontmatter Migration
@@ -205,7 +205,7 @@ When syncing to daily notes, documents are grouped by date and inserted into sec
 ```mermaid
 flowchart TD
     A[Documents List] --> B[For Each Document]
-    B --> C[Extract Date from created_at/updated_at]
+    B --> C[Extract Date from document timestamps]
     C --> D[Group by Date YYYY-MM-DD]
     D --> E[Convert ProseMirror to Markdown]
     E --> F[Add to Daily Notes Map]

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "granola-sync",
   "name": "Granola Sync",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "minAppVersion": "0.15.0",
   "description": "Sync Granola notes to your vault.",
   "author": "Tom Elliot",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-granola-sync",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "Sync Granola notes to your vault.",
   "main": "main.js",
   "scripts": {

--- a/src/services/documentProcessor.ts
+++ b/src/services/documentProcessor.ts
@@ -22,7 +22,10 @@ export class DocumentProcessor {
    * @param transcriptPath - Optional resolved transcript path (with collision detection) to include in frontmatter
    * @returns Object containing the filename and full markdown content
    */
-  prepareNote(doc: GranolaDoc, transcriptPath?: string): { filename: string; content: string } {
+  prepareNote(
+    doc: GranolaDoc,
+    transcriptPath?: string
+  ): { filename: string; content: string } {
     const contentToParse = doc.last_viewed_panel?.content;
     if (
       !contentToParse ||
@@ -44,8 +47,8 @@ export class DocumentProcessor {
       `title: "${escapedTitleForYaml}"`,
       `type: note`,
     ];
-    if (doc.created_at) frontmatterLines.push(`created_at: ${doc.created_at}`);
-    if (doc.updated_at) frontmatterLines.push(`updated_at: ${doc.updated_at}`);
+    if (doc.created_at) frontmatterLines.push(`created: ${doc.created_at}`);
+    if (doc.updated_at) frontmatterLines.push(`updated: ${doc.updated_at}`);
     const attendees =
       doc.people?.attendees
         ?.map((attendee) => attendee.name || attendee.email || "Unknown")
@@ -56,14 +59,14 @@ export class DocumentProcessor {
     } else {
       frontmatterLines.push(`attendees: []`);
     }
-    
+
     // Add transcript link to frontmatter if path provided
     // Path is only provided for individual note files (not for DAILY_NOTES destination)
     if (this.settings.syncTranscripts && transcriptPath) {
       // Use wiki-style links in frontmatter
       frontmatterLines.push(`transcript: "[[${transcriptPath}]]"`);
     }
-    
+
     frontmatterLines.push("---", "");
 
     let finalMarkdown = frontmatterLines.join("\n");

--- a/src/services/transcriptFormatter.ts
+++ b/src/services/transcriptFormatter.ts
@@ -29,8 +29,8 @@ export function formatTranscriptBySpeaker(
     `title: "${escapedTitleForYaml} - Transcript"`,
     `type: transcript`,
   ];
-  if (createdAt) frontmatterLines.push(`created_at: ${createdAt}`);
-  if (updatedAt) frontmatterLines.push(`updated_at: ${updatedAt}`);
+  if (createdAt) frontmatterLines.push(`created: ${createdAt}`);
+  if (updatedAt) frontmatterLines.push(`updated: ${updatedAt}`);
   const attendeesArray = attendees || [];
   if (attendeesArray.length > 0) {
     const attendeesYaml = attendeesArray

--- a/tests/unit/documentProcessor.test.ts
+++ b/tests/unit/documentProcessor.test.ts
@@ -75,8 +75,8 @@ describe("DocumentProcessor", () => {
       expect(result.content).toContain("granola_id: doc-123");
       expect(result.content).toContain('title: "Test Note"');
       expect(result.content).toContain("type: note");
-      expect(result.content).toContain("created_at: 2024-01-15T10:00:00Z");
-      expect(result.content).toContain("updated_at: 2024-01-15T12:00:00Z");
+      expect(result.content).toContain("created: 2024-01-15T10:00:00Z");
+      expect(result.content).toContain("updated: 2024-01-15T12:00:00Z");
       expect(result.content).toContain("# Mock Content");
     });
 
@@ -97,8 +97,8 @@ describe("DocumentProcessor", () => {
       expect(result.filename).toBe("Minimal Note.md");
       expect(result.content).toContain("granola_id: doc-456");
       expect(result.content).toContain("type: note");
-      expect(result.content).not.toContain("created_at:");
-      expect(result.content).not.toContain("updated_at:");
+      expect(result.content).not.toContain("created:");
+      expect(result.content).not.toContain("updated:");
     });
 
     it("should escape quotes in titles for YAML frontmatter", () => {
@@ -138,9 +138,14 @@ describe("DocumentProcessor", () => {
         },
       };
 
-      const result = documentProcessor.prepareNote(doc, "Transcripts/Test Note-transcript.md");
+      const result = documentProcessor.prepareNote(
+        doc,
+        "Transcripts/Test Note-transcript.md"
+      );
 
-      expect(result.content).toContain('transcript: "[[Transcripts/Test Note-transcript.md]]"');
+      expect(result.content).toContain(
+        'transcript: "[[Transcripts/Test Note-transcript.md]]"'
+      );
       expect(result.content).not.toContain("[Transcript]");
     });
 
@@ -209,9 +214,14 @@ describe("DocumentProcessor", () => {
         },
       };
 
-      const result = documentProcessor.prepareNote(doc, "Transcripts/My Meeting Transcript.md");
+      const result = documentProcessor.prepareNote(
+        doc,
+        "Transcripts/My Meeting Transcript.md"
+      );
 
-      expect(result.content).toContain('transcript: "[[Transcripts/My Meeting Transcript.md]]"');
+      expect(result.content).toContain(
+        'transcript: "[[Transcripts/My Meeting Transcript.md]]"'
+      );
     });
 
     it("should use wiki-style links for transcript paths without spaces in frontmatter", () => {
@@ -234,9 +244,14 @@ describe("DocumentProcessor", () => {
         },
       };
 
-      const result = documentProcessor.prepareNote(doc, "Transcripts/TestNote-transcript.md");
+      const result = documentProcessor.prepareNote(
+        doc,
+        "Transcripts/TestNote-transcript.md"
+      );
 
-      expect(result.content).toContain('transcript: "[[Transcripts/TestNote-transcript.md]]"');
+      expect(result.content).toContain(
+        'transcript: "[[Transcripts/TestNote-transcript.md]]"'
+      );
     });
 
     it("should use default title when title is missing", () => {

--- a/tests/unit/transcriptFormatter.test.ts
+++ b/tests/unit/transcriptFormatter.test.ts
@@ -82,13 +82,19 @@ describe("formatTranscriptBySpeaker", () => {
     const youSections = result.match(/## You \(/g);
     expect(youSections).toHaveLength(1);
     expect(result).toContain("## You (00:00:01)");
-    expect(result).toContain("First sentence. Second sentence. Third sentence.");
+    expect(result).toContain(
+      "First sentence. Second sentence. Third sentence."
+    );
   });
 
   it("should handle empty transcript data", () => {
     const transcriptData: TranscriptEntry[] = [];
 
-    const result = formatTranscriptBySpeaker(transcriptData, "Empty", "empty-id");
+    const result = formatTranscriptBySpeaker(
+      transcriptData,
+      "Empty",
+      "empty-id"
+    );
 
     expect(result).toContain("---");
     expect(result).toContain("granola_id: empty-id");
@@ -118,7 +124,9 @@ describe("formatTranscriptBySpeaker", () => {
       "test-id"
     );
 
-    expect(result).toContain('title: "Meeting \\"Project Alpha\\" - Transcript"');
+    expect(result).toContain(
+      'title: "Meeting \\"Project Alpha\\" - Transcript"'
+    );
   });
 
   it("should distinguish between microphone and speaker sources", () => {
@@ -266,8 +274,8 @@ describe("formatTranscriptBySpeaker", () => {
     expect(result).toContain("---");
     expect(result).toContain("granola_id: meeting-123");
     expect(result).toContain("type: transcript");
-    expect(result).toContain(`created_at: ${createdAt}`);
-    expect(result).toContain(`updated_at: ${updatedAt}`);
+    expect(result).toContain(`created: ${createdAt}`);
+    expect(result).toContain(`updated: ${updatedAt}`);
     expect(result).toContain("---");
   });
 
@@ -293,8 +301,8 @@ describe("formatTranscriptBySpeaker", () => {
     expect(result).toContain("---");
     expect(result).toContain("granola_id: meeting-456");
     expect(result).toContain("type: transcript");
-    expect(result).not.toContain("created_at:");
-    expect(result).not.toContain("updated_at:");
+    expect(result).not.toContain("created:");
+    expect(result).not.toContain("updated:");
     expect(result).toContain("---");
   });
 
@@ -349,7 +357,6 @@ describe("formatTranscriptBySpeaker", () => {
 
     expect(result).not.toContain("note:");
   });
-
 
   it("should use wiki-style links for note paths in frontmatter", () => {
     const transcriptData: TranscriptEntry[] = [


### PR DESCRIPTION
- Renamed `created_at` and `updated_at` to `created` and `updated` in all synced documents
- Added Codecov integration with `.codecov.yml` configuration file
- Added stale issue/PR management workflow to automatically close inactive items after 15 days

Closes https://github.com/tomelliot/obsidian-granola-sync/issues/49