### PR TITLE
fix: Escape special characters in attendee names for YAML front matter

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -281,6 +281,15 @@ export default class GranolaSync extends Plugin {
     documents: GranolaDoc[],
     forceOverwrite: boolean = false
   ): Promise<number> {
+    // Extract attendees from people.attendees for all documents before processing
+    for (const doc of documents) {
+      if (doc.people?.attendees && doc.people.attendees.length > 0) {
+        doc.attendees = doc.people.attendees
+          .map((attendee) => attendee.name || attendee.email || "Unknown")
+          .filter((name) => name !== "Unknown");
+      }
+    }
+    
     const dailyNotesMap = this.dailyNoteBuilder.buildDailyNotesMap(documents);
     const sectionHeadingSetting = this.settings.dailyNoteSectionHeading.trim();
     let processedCount = 0;
@@ -315,6 +324,15 @@ export default class GranolaSync extends Plugin {
     forceOverwrite: boolean = false,
     transcriptDataMap: Map<string, TranscriptEntry[]> | null = null
   ): Promise<number> {
+    // Extract attendees from people.attendees for all documents before processing
+    for (const doc of documents) {
+      if (doc.people?.attendees && doc.people.attendees.length > 0) {
+        doc.attendees = doc.people.attendees
+          .map((attendee) => attendee.name || attendee.email || "Unknown")
+          .filter((name) => name !== "Unknown");
+      }
+    }
+    
     let processedCount = 0;
     let syncedCount = 0;
     const isCombinedMode =

--- a/src/main.ts
+++ b/src/main.ts
@@ -281,14 +281,7 @@ export default class GranolaSync extends Plugin {
     documents: GranolaDoc[],
     forceOverwrite: boolean = false
   ): Promise<number> {
-    // Extract attendees from people.attendees for all documents before processing
-    for (const doc of documents) {
-      if (doc.people?.attendees && doc.people.attendees.length > 0) {
-        doc.attendees = doc.people.attendees
-          .map((attendee) => attendee.name || attendee.email || "Unknown")
-          .filter((name) => name !== "Unknown");
-      }
-    }
+
     
     const dailyNotesMap = this.dailyNoteBuilder.buildDailyNotesMap(documents);
     const sectionHeadingSetting = this.settings.dailyNoteSectionHeading.trim();
@@ -324,14 +317,7 @@ export default class GranolaSync extends Plugin {
     forceOverwrite: boolean = false,
     transcriptDataMap: Map<string, TranscriptEntry[]> | null = null
   ): Promise<number> {
-    // Extract attendees from people.attendees for all documents before processing
-    for (const doc of documents) {
-      if (doc.people?.attendees && doc.people.attendees.length > 0) {
-        doc.attendees = doc.people.attendees
-          .map((attendee) => attendee.name || attendee.email || "Unknown")
-          .filter((name) => name !== "Unknown");
-      }
-    }
+
     
     let processedCount = 0;
     let syncedCount = 0;

--- a/src/services/documentProcessor.ts
+++ b/src/services/documentProcessor.ts
@@ -1,6 +1,7 @@
 import { GranolaDoc } from "./granolaApi";
 import { convertProsemirrorToMarkdown } from "./prosemirrorMarkdown";
 import { sanitizeFilename, getTitleOrDefault } from "../utils/filenameUtils";
+import { escapeYamlString } from "../utils/yamlUtils";
 import { PathResolver } from "./pathResolver";
 import { TranscriptSettings } from "../settings";
 
@@ -53,7 +54,7 @@ export class DocumentProcessor {
         ?.map((attendee) => attendee.name || attendee.email || "Unknown")
         .filter((name) => name !== "Unknown") || [];
     if (attendees.length > 0) {
-      const attendeesYaml = attendees.map((name) => `  - ${name}`).join("\n");
+      const attendeesYaml = attendees.map((name) => `  - ${escapeYamlString(name)}`).join("\n");
       frontmatterLines.push(`attendees:\n${attendeesYaml}`);
     } else {
       frontmatterLines.push(`attendees: []`);
@@ -135,7 +136,7 @@ export class DocumentProcessor {
         ?.map((attendee) => attendee.name || attendee.email || "Unknown")
         .filter((name) => name !== "Unknown") || [];
     if (attendees.length > 0) {
-      const attendeesYaml = attendees.map((name) => `  - ${name}`).join("\n");
+      const attendeesYaml = attendees.map((name) => `  - ${escapeYamlString(name)}`).join("\n");
       frontmatterLines.push(`attendees:\n${attendeesYaml}`);
     } else {
       frontmatterLines.push(`attendees: []`);

--- a/src/services/transcriptFormatter.ts
+++ b/src/services/transcriptFormatter.ts
@@ -1,4 +1,5 @@
 import { TranscriptEntry } from "./granolaApi";
+import { escapeYamlString } from "../utils/yamlUtils";
 
 /**
  * Formats transcript body content into markdown, grouped by speaker.
@@ -94,7 +95,7 @@ export function formatTranscriptBySpeaker(
   const attendeesArray = attendees || [];
   if (attendeesArray.length > 0) {
     const attendeesYaml = attendeesArray
-      .map((name) => `  - ${name}`)
+      .map((name) => `  - ${escapeYamlString(name)}`)
       .join("\n");
     frontmatterLines.push(`attendees:\n${attendeesYaml}`);
   } else {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -38,3 +38,4 @@ export const log = {
     console.error("[Granola Sync]", ...args);
   },
 };
+

--- a/src/utils/yamlUtils.ts
+++ b/src/utils/yamlUtils.ts
@@ -1,0 +1,19 @@
+/**
+ * Escapes a string for safe use as a YAML value.
+ * Wraps the string in double quotes and escapes special characters.
+ *
+ * @param value - The string to escape
+ * @returns A properly escaped YAML string value
+ */
+export function escapeYamlString(value: string): string {
+  if (value === "") {
+    return '""';
+  }
+
+  // Escape backslashes first, then double quotes
+  const escaped = value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+
+  // Always wrap in double quotes to handle all special characters safely
+  return `"${escaped}"`;
+}
+

--- a/tests/unit/yamlUtils.test.ts
+++ b/tests/unit/yamlUtils.test.ts
@@ -1,0 +1,94 @@
+import { escapeYamlString } from "../../src/utils/yamlUtils";
+
+describe("escapeYamlString", () => {
+  it("should wrap normal strings in double quotes", () => {
+    const result = escapeYamlString("John Doe");
+    expect(result).toBe('"John Doe"');
+  });
+
+  it("should handle empty strings", () => {
+    const result = escapeYamlString("");
+    expect(result).toBe('""');
+  });
+
+  it("should escape asterisks by wrapping in quotes", () => {
+    const result = escapeYamlString("John* Doe");
+    expect(result).toBe('"John* Doe"');
+  });
+
+  it("should escape colons by wrapping in quotes", () => {
+    const result = escapeYamlString("John: Doe");
+    expect(result).toBe('"John: Doe"');
+  });
+
+  it("should escape double quotes within the string", () => {
+    const result = escapeYamlString('John "The Man" Doe');
+    expect(result).toBe('"John \\"The Man\\" Doe"');
+  });
+
+  it("should escape backslashes within the string", () => {
+    const result = escapeYamlString("John\\Doe");
+    expect(result).toBe('"John\\\\Doe"');
+  });
+
+  it("should handle strings with multiple special characters", () => {
+    const result = escapeYamlString('John* "The: Man" Doe\\Jr');
+    expect(result).toBe('"John* \\"The: Man\\" Doe\\\\Jr"');
+  });
+
+  it("should handle strings with @ symbol", () => {
+    const result = escapeYamlString("john@example.com");
+    expect(result).toBe('"john@example.com"');
+  });
+
+  it("should handle strings with # symbol", () => {
+    const result = escapeYamlString("John #1");
+    expect(result).toBe('"John #1"');
+  });
+
+  it("should handle strings with brackets", () => {
+    const result = escapeYamlString("John [CEO]");
+    expect(result).toBe('"John [CEO]"');
+  });
+
+  it("should handle strings with curly braces", () => {
+    const result = escapeYamlString("John {admin}");
+    expect(result).toBe('"John {admin}"');
+  });
+
+  it("should handle strings with ampersand", () => {
+    const result = escapeYamlString("John & Jane");
+    expect(result).toBe('"John & Jane"');
+  });
+
+  it("should handle strings with exclamation mark", () => {
+    const result = escapeYamlString("John!");
+    expect(result).toBe('"John!"');
+  });
+
+  it("should handle strings with percent sign", () => {
+    const result = escapeYamlString("100% Attendance");
+    expect(result).toBe('"100% Attendance"');
+  });
+
+  it("should handle strings with pipe character", () => {
+    const result = escapeYamlString("John | Manager");
+    expect(result).toBe('"John | Manager"');
+  });
+
+  it("should handle strings with greater than and less than", () => {
+    const result = escapeYamlString("John <CEO>");
+    expect(result).toBe('"John <CEO>"');
+  });
+
+  it("should handle strings that start with special YAML characters", () => {
+    const result = escapeYamlString("- John Doe");
+    expect(result).toBe('"- John Doe"');
+  });
+
+  it("should handle strings with newlines", () => {
+    const result = escapeYamlString("John\nDoe");
+    expect(result).toBe('"John\nDoe"');
+  });
+});
+


### PR DESCRIPTION
Fixes #60

## Problem
When attendee names contain special characters (e.g., `*`, `:`, `@`, etc.), they are inserted directly into YAML front matter without proper escaping, causing invalid YAML and breaking sync.

## Solution
- Created `escapeYamlString()` utility function that properly quotes and escapes YAML strings
- Updated `DocumentProcessor` to escape attendee names when generating front matter
- Updated `TranscriptFormatter` to escape attendee names when generating front matter
- Added comprehensive unit tests covering various special characters

## Testing
- All 18 new unit tests pass
- All existing related tests pass
- Handles special characters: `*`, `:`, `"`, `\`, `@`, `#`, brackets, braces, and more