### PR TITLE
fix: add seconds to filename timestamps to prevent collisions

### DIFF
--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -15,17 +15,18 @@ export function getNoteDate(doc: GranolaDoc): Date {
 
 /**
  * Formats a date as a filename-safe human-readable string.
- * Format: YYYY-MM-DD HH-MM (e.g., "2024-01-15 10-30")
+ * Format: YYYY-MM-DD HH-MM-SS (e.g., "2024-01-15 10-30-45")
  *
  * @param date - The date to format
  * @returns Filename-safe date string
  */
 export function formatDateForFilename(date: Date): string {
   const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  const hours = String(date.getHours()).padStart(2, '0');
-  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  const seconds = String(date.getSeconds()).padStart(2, "0");
 
-  return `${year}-${month}-${day} ${hours}-${minutes}`;
+  return `${year}-${month}-${day} ${hours}-${minutes}-${seconds}`;
 }

--- a/tests/unit/dateUtils.test.ts
+++ b/tests/unit/dateUtils.test.ts
@@ -93,16 +93,16 @@ describe("getNoteDate", () => {
 });
 
 describe("formatDateForFilename", () => {
-  it("should format date with correct pattern YYYY-MM-DD HH-MM", () => {
-    const date = new Date(2024, 0, 15, 10, 30); // Use local time
+  it("should format date with correct pattern YYYY-MM-DD HH-MM-SS", () => {
+    const date = new Date(2024, 0, 15, 10, 30, 45); // Use local time
     const result = formatDateForFilename(date);
-    expect(result).toBe("2024-01-15 10-30");
+    expect(result).toBe("2024-01-15 10-30-45");
   });
 
-  it("should pad single digit months and days with zeros", () => {
-    const date = new Date(2024, 2, 5, 8, 7);
+  it("should pad single digit months, days, hours, minutes, and seconds with zeros", () => {
+    const date = new Date(2024, 2, 5, 8, 7, 3);
     const result = formatDateForFilename(date);
-    expect(result).toBe("2024-03-05 08-07");
+    expect(result).toBe("2024-03-05 08-07-03");
   });
 
   it("should produce filename-safe strings (no colons or slashes)", () => {

--- a/tests/unit/fileSyncService.test.ts
+++ b/tests/unit/fileSyncService.test.ts
@@ -408,7 +408,7 @@ describe("FileSyncService", () => {
       mockApp.vault.getAbstractFileByPath.mockReturnValue(existingFile);
       jest
         .spyOn(dateUtils, "formatDateForFilename")
-        .mockReturnValue("2024-01-01 10-30");
+        .mockReturnValue("2024-01-01 10-30-00");
 
       const noteDate = new Date("2024-01-01T10:30:00Z");
       const result = fileSyncService.resolveFilePath(
@@ -418,7 +418,7 @@ describe("FileSyncService", () => {
         false
       );
 
-      expect(result).toBe("granola-folder/note-2024-01-01_10-30.md");
+      expect(result).toBe("granola-folder/note-2024-01-01_10-30-00.md");
     });
 
     it("should not append date suffix when file exists with same granola_id", async () => {

--- a/tests/unit/filenameUtils.test.ts
+++ b/tests/unit/filenameUtils.test.ts
@@ -82,6 +82,7 @@ describe("getTitleOrDefault", () => {
   it("should return default title with timestamp when title is missing", () => {
     const doc: GranolaDoc = {
       id: "doc-123",
+      title: null,
       created_at: "2024-01-15T10:30:00Z",
     };
 

--- a/tests/unit/filenameUtils.test.ts
+++ b/tests/unit/filenameUtils.test.ts
@@ -87,7 +87,7 @@ describe("getTitleOrDefault", () => {
 
     const result = getTitleOrDefault(doc);
     expect(result).toMatch(
-      /^Untitled Granola Note at \d{4}-\d{2}-\d{2} \d{2}-\d{2}$/
+      /^Untitled Granola Note at \d{4}-\d{2}-\d{2} \d{2}-\d{2}-\d{2}$/
     );
   });
 });


### PR DESCRIPTION
## Filename collision prevention
- Add seconds to timestamp format in filenames to prevent collisions when multiple notes are created within the same minute

## File sync service refactoring
- Extract saveToDisk logic into separate private methods (createNewFile, updateExistingFile, attemptRename) for improved maintainability and testability
- Enhance error logging with additional context including granolaId, type, and file paths
