### PR TITLE
feat: Add combined note and transcript file option

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -359,8 +359,7 @@ export default class GranolaSync extends Plugin {
       if (isCombinedMode && transcriptDataMap) {
         const transcriptData = transcriptDataMap.get(doc.id || "");
         if (transcriptData && transcriptData.length > 0) {
-          const title = getTitleOrDefault(doc);
-          const transcriptBody = formatTranscriptBody(transcriptData, title);
+          const transcriptBody = formatTranscriptBody(transcriptData);
           if (
             await this.fileSyncService.saveCombinedNoteToDisk(
               doc,

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_SETTINGS,
   GranolaSyncSettingTab,
   SyncDestination,
+  TranscriptDestination,
 } from "./settings";
 import {
   fetchAllGranolaDocuments,
@@ -20,7 +21,10 @@ import {
   loadCredentials as loadGranolaCredentials,
   stopCredentialsServer,
 } from "./services/credentials";
-import { formatTranscriptBySpeaker } from "./services/transcriptFormatter";
+import {
+  formatTranscriptBySpeaker,
+  formatTranscriptBody,
+} from "./services/transcriptFormatter";
 import { PathResolver } from "./services/pathResolver";
 import { FileSyncService } from "./services/fileSyncService";
 import { DocumentProcessor } from "./services/documentProcessor";
@@ -237,11 +241,16 @@ export default class GranolaSync extends Plugin {
 
     // Always sync transcripts first if enabled, so notes can link to them
     const forceOverwrite = mode === "full";
+    let transcriptDataMap: Map<string, TranscriptEntry[]> | null = null;
     if (this.settings.syncTranscripts) {
-      await this.syncTranscripts(documents, accessToken, forceOverwrite);
+      transcriptDataMap = await this.syncTranscripts(
+        documents,
+        accessToken,
+        forceOverwrite
+      );
     }
     if (this.settings.syncNotes) {
-      await this.syncNotes(documents, forceOverwrite);
+      await this.syncNotes(documents, forceOverwrite, transcriptDataMap);
     }
 
     // Show success message
@@ -250,12 +259,17 @@ export default class GranolaSync extends Plugin {
 
   private async syncNotes(
     documents: GranolaDoc[],
-    forceOverwrite: boolean = false
+    forceOverwrite: boolean = false,
+    transcriptDataMap: Map<string, TranscriptEntry[]> | null = null
   ): Promise<void> {
     const syncedCount =
       this.settings.syncDestination === SyncDestination.DAILY_NOTES
         ? await this.syncNotesToDailyNotes(documents, forceOverwrite)
-        : await this.syncNotesToIndividualFiles(documents, forceOverwrite);
+        : await this.syncNotesToIndividualFiles(
+            documents,
+            forceOverwrite,
+            transcriptDataMap
+          );
 
     this.settings.latestSyncTime = Date.now();
     await this.saveSettings();
@@ -298,10 +312,15 @@ export default class GranolaSync extends Plugin {
 
   private async syncNotesToIndividualFiles(
     documents: GranolaDoc[],
-    forceOverwrite: boolean = false
+    forceOverwrite: boolean = false,
+    transcriptDataMap: Map<string, TranscriptEntry[]> | null = null
   ): Promise<number> {
     let processedCount = 0;
     let syncedCount = 0;
+    const isCombinedMode =
+      this.settings.syncTranscripts &&
+      this.settings.transcriptDestination ===
+        TranscriptDestination.COMBINED_WITH_NOTE;
 
     for (const doc of documents) {
       const contentToParse = doc.last_viewed_panel?.content;
@@ -315,10 +334,19 @@ export default class GranolaSync extends Plugin {
 
       // Skip processing if note already exists locally and is up-to-date (unless forceOverwrite is true)
       if (!forceOverwrite) {
-        const existingNote = this.fileSyncService.findByGranolaId(doc.id, "note");
+        const existingNote = this.fileSyncService.findByGranolaId(
+          doc.id,
+          isCombinedMode ? "combined" : "note"
+        );
         if (existingNote) {
           // Check if remote is newer than local
-          if (!this.fileSyncService.isRemoteNewer(doc.id, doc.updated_at, "note")) {
+          if (
+            !this.fileSyncService.isRemoteNewer(
+              doc.id,
+              doc.updated_at,
+              isCombinedMode ? "combined" : "note"
+            )
+          ) {
             continue;
           }
         }
@@ -327,30 +355,66 @@ export default class GranolaSync extends Plugin {
       processedCount++;
       this.updateSyncStatus("Note", processedCount, documents.length);
 
-      // Compute transcript path before preparing note (for frontmatter linking)
-      // Only add transcript link when syncing to individual files (not DAILY_NOTES)
-      let transcriptPath: string | null = null;
-      if (this.settings.syncTranscripts) {
-        const title = getTitleOrDefault(doc);
-        const noteDate = getNoteDate(doc);
-        const transcriptFilename = sanitizeFilename(title) + "-transcript.md";
-        transcriptPath = this.fileSyncService.resolveFilePath(
-          transcriptFilename,
-          noteDate,
-          doc.id,
-          true
-        );
-      }
+      // Handle combined mode: save note and transcript together
+      if (isCombinedMode && transcriptDataMap) {
+        const transcriptData = transcriptDataMap.get(doc.id || "");
+        if (transcriptData && transcriptData.length > 0) {
+          const title = getTitleOrDefault(doc);
+          const transcriptBody = formatTranscriptBody(transcriptData, title);
+          if (
+            await this.fileSyncService.saveCombinedNoteToDisk(
+              doc,
+              this.documentProcessor,
+              transcriptBody,
+              forceOverwrite
+            )
+          ) {
+            syncedCount++;
+          }
+        } else {
+          // No transcript available, save as regular note
+          if (
+            await this.fileSyncService.saveNoteToDisk(
+              doc,
+              this.documentProcessor,
+              forceOverwrite
+            )
+          ) {
+            syncedCount++;
+          }
+        }
+      } else {
+        // Regular mode: save note separately (with optional transcript link)
+        // Compute transcript path before preparing note (for frontmatter linking)
+        // Only add transcript link when syncing to individual files (not DAILY_NOTES)
+        // and not in combined mode
+        let transcriptPath: string | null = null;
+        if (
+          this.settings.syncTranscripts &&
+          this.settings.transcriptDestination !==
+            TranscriptDestination.COMBINED_WITH_NOTE
+        ) {
+          const title = getTitleOrDefault(doc);
+          const noteDate = getNoteDate(doc);
+          const transcriptFilename = sanitizeFilename(title) + "-transcript.md";
+          transcriptPath = this.fileSyncService.resolveFilePath(
+            transcriptFilename,
+            noteDate,
+            doc.id,
+            true
+          );
+        }
 
-      if (
-        await this.fileSyncService.saveNoteToDisk(
-          doc,
-          this.documentProcessor,
-          forceOverwrite,
-          transcriptPath ?? undefined
-        )
-      ) {
-        syncedCount++;
+        if (
+          await this.fileSyncService.saveNoteToDisk(
+            doc,
+            this.documentProcessor,
+            forceOverwrite,
+            transcriptPath ?? undefined
+          )
+        ) {
+          syncedCount++;
+        }
       }
     }
 
@@ -364,21 +428,34 @@ export default class GranolaSync extends Plugin {
     documents: GranolaDoc[],
     accessToken: string,
     forceOverwrite: boolean = false
-  ): Promise<void> {
+  ): Promise<Map<string, TranscriptEntry[]>> {
+    const transcriptDataMap = new Map<string, TranscriptEntry[]>();
+    const isCombinedMode =
+      this.settings.transcriptDestination ===
+      TranscriptDestination.COMBINED_WITH_NOTE;
+
     let processedCount = 0;
     let syncedCount = 0;
+
     for (const doc of documents) {
       const docId = doc.id;
       const title = getTitleOrDefault(doc);
       try {
         // Skip fetching if transcript already exists locally and is up-to-date (unless forceOverwrite is true)
+        // In combined mode, check for combined files instead of transcript files
         if (!forceOverwrite) {
           const existingTranscript = this.fileSyncService.findByGranolaId(
             docId,
-            "transcript"
+            isCombinedMode ? "combined" : "transcript"
           );
           if (existingTranscript) {
-            if (!this.fileSyncService.isRemoteNewer(docId, doc.updated_at, "transcript")) {
+            if (
+              !this.fileSyncService.isRemoteNewer(
+                docId,
+                doc.updated_at,
+                isCombinedMode ? "combined" : "transcript"
+              )
+            ) {
               continue;
             }
           }
@@ -389,6 +466,18 @@ export default class GranolaSync extends Plugin {
           docId
         );
         if (transcriptData.length === 0) {
+          continue;
+        }
+
+        // Store transcript data for use in combined mode
+        if (docId) {
+          transcriptDataMap.set(docId, transcriptData);
+        }
+
+        // In combined mode, skip saving separate transcript files
+        if (isCombinedMode) {
+          processedCount++;
+          this.updateSyncStatus("Transcript", processedCount, documents.length);
           continue;
         }
 
@@ -453,5 +542,6 @@ export default class GranolaSync extends Plugin {
     log.debug(
       `syncTranscripts - Completed: ${syncedCount} saved out of ${processedCount} processed`
     );
+    return transcriptDataMap;
   }
 }

--- a/src/services/documentProcessor.ts
+++ b/src/services/documentProcessor.ts
@@ -3,7 +3,6 @@ import { convertProsemirrorToMarkdown } from "./prosemirrorMarkdown";
 import { sanitizeFilename, getTitleOrDefault } from "../utils/filenameUtils";
 import { PathResolver } from "./pathResolver";
 import { TranscriptSettings } from "../settings";
-import { formatTranscriptBody } from "./transcriptFormatter";
 
 /**
  * Service for processing Granola documents into Obsidian-ready markdown.

--- a/src/services/transcriptFormatter.ts
+++ b/src/services/transcriptFormatter.ts
@@ -5,12 +5,10 @@ import { TranscriptEntry } from "./granolaApi";
  * Returns only the transcript markdown content without frontmatter.
  *
  * @param transcriptData - Array of transcript entries from Granola API
- * @param title - Title of the note/transcript
  * @returns Formatted markdown string with speaker-grouped content (no frontmatter)
  */
 export function formatTranscriptBody(
-  transcriptData: TranscriptEntry[],
-  title: string
+  transcriptData: TranscriptEntry[]
 ): string {
   let transcriptMd = "";
   let currentSpeaker: string | null = null;
@@ -73,7 +71,7 @@ export function formatTranscriptBySpeaker(
   includeFrontmatter: boolean = true
 ): string {
   // Get the transcript body content
-  const transcriptBody = formatTranscriptBody(transcriptData, title);
+  const transcriptBody = formatTranscriptBody(transcriptData);
 
   // If frontmatter is not needed, return just the body
   if (!includeFrontmatter) {

--- a/src/services/transcriptFormatter.ts
+++ b/src/services/transcriptFormatter.ts
@@ -1,58 +1,18 @@
 import { TranscriptEntry } from "./granolaApi";
 
 /**
- * Formats transcript data into markdown, grouped by speaker.
+ * Formats transcript body content into markdown, grouped by speaker.
+ * Returns only the transcript markdown content without frontmatter.
  *
  * @param transcriptData - Array of transcript entries from Granola API
  * @param title - Title of the note/transcript
- * @param granolaId - Granola document ID
- * @param createdAt - Optional creation timestamp
- * @param updatedAt - Optional update timestamp
- * @param attendees - Optional array of attendee names
- * @param notePath - Optional resolved note path (with collision detection) to include in frontmatter
- * @returns Formatted markdown string with frontmatter and speaker-grouped content
+ * @returns Formatted markdown string with speaker-grouped content (no frontmatter)
  */
-export function formatTranscriptBySpeaker(
+export function formatTranscriptBody(
   transcriptData: TranscriptEntry[],
-  title: string,
-  granolaId: string,
-  createdAt?: string,
-  updatedAt?: string,
-  attendees?: string[],
-  notePath?: string
+  title: string
 ): string {
-  // Add frontmatter with granola_id for transcript deduplication
-  const escapedTitleForYaml = title.replace(/"/g, '\\"');
-  const frontmatterLines = [
-    "---",
-    `granola_id: ${granolaId}`,
-    `title: "${escapedTitleForYaml} - Transcript"`,
-    `type: transcript`,
-  ];
-  if (createdAt) frontmatterLines.push(`created: ${createdAt}`);
-  if (updatedAt) frontmatterLines.push(`updated: ${updatedAt}`);
-  const attendeesArray = attendees || [];
-  if (attendeesArray.length > 0) {
-    const attendeesYaml = attendeesArray
-      .map((name) => `  - ${name}`)
-      .join("\n");
-    frontmatterLines.push(`attendees:\n${attendeesYaml}`);
-  } else {
-    frontmatterLines.push(`attendees: []`);
-  }
-
-  // Add note link to frontmatter if path provided
-  // Path is only provided when notes are synced to individual files (not DAILY_NOTES)
-  if (notePath) {
-    // Use wiki-style links in frontmatter
-    frontmatterLines.push(`note: "[[${notePath}]]"`);
-  }
-
-  frontmatterLines.push("---", "");
-
-  let transcriptMd = frontmatterLines.join("\n") + "\n";
-
-  transcriptMd += `# Transcript for: ${title}\n\n`;
+  let transcriptMd = "";
   let currentSpeaker: string | null = null;
   let currentStart: string | null = null;
   let currentText: string[] = [];
@@ -87,4 +47,67 @@ export function formatTranscriptBySpeaker(
   }
 
   return transcriptMd;
+}
+
+/**
+ * Formats transcript data into markdown, grouped by speaker.
+ *
+ * @param transcriptData - Array of transcript entries from Granola API
+ * @param title - Title of the note/transcript
+ * @param granolaId - Granola document ID
+ * @param createdAt - Optional creation timestamp
+ * @param updatedAt - Optional update timestamp
+ * @param attendees - Optional array of attendee names
+ * @param notePath - Optional resolved note path (with collision detection) to include in frontmatter
+ * @param includeFrontmatter - Whether to include frontmatter (default: true)
+ * @returns Formatted markdown string with optional frontmatter and speaker-grouped content
+ */
+export function formatTranscriptBySpeaker(
+  transcriptData: TranscriptEntry[],
+  title: string,
+  granolaId: string,
+  createdAt?: string,
+  updatedAt?: string,
+  attendees?: string[],
+  notePath?: string,
+  includeFrontmatter: boolean = true
+): string {
+  // Get the transcript body content
+  const transcriptBody = formatTranscriptBody(transcriptData, title);
+
+  // If frontmatter is not needed, return just the body
+  if (!includeFrontmatter) {
+    return transcriptBody;
+  }
+
+  // Add frontmatter with granola_id for transcript deduplication
+  const escapedTitleForYaml = title.replace(/"/g, '\\"');
+  const frontmatterLines = [
+    "---",
+    `granola_id: ${granolaId}`,
+    `title: "${escapedTitleForYaml} - Transcript"`,
+    `type: transcript`,
+  ];
+  if (createdAt) frontmatterLines.push(`created: ${createdAt}`);
+  if (updatedAt) frontmatterLines.push(`updated: ${updatedAt}`);
+  const attendeesArray = attendees || [];
+  if (attendeesArray.length > 0) {
+    const attendeesYaml = attendeesArray
+      .map((name) => `  - ${name}`)
+      .join("\n");
+    frontmatterLines.push(`attendees:\n${attendeesYaml}`);
+  } else {
+    frontmatterLines.push(`attendees: []`);
+  }
+
+  // Add note link to frontmatter if path provided
+  // Path is only provided when notes are synced to individual files (not DAILY_NOTES)
+  if (notePath) {
+    // Use wiki-style links in frontmatter
+    frontmatterLines.push(`note: "[[${notePath}]]"`);
+  }
+
+  frontmatterLines.push("---", "");
+
+  return frontmatterLines.join("\n") + "\n" + `# Transcript for: ${title}\n\n` + transcriptBody;
 }

--- a/src/services/transcriptFormatter.ts
+++ b/src/services/transcriptFormatter.ts
@@ -20,7 +20,6 @@ export function formatTranscriptBody(
   for (let i = 0; i < transcriptData.length; i++) {
     const entry = transcriptData[i];
     const speaker = getSpeaker(entry.source);
-
     if (currentSpeaker === null) {
       currentSpeaker = speaker;
       currentStart = entry.start_timestamp;
@@ -29,7 +28,11 @@ export function formatTranscriptBody(
       currentText.push(entry.text);
     } else {
       // Write previous block
-      transcriptMd += `## ${currentSpeaker} (${currentStart})\n\n`;
+      // We use level three headings (###) because it matches the
+      // headings that granola uses for notes. That allows us to
+      // use consistent parent headings for notes and transcripts
+      // (level two headigns: ##).
+      transcriptMd += `### ${currentSpeaker} (${currentStart})\n\n`;
       transcriptMd += currentText.join(" ") + "\n\n";
       // Start new block
       currentSpeaker = speaker;
@@ -40,7 +43,7 @@ export function formatTranscriptBody(
 
   // Write last block
   if (currentSpeaker !== null) {
-    transcriptMd += `## ${currentSpeaker} (${currentStart})\n\n`;
+    transcriptMd += `### ${currentSpeaker} (${currentStart})\n\n`;
     transcriptMd += currentText.join(" ") + "\n\n";
   }
 
@@ -107,5 +110,11 @@ export function formatTranscriptBySpeaker(
 
   frontmatterLines.push("---", "");
 
-  return frontmatterLines.join("\n") + "\n" + `# Transcript for: ${title}\n\n` + transcriptBody;
+  const noteContent =
+    frontmatterLines.join("\n") +
+    "\n" +
+    `# Transcript for: ${title}\n\n` +
+    transcriptBody;
+
+  return noteContent;
 }

--- a/tests/unit/transcriptFormatter.test.ts
+++ b/tests/unit/transcriptFormatter.test.ts
@@ -619,4 +619,36 @@ describe("formatTranscriptBody", () => {
 
     expect(result).toContain("## You (01:23:45)");
   });
+
+  it("should use level 3 headings (###) for speaker headings", () => {
+    const transcriptData: TranscriptEntry[] = [
+      {
+        document_id: "doc1",
+        start_timestamp: "00:00:01",
+        end_timestamp: "00:00:05",
+        text: "Hello, how are you?",
+        source: "microphone",
+        id: "entry1",
+        is_final: true,
+      },
+      {
+        document_id: "doc1",
+        start_timestamp: "00:00:06",
+        end_timestamp: "00:00:10",
+        text: "I'm doing great, thanks!",
+        source: "speaker",
+        id: "entry2",
+        is_final: true,
+      },
+    ];
+
+    const result = formatTranscriptBody(transcriptData);
+
+    // Verify headings start with exactly three hashes at the beginning of a line
+    expect(result).toMatch(/^### You \(00:00:01\)/m);
+    expect(result).toMatch(/^### Guest \(00:00:06\)/m);
+    // Ensure no level 2 headings exist (pattern that starts with exactly two hashes)
+    expect(result).not.toMatch(/^## You \(/m);
+    expect(result).not.toMatch(/^## Guest \(/m);
+  });
 });


### PR DESCRIPTION
## Combined note and transcript file support
- Adds new transcript destination option to save notes and transcripts together in a single file
- Combined files include both note and transcript content with separate "## Note" and "## Transcript" sections
- Uses `type: combined` in frontmatter to distinguish from separate note/transcript files
- Only available when both notes and transcripts sync are enabled

## Transcript formatting refactoring
- Extracts `formatTranscriptBody` function to format transcript content without frontmatter
- Updates `formatTranscriptBySpeaker` to support optional frontmatter via `includeFrontmatter` parameter
- Changes transcript speaker headings from level 2 (##) to level 3 (###) to match note heading hierarchy

## File sync service
- Extends file type support from `"note" | "transcript"` to `"note" | "transcript" | "combined"` throughout cache and lookup methods
- Adds `saveCombinedNoteToDisk` method to handle saving combined files
- Updates sync logic to pass transcript data between sync operations for combined mode
- Combined files use note folder path structure, not transcript folder

## Settings UI
- Adds "Save with note in same file" option to transcript destination dropdown
- Option only appears when both notes and transcripts are enabled
- Adds explanatory text for combined mode behavior
