### PR TITLE
Combined note and transcript file

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -359,8 +359,7 @@ export default class GranolaSync extends Plugin {
       if (isCombinedMode && transcriptDataMap) {
         const transcriptData = transcriptDataMap.get(doc.id || "");
         if (transcriptData && transcriptData.length > 0) {
-          const title = getTitleOrDefault(doc);
-          const transcriptBody = formatTranscriptBody(transcriptData, title);
+          const transcriptBody = formatTranscriptBody(transcriptData);
           if (
             await this.fileSyncService.saveCombinedNoteToDisk(
               doc,

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_SETTINGS,
   GranolaSyncSettingTab,
   SyncDestination,
+  TranscriptDestination,
 } from "./settings";
 import {
   fetchAllGranolaDocuments,
@@ -20,7 +21,10 @@ import {
   loadCredentials as loadGranolaCredentials,
   stopCredentialsServer,
 } from "./services/credentials";
-import { formatTranscriptBySpeaker } from "./services/transcriptFormatter";
+import {
+  formatTranscriptBySpeaker,
+  formatTranscriptBody,
+} from "./services/transcriptFormatter";
 import { PathResolver } from "./services/pathResolver";
 import { FileSyncService } from "./services/fileSyncService";
 import { DocumentProcessor } from "./services/documentProcessor";
@@ -237,11 +241,16 @@ export default class GranolaSync extends Plugin {
 
     // Always sync transcripts first if enabled, so notes can link to them
     const forceOverwrite = mode === "full";
+    let transcriptDataMap: Map<string, TranscriptEntry[]> | null = null;
     if (this.settings.syncTranscripts) {
-      await this.syncTranscripts(documents, accessToken, forceOverwrite);
+      transcriptDataMap = await this.syncTranscripts(
+        documents,
+        accessToken,
+        forceOverwrite
+      );
     }
     if (this.settings.syncNotes) {
-      await this.syncNotes(documents, forceOverwrite);
+      await this.syncNotes(documents, forceOverwrite, transcriptDataMap);
     }
 
     // Show success message
@@ -250,12 +259,17 @@ export default class GranolaSync extends Plugin {
 
   private async syncNotes(
     documents: GranolaDoc[],
-    forceOverwrite: boolean = false
+    forceOverwrite: boolean = false,
+    transcriptDataMap: Map<string, TranscriptEntry[]> | null = null
   ): Promise<void> {
     const syncedCount =
       this.settings.syncDestination === SyncDestination.DAILY_NOTES
         ? await this.syncNotesToDailyNotes(documents, forceOverwrite)
-        : await this.syncNotesToIndividualFiles(documents, forceOverwrite);
+        : await this.syncNotesToIndividualFiles(
+            documents,
+            forceOverwrite,
+            transcriptDataMap
+          );
 
     this.settings.latestSyncTime = Date.now();
     await this.saveSettings();
@@ -298,10 +312,15 @@ export default class GranolaSync extends Plugin {
 
   private async syncNotesToIndividualFiles(
     documents: GranolaDoc[],
-    forceOverwrite: boolean = false
+    forceOverwrite: boolean = false,
+    transcriptDataMap: Map<string, TranscriptEntry[]> | null = null
   ): Promise<number> {
     let processedCount = 0;
     let syncedCount = 0;
+    const isCombinedMode =
+      this.settings.syncTranscripts &&
+      this.settings.transcriptDestination ===
+        TranscriptDestination.COMBINED_WITH_NOTE;
 
     for (const doc of documents) {
       const contentToParse = doc.last_viewed_panel?.content;
@@ -315,10 +334,19 @@ export default class GranolaSync extends Plugin {
 
       // Skip processing if note already exists locally and is up-to-date (unless forceOverwrite is true)
       if (!forceOverwrite) {
-        const existingNote = this.fileSyncService.findByGranolaId(doc.id, "note");
+        const existingNote = this.fileSyncService.findByGranolaId(
+          doc.id,
+          isCombinedMode ? "combined" : "note"
+        );
         if (existingNote) {
           // Check if remote is newer than local
-          if (!this.fileSyncService.isRemoteNewer(doc.id, doc.updated_at, "note")) {
+          if (
+            !this.fileSyncService.isRemoteNewer(
+              doc.id,
+              doc.updated_at,
+              isCombinedMode ? "combined" : "note"
+            )
+          ) {
             continue;
           }
         }
@@ -327,30 +355,66 @@ export default class GranolaSync extends Plugin {
       processedCount++;
       this.updateSyncStatus("Note", processedCount, documents.length);
 
-      // Compute transcript path before preparing note (for frontmatter linking)
-      // Only add transcript link when syncing to individual files (not DAILY_NOTES)
-      let transcriptPath: string | null = null;
-      if (this.settings.syncTranscripts) {
-        const title = getTitleOrDefault(doc);
-        const noteDate = getNoteDate(doc);
-        const transcriptFilename = sanitizeFilename(title) + "-transcript.md";
-        transcriptPath = this.fileSyncService.resolveFilePath(
-          transcriptFilename,
-          noteDate,
-          doc.id,
-          true
-        );
-      }
+      // Handle combined mode: save note and transcript together
+      if (isCombinedMode && transcriptDataMap) {
+        const transcriptData = transcriptDataMap.get(doc.id || "");
+        if (transcriptData && transcriptData.length > 0) {
+          const title = getTitleOrDefault(doc);
+          const transcriptBody = formatTranscriptBody(transcriptData, title);
+          if (
+            await this.fileSyncService.saveCombinedNoteToDisk(
+              doc,
+              this.documentProcessor,
+              transcriptBody,
+              forceOverwrite
+            )
+          ) {
+            syncedCount++;
+          }
+        } else {
+          // No transcript available, save as regular note
+          if (
+            await this.fileSyncService.saveNoteToDisk(
+              doc,
+              this.documentProcessor,
+              forceOverwrite
+            )
+          ) {
+            syncedCount++;
+          }
+        }
+      } else {
+        // Regular mode: save note separately (with optional transcript link)
+        // Compute transcript path before preparing note (for frontmatter linking)
+        // Only add transcript link when syncing to individual files (not DAILY_NOTES)
+        // and not in combined mode
+        let transcriptPath: string | null = null;
+        if (
+          this.settings.syncTranscripts &&
+          this.settings.transcriptDestination !==
+            TranscriptDestination.COMBINED_WITH_NOTE
+        ) {
+          const title = getTitleOrDefault(doc);
+          const noteDate = getNoteDate(doc);
+          const transcriptFilename = sanitizeFilename(title) + "-transcript.md";
+          transcriptPath = this.fileSyncService.resolveFilePath(
+            transcriptFilename,
+            noteDate,
+            doc.id,
+            true
+          );
+        }
 
-      if (
-        await this.fileSyncService.saveNoteToDisk(
-          doc,
-          this.documentProcessor,
-          forceOverwrite,
-          transcriptPath ?? undefined
-        )
-      ) {
-        syncedCount++;
+        if (
+          await this.fileSyncService.saveNoteToDisk(
+            doc,
+            this.documentProcessor,
+            forceOverwrite,
+            transcriptPath ?? undefined
+          )
+        ) {
+          syncedCount++;
+        }
       }
     }
 
@@ -364,21 +428,34 @@ export default class GranolaSync extends Plugin {
     documents: GranolaDoc[],
     accessToken: string,
     forceOverwrite: boolean = false
-  ): Promise<void> {
+  ): Promise<Map<string, TranscriptEntry[]>> {
+    const transcriptDataMap = new Map<string, TranscriptEntry[]>();
+    const isCombinedMode =
+      this.settings.transcriptDestination ===
+      TranscriptDestination.COMBINED_WITH_NOTE;
+
     let processedCount = 0;
     let syncedCount = 0;
+
     for (const doc of documents) {
       const docId = doc.id;
       const title = getTitleOrDefault(doc);
       try {
         // Skip fetching if transcript already exists locally and is up-to-date (unless forceOverwrite is true)
+        // In combined mode, check for combined files instead of transcript files
         if (!forceOverwrite) {
           const existingTranscript = this.fileSyncService.findByGranolaId(
             docId,
-            "transcript"
+            isCombinedMode ? "combined" : "transcript"
           );
           if (existingTranscript) {
-            if (!this.fileSyncService.isRemoteNewer(docId, doc.updated_at, "transcript")) {
+            if (
+              !this.fileSyncService.isRemoteNewer(
+                docId,
+                doc.updated_at,
+                isCombinedMode ? "combined" : "transcript"
+              )
+            ) {
               continue;
             }
           }
@@ -389,6 +466,18 @@ export default class GranolaSync extends Plugin {
           docId
         );
         if (transcriptData.length === 0) {
+          continue;
+        }
+
+        // Store transcript data for use in combined mode
+        if (docId) {
+          transcriptDataMap.set(docId, transcriptData);
+        }
+
+        // In combined mode, skip saving separate transcript files
+        if (isCombinedMode) {
+          processedCount++;
+          this.updateSyncStatus("Transcript", processedCount, documents.length);
           continue;
         }
 
@@ -453,5 +542,6 @@ export default class GranolaSync extends Plugin {
     log.debug(
       `syncTranscripts - Completed: ${syncedCount} saved out of ${processedCount} processed`
     );
+    return transcriptDataMap;
   }
 }

--- a/src/services/documentProcessor.ts
+++ b/src/services/documentProcessor.ts
@@ -147,12 +147,12 @@ export class DocumentProcessor {
     let finalMarkdown = frontmatterLines.join("\n");
 
     // Add note content with heading
-    finalMarkdown += "## Note\n\n";
+    finalMarkdown += "# Note\n\n";
     finalMarkdown += markdownContent;
     finalMarkdown += "\n\n";
 
     // Add transcript content at the end with heading
-    finalMarkdown += "## Transcript\n\n";
+    finalMarkdown += "# Transcript\n\n";
     finalMarkdown += transcriptContent;
 
     const filename = sanitizeFilename(title) + ".md";

--- a/src/services/documentProcessor.ts
+++ b/src/services/documentProcessor.ts
@@ -3,7 +3,6 @@ import { convertProsemirrorToMarkdown } from "./prosemirrorMarkdown";
 import { sanitizeFilename, getTitleOrDefault } from "../utils/filenameUtils";
 import { PathResolver } from "./pathResolver";
 import { TranscriptSettings } from "../settings";
-import { formatTranscriptBody } from "./transcriptFormatter";
 
 /**
  * Service for processing Granola documents into Obsidian-ready markdown.

--- a/src/services/transcriptFormatter.ts
+++ b/src/services/transcriptFormatter.ts
@@ -5,12 +5,10 @@ import { TranscriptEntry } from "./granolaApi";
  * Returns only the transcript markdown content without frontmatter.
  *
  * @param transcriptData - Array of transcript entries from Granola API
- * @param title - Title of the note/transcript
  * @returns Formatted markdown string with speaker-grouped content (no frontmatter)
  */
 export function formatTranscriptBody(
-  transcriptData: TranscriptEntry[],
-  title: string
+  transcriptData: TranscriptEntry[]
 ): string {
   let transcriptMd = "";
   let currentSpeaker: string | null = null;
@@ -73,7 +71,7 @@ export function formatTranscriptBySpeaker(
   includeFrontmatter: boolean = true
 ): string {
   // Get the transcript body content
-  const transcriptBody = formatTranscriptBody(transcriptData, title);
+  const transcriptBody = formatTranscriptBody(transcriptData);
 
   // If frontmatter is not needed, return just the body
   if (!includeFrontmatter) {

--- a/src/services/transcriptFormatter.ts
+++ b/src/services/transcriptFormatter.ts
@@ -1,58 +1,18 @@
 import { TranscriptEntry } from "./granolaApi";
 
 /**
- * Formats transcript data into markdown, grouped by speaker.
+ * Formats transcript body content into markdown, grouped by speaker.
+ * Returns only the transcript markdown content without frontmatter.
  *
  * @param transcriptData - Array of transcript entries from Granola API
  * @param title - Title of the note/transcript
- * @param granolaId - Granola document ID
- * @param createdAt - Optional creation timestamp
- * @param updatedAt - Optional update timestamp
- * @param attendees - Optional array of attendee names
- * @param notePath - Optional resolved note path (with collision detection) to include in frontmatter
- * @returns Formatted markdown string with frontmatter and speaker-grouped content
+ * @returns Formatted markdown string with speaker-grouped content (no frontmatter)
  */
-export function formatTranscriptBySpeaker(
+export function formatTranscriptBody(
   transcriptData: TranscriptEntry[],
-  title: string,
-  granolaId: string,
-  createdAt?: string,
-  updatedAt?: string,
-  attendees?: string[],
-  notePath?: string
+  title: string
 ): string {
-  // Add frontmatter with granola_id for transcript deduplication
-  const escapedTitleForYaml = title.replace(/"/g, '\\"');
-  const frontmatterLines = [
-    "---",
-    `granola_id: ${granolaId}`,
-    `title: "${escapedTitleForYaml} - Transcript"`,
-    `type: transcript`,
-  ];
-  if (createdAt) frontmatterLines.push(`created: ${createdAt}`);
-  if (updatedAt) frontmatterLines.push(`updated: ${updatedAt}`);
-  const attendeesArray = attendees || [];
-  if (attendeesArray.length > 0) {
-    const attendeesYaml = attendeesArray
-      .map((name) => `  - ${name}`)
-      .join("\n");
-    frontmatterLines.push(`attendees:\n${attendeesYaml}`);
-  } else {
-    frontmatterLines.push(`attendees: []`);
-  }
-
-  // Add note link to frontmatter if path provided
-  // Path is only provided when notes are synced to individual files (not DAILY_NOTES)
-  if (notePath) {
-    // Use wiki-style links in frontmatter
-    frontmatterLines.push(`note: "[[${notePath}]]"`);
-  }
-
-  frontmatterLines.push("---", "");
-
-  let transcriptMd = frontmatterLines.join("\n") + "\n";
-
-  transcriptMd += `# Transcript for: ${title}\n\n`;
+  let transcriptMd = "";
   let currentSpeaker: string | null = null;
   let currentStart: string | null = null;
   let currentText: string[] = [];
@@ -87,4 +47,67 @@ export function formatTranscriptBySpeaker(
   }
 
   return transcriptMd;
+}
+
+/**
+ * Formats transcript data into markdown, grouped by speaker.
+ *
+ * @param transcriptData - Array of transcript entries from Granola API
+ * @param title - Title of the note/transcript
+ * @param granolaId - Granola document ID
+ * @param createdAt - Optional creation timestamp
+ * @param updatedAt - Optional update timestamp
+ * @param attendees - Optional array of attendee names
+ * @param notePath - Optional resolved note path (with collision detection) to include in frontmatter
+ * @param includeFrontmatter - Whether to include frontmatter (default: true)
+ * @returns Formatted markdown string with optional frontmatter and speaker-grouped content
+ */
+export function formatTranscriptBySpeaker(
+  transcriptData: TranscriptEntry[],
+  title: string,
+  granolaId: string,
+  createdAt?: string,
+  updatedAt?: string,
+  attendees?: string[],
+  notePath?: string,
+  includeFrontmatter: boolean = true
+): string {
+  // Get the transcript body content
+  const transcriptBody = formatTranscriptBody(transcriptData, title);
+
+  // If frontmatter is not needed, return just the body
+  if (!includeFrontmatter) {
+    return transcriptBody;
+  }
+
+  // Add frontmatter with granola_id for transcript deduplication
+  const escapedTitleForYaml = title.replace(/"/g, '\\"');
+  const frontmatterLines = [
+    "---",
+    `granola_id: ${granolaId}`,
+    `title: "${escapedTitleForYaml} - Transcript"`,
+    `type: transcript`,
+  ];
+  if (createdAt) frontmatterLines.push(`created: ${createdAt}`);
+  if (updatedAt) frontmatterLines.push(`updated: ${updatedAt}`);
+  const attendeesArray = attendees || [];
+  if (attendeesArray.length > 0) {
+    const attendeesYaml = attendeesArray
+      .map((name) => `  - ${name}`)
+      .join("\n");
+    frontmatterLines.push(`attendees:\n${attendeesYaml}`);
+  } else {
+    frontmatterLines.push(`attendees: []`);
+  }
+
+  // Add note link to frontmatter if path provided
+  // Path is only provided when notes are synced to individual files (not DAILY_NOTES)
+  if (notePath) {
+    // Use wiki-style links in frontmatter
+    frontmatterLines.push(`note: "[[${notePath}]]"`);
+  }
+
+  frontmatterLines.push("---", "");
+
+  return frontmatterLines.join("\n") + "\n" + `# Transcript for: ${title}\n\n` + transcriptBody;
 }

--- a/tests/unit/documentProcessor.test.ts
+++ b/tests/unit/documentProcessor.test.ts
@@ -420,9 +420,9 @@ describe("DocumentProcessor", () => {
       expect(result.content).toContain("type: combined");
       expect(result.content).toContain("created: 2024-01-15T10:00:00Z");
       expect(result.content).toContain("updated: 2024-01-15T12:00:00Z");
-      expect(result.content).toContain("## Note\n\n");
+      expect(result.content).toContain("# Note\n\n");
       expect(result.content).toContain("# Mock Content");
-      expect(result.content).toContain("## Transcript\n\n");
+      expect(result.content).toContain("# Transcript\n\n");
       expect(result.content).toContain("## You (00:00:01)");
       expect(result.content).toContain("Hello world.");
       expect(result.content).toContain("## Guest (00:00:05)");
@@ -560,8 +560,8 @@ describe("DocumentProcessor", () => {
 
       const result = documentProcessor.prepareCombinedNote(doc, transcriptContent);
 
-      const noteIndex = result.content.indexOf("## Note");
-      const transcriptIndex = result.content.indexOf("## Transcript");
+      const noteIndex = result.content.indexOf("# Note");
+      const transcriptIndex = result.content.indexOf("# Transcript");
       const noteContentIndex = result.content.indexOf("# Mock Content");
       const transcriptContentIndex = result.content.indexOf("Transcript text");
 


### PR DESCRIPTION
## Description
This PR introduces a new option to save Granola notes and their corresponding transcripts into a single combined Markdown file.

When the "Save with note in same file" option is selected for transcript syncing:
- Notes and transcripts are saved in the same file, with the transcript content appended at the end of the note.
- The file uses `## Note` and `## Transcript` headings to separate content.
- Frontmatter includes `type: combined` and standard fields, but omits `note` and `transcript` link fields.
- This option is only available when both note and transcript syncing are enabled, and only applies to individual file destinations (not daily notes).
- The settings UI dynamically shows/hides this option and related transcript folder settings based on the selected mode.
- Sync logic has been updated to fetch transcripts and pass them to the note sync process when in combined mode, skipping the creation of separate transcript files.
- Cache and file management services now support the new `combined` file type.

This feature aims to provide users with a more integrated way to store their Granola content, keeping all relevant information for a document within a single Obsidian file.

## PR Best Practices
- Keep the set of changes to the smallest set possible
- Keep changes aligned with the focus of the PR or issue it's resolving
- Split large changes into multiple smaller PRs when appropriate

## Testing
- [ ] Tests added/updated
- [ ] Manual testing completed
- [ ] All tests pass

## Checklist
- [ ] Self-review completed (it works on your machine)
- [ ] Documentation updated
- [ ] No new warnings introduced

---
<a href="https://cursor.com/background-agent?bcId=bc-881a40a8-8bc5-40f0-8a8c-fccc6a3be8f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-881a40a8-8bc5-40f0-8a8c-fccc6a3be8f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

