### PR TITLE
Sync transcripts and notes if updated

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -312,6 +312,18 @@ export default class GranolaSync extends Plugin {
       ) {
         continue;
       }
+
+      // Skip processing if note already exists locally and is up-to-date (unless forceOverwrite is true)
+      if (!forceOverwrite) {
+        const existingNote = this.fileSyncService.findByGranolaId(doc.id, "note");
+        if (existingNote) {
+          // Check if remote is newer than local
+          if (!this.fileSyncService.isRemoteNewer(doc.id, doc.updated_at, "note")) {
+            continue;
+          }
+        }
+      }
+
       processedCount++;
       this.updateSyncStatus("Note", processedCount, documents.length);
 
@@ -359,14 +371,16 @@ export default class GranolaSync extends Plugin {
       const docId = doc.id;
       const title = getTitleOrDefault(doc);
       try {
-        // Skip fetching if transcript already exists locally (unless forceOverwrite is true)
+        // Skip fetching if transcript already exists locally and is up-to-date (unless forceOverwrite is true)
         if (!forceOverwrite) {
           const existingTranscript = this.fileSyncService.findByGranolaId(
             docId,
             "transcript"
           );
           if (existingTranscript) {
-            continue;
+            if (!this.fileSyncService.isRemoteNewer(docId, doc.updated_at, "transcript")) {
+              continue;
+            }
           }
         }
 


### PR DESCRIPTION
## Description
This PR implements timestamp-based synchronization for Granola notes and transcripts. Previously, local files were not updated if they already existed, even if the remote Granola recording continued.

Now, local notes and transcripts will be updated if the remote Granola API's `updated_at` timestamp is more recent than the local file's `updated` frontmatter field. This ensures data consistency and improves sync efficiency by only fetching changed content. The `updated_at` from the Granola API is used for both notes and transcripts to determine if an update is needed.

## PR Best Practices
- Keep the set of changes to the smallest set possible
- Keep changes aligned with the focus of the PR or issue it's resolving
- Split large changes into multiple smaller PRs when appropriate

## Testing
- [x] Tests added/updated
- [ ] Manual testing completed
- [x] All tests pass

## Checklist
- [x] Self-review completed (it works on your machine)
- [ ] Documentation updated
- [x] No new warnings introduced

---
<a href="https://cursor.com/background-agent?bcId=bc-7b7c5661-6b89-4ca5-b3c2-b7db6df2b83a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7b7c5661-6b89-4ca5-b3c2-b7db6df2b83a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

Closes https://github.com/tomelliot/obsidian-granola-sync/issues/50
