### PR TITLE
Feature/vault root destination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # vscode
 .vscode 
+.windsurf
+.cursor
 
 # Intellij
 *.iml

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This plugin allows you to synchronize your notes and transcripts from Granola (h
 
 - Sync Granola notes to your Obsidian vault
 - Sync Granola transcripts to your vault, with flexible destination options
-- Support for syncing to daily notes, a dedicated folder, or a daily note folder structure
+- Support for syncing to daily notes, a dedicated folder, the vault root, or a daily note folder structure
 - Automatic bidirectional linking between notes and transcripts when using individual files
 - Periodic automatic syncing with customizable interval
 - Granular settings for notes and transcripts
@@ -27,8 +27,8 @@ This plugin allows you to synchronize your notes and transcripts from Granola (h
 
 1. Configure note syncing:
    - Choose whether to sync notes
-   - Select the destination: a specific folder, daily notes, or daily note folder structure
-   - Optionally set a section heading for daily notes
+   - Select the destination: a specific folder, the vault root, daily notes, or daily note folder structure
+   - Optionally set a section heading for daily notes (when using daily notes)
 2. Configure transcript syncing:
    - Choose whether to sync transcripts
    - Select the destination: a dedicated transcripts folder or daily note folder structure

--- a/docs/sync-process.md
+++ b/docs/sync-process.md
@@ -178,7 +178,7 @@ The plugin automatically migrates legacy frontmatter formats on load:
 
 ## Note Syncing
 
-Notes can be synced to three different destinations, each with different behavior:
+Notes can be synced to four different destinations, each with different behavior:
 
 ### Note Sync Destinations
 
@@ -188,6 +188,7 @@ flowchart TD
     B -->|Daily Notes| C[Group by Date]
     B -->|Daily Note Folder Structure| D[Individual Files]
     B -->|Granola Folder| D
+    B -->|Vault Root| D
 
     C --> E[Create/Update Daily Note]
     E --> F[Update Section with Heading]
@@ -277,9 +278,9 @@ Path computation depends on the destination type:
 - Extracts folder structure from date format
 - Combines with base daily notes folder
 
-**Granola Folder / Granola Transcripts Folder**:
+**Granola Folder / Vault Root / Granola Transcripts Folder**:
 
-- Uses configured folder path directly
+- Uses configured folder path directly (or the vault root when selected)
 - Normalizes path separators
 
 **Filename Sanitization**:

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -24,8 +24,8 @@ const prod = process.argv[2] === "production";
 const DEV_PLUGIN_PATH =
   process.env.DEV_PLUGIN_PATH ||
   path.join(
-    process.env.HOME,
-    "Documents/Obsidian Vault/.obsidian/plugins/obsidian-granola-sync/main.js"
+    process.env.HOME ?? "",
+    "obs-notes/.obsidian/plugins/obsidian-granola-sync/main.js"
   );
 
 function copyToDevPlugin() {

--- a/src/services/fileSyncService.ts
+++ b/src/services/fileSyncService.ts
@@ -88,6 +88,10 @@ export class FileSyncService {
    * @returns True if the folder exists or was created successfully, false on error
    */
   async ensureFolder(folderPath: string): Promise<boolean> {
+    if (folderPath === "." || folderPath === "") {
+      // Vault root requires no folder creation
+      return true;
+    }
     try {
       const folderExists = this.app.vault.getAbstractFileByPath(folderPath);
       if (!folderExists) {
@@ -189,7 +193,10 @@ export class FileSyncService {
 
     const type = isTranscript ? "transcript" : "note";
     let resolvedFilename = filename;
-    let filePath = normalizePath(`${folderPath}/${resolvedFilename}`);
+    let filePath =
+      folderPath === "."
+        ? normalizePath(resolvedFilename)
+        : normalizePath(`${folderPath}/${resolvedFilename}`);
 
     if (!this.findByGranolaId(granolaId, type)) {
       const existingFile = this.app.vault.getAbstractFileByPath(filePath);
@@ -261,6 +268,8 @@ export class FileSyncService {
           return this.pathResolver.computeDailyNoteFolderPath(noteDate);
         case SyncDestination.GRANOLA_FOLDER:
           return normalizePath(settings.granolaFolder);
+        case SyncDestination.VAULT_ROOT:
+          return ".";
         default:
           new Notice(
             `Invalid sync destination for individual files: ${settings.syncDestination}`,

--- a/src/services/pathResolver.ts
+++ b/src/services/pathResolver.ts
@@ -55,17 +55,16 @@ export class PathResolver {
   computeNotePath(title: string, noteDate: Date): string {
     const noteFilename = sanitizeFilename(title) + ".md";
 
-    if (
-      this.settings.syncDestination ===
-      SyncDestination.DAILY_NOTE_FOLDER_STRUCTURE
-    ) {
-      const folderPath = this.computeDailyNoteFolderPath(noteDate);
-      return normalizePath(`${folderPath}/${noteFilename}`);
-    } else {
-      // GRANOLA_FOLDER
-      return normalizePath(
-        `${this.settings.granolaFolder}/${noteFilename}`
-      );
+    switch (this.settings.syncDestination) {
+      case SyncDestination.DAILY_NOTE_FOLDER_STRUCTURE: {
+        const folderPath = this.computeDailyNoteFolderPath(noteDate);
+        return normalizePath(`${folderPath}/${noteFilename}`);
+      }
+      case SyncDestination.VAULT_ROOT:
+        return normalizePath(noteFilename);
+      case SyncDestination.GRANOLA_FOLDER:
+      default:
+        return normalizePath(`${this.settings.granolaFolder}/${noteFilename}`);
     }
   }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,6 +5,7 @@ export enum SyncDestination {
   GRANOLA_FOLDER = "granola_folder",
   DAILY_NOTES = "daily_notes",
   DAILY_NOTE_FOLDER_STRUCTURE = "daily_note_folder_structure",
+  VAULT_ROOT = "vault_root",
 }
 
 export enum TranscriptDestination {
@@ -160,6 +161,7 @@ export class GranolaSyncSettingTab extends PluginSettingTab {
               SyncDestination.DAILY_NOTE_FOLDER_STRUCTURE,
               "Use daily note folder structure"
             )
+            .addOption(SyncDestination.VAULT_ROOT, "Save to vault root")
             .setValue(this.plugin.settings.syncDestination)
             .onChange(async (value) => {
               this.plugin.settings.syncDestination = value as SyncDestination;
@@ -187,6 +189,11 @@ export class GranolaSyncSettingTab extends PluginSettingTab {
         case SyncDestination.DAILY_NOTE_FOLDER_STRUCTURE:
           explanationEl.setText(
             "Notes will be saved as individual files but organized in the same date-based folder structure as your daily notes. Best of both worlds - individual files with chronological organization."
+          );
+          break;
+        case SyncDestination.VAULT_ROOT:
+          explanationEl.setText(
+            "Notes will be saved as individual files directly in the root of your vault. Useful when you prefer to manually organize files or rely on metadata-driven views."
           );
           break;
       }

--- a/tests/unit/fileSyncService.test.ts
+++ b/tests/unit/fileSyncService.test.ts
@@ -233,6 +233,20 @@ describe("FileSyncService", () => {
       expect(result).toBe("granola-folder/note.md");
     });
 
+    it("should resolve path to vault root when configured", () => {
+      mockSettings.syncDestination = SyncDestination.VAULT_ROOT;
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(null);
+
+      const result = fileSyncService.resolveFilePath(
+        "note.md",
+        new Date(),
+        "doc-1",
+        false
+      );
+
+      expect(result).toBe("note.md");
+    });
+
     it("should append date suffix when filename collision exists", () => {
       mockSettings.syncDestination = SyncDestination.GRANOLA_FOLDER;
       const existingFile = new TFile("granola-folder/note.md");
@@ -354,6 +368,37 @@ describe("FileSyncService", () => {
       );
       expect(saveFileSpy).toHaveBeenCalledWith(
         "granola-folder/note.md",
+        "content",
+        "doc-1",
+        "note",
+        false
+      );
+    });
+
+    it("should skip ensureFolder when saving to vault root", async () => {
+      mockSettings.syncDestination = SyncDestination.VAULT_ROOT;
+      const ensureFolderSpy = jest
+        .spyOn(fileSyncService, "ensureFolder")
+        .mockResolvedValue(true);
+      const resolveFilePathSpy = jest
+        .spyOn(fileSyncService, "resolveFilePath")
+        .mockReturnValue("note.md");
+      const saveFileSpy = jest
+        .spyOn(fileSyncService, "saveFile")
+        .mockResolvedValue(true);
+
+      const result = await fileSyncService.saveToDisk(
+        "note.md",
+        "content",
+        new Date(),
+        "doc-1"
+      );
+
+      expect(result).toBe(true);
+      expect(ensureFolderSpy).toHaveBeenCalledWith(".");
+      expect(resolveFilePathSpy).toHaveBeenCalled();
+      expect(saveFileSpy).toHaveBeenCalledWith(
+        "note.md",
         "content",
         "doc-1",
         "note",

--- a/tests/unit/pathResolver.test.ts
+++ b/tests/unit/pathResolver.test.ts
@@ -160,5 +160,19 @@ describe("PathResolver", () => {
 
       expect(result).toBe("granola/Test_File_Name_.md");
     });
+
+    it("should place notes in vault root when configured", () => {
+      pathResolver = new PathResolver({
+        transcriptDestination: TranscriptDestination.GRANOLA_TRANSCRIPTS_FOLDER,
+        granolaTranscriptsFolder: "transcripts",
+        syncDestination: SyncDestination.VAULT_ROOT,
+        granolaFolder: "granola",
+      });
+
+      const noteDate = new Date("2024-05-10");
+      const result = pathResolver.computeNotePath("Root Level Note", noteDate);
+
+      expect(result).toBe("Root Level Note.md");
+    });
   });
 });


### PR DESCRIPTION
## Problem / Need
Users who sync notes as individual files needed a way to drop them directly into the vault root, instead of routing everything through a custom folder or daily-note structure. The plugin’s documentation and tooling also didn’t reflect such a workflow, making it hard to keep the root tidy or mirror personal filing habits.

## Solution
When you select “Save to vault root” under Notes sync destination, every Granola note that syncs as an individual Markdown file is written straight into the top level of your Obsidian vault:

No intermediate folders are created; files appear alongside the rest of your root-level notes.
The usual frontmatter (granola_id, timestamps, transcript links, etc.) is still added, so the plugin keeps tracking each file even after future syncs.

Transcript behavior is unchanged: if transcript syncing is on, the note’s frontmatter points to the transcript file; if transcripts live elsewhere, that link still works.


## PR Best Practices
- Keep the set of changes to the smallest set possible
- Keep changes aligned with the focus of the PR or issue it's resolving
- Split large changes into multiple smaller PRs when appropriate

## Testing
- [x] Tests added/updated
- [x] Manual testing completed
- [x] All tests pass

## Checklist
- [x] Self-review completed (it works on your machine)
- [x] Documentation updated
- [X] No new warnings introduced

