### PR TITLE
fix: add fallback for daily note lookup with subfolder formats

### DIFF
--- a/src/services/pathResolver.ts
+++ b/src/services/pathResolver.ts
@@ -7,7 +7,7 @@ import {
 } from "../utils/filenameUtils";
 import { TranscriptSettings, NoteSettings } from "../settings";
 import { GranolaDoc } from "./granolaApi";
-import { getNoteDate } from "../utils/dateUtils";
+import { getNoteDate, computeDailyNoteFilePath as computeDailyNotePath } from "../utils/dateUtils";
 
 /**
  * Resolves file paths for notes and transcripts based on plugin settings
@@ -15,6 +15,18 @@ import { getNoteDate } from "../utils/dateUtils";
  */
 export class PathResolver {
   constructor(private settings: NoteSettings & TranscriptSettings) {}
+
+  /**
+   * Computes the full file path for a daily note based on its date.
+   * Uses the daily notes plugin settings to determine the structure.
+   * Delegates to the shared utility function in dateUtils.
+   *
+   * @param noteDate - The date of the note
+   * @returns The full file path for the daily note (including .md extension)
+   */
+  computeDailyNoteFilePath(noteDate: Date): string {
+    return computeDailyNotePath(noteDate);
+  }
 
   /**
    * Computes the folder path for a daily note based on its date.

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,3 +1,6 @@
+import { normalizePath } from "obsidian";
+import { getDailyNoteSettings } from "obsidian-daily-notes-interface";
+import moment from "moment";
 import { GranolaDoc } from "../services/granolaApi";
 
 /**
@@ -29,4 +32,28 @@ export function formatDateForFilename(date: Date): string {
   const seconds = String(date.getSeconds()).padStart(2, "0");
 
   return `${year}-${month}-${day} ${hours}-${minutes}-${seconds}`;
+}
+
+/**
+ * Computes the full file path for a daily note based on its date.
+ * Uses the daily notes plugin settings to determine the structure.
+ * This is a standalone utility for use across the codebase.
+ *
+ * @param noteDate - The date of the note
+ * @returns The full file path for the daily note (including .md extension)
+ */
+export function computeDailyNoteFilePath(noteDate: Date): string {
+  const dailyNoteSettings = getDailyNoteSettings();
+  const noteMoment = moment(noteDate);
+
+  // Format the date according to the daily note format
+  const formattedPath = noteMoment.format(
+    dailyNoteSettings.format || "YYYY-MM-DD"
+  );
+
+  // Combine with the base daily notes folder
+  const baseFolder = dailyNoteSettings.folder || "";
+  return normalizePath(
+    baseFolder ? `${baseFolder}/${formattedPath}.md` : `${formattedPath}.md`
+  );
 }


### PR DESCRIPTION
## Summary

This fixes a bug in the existing "Link from daily notes" feature for users with subfolder-based daily note formats.

When using formats like `YYYY/MM-MMMM/DD-dddd/_note` (which are valid Obsidian Daily Notes configurations), the feature fails with:

```
TypeError: Cannot read properties of undefined (reading 'path')
at Xt.updateDailyNoteSection
```

**Root cause:** The `obsidian-daily-notes-interface` library's `getAllDailyNotes()` function doesn't reliably find existing files with complex subfolder formats. When `getDailyNote()` returns null, the plugin tries to create the file, gets "File already exists", and the error propagates.

## Why this isn't an edge case

- Obsidian's core Daily Notes plugin explicitly supports subfolder-based date formats via moment.js formatting
- The plugin's "Base folder: Daily Notes folder" setting indicates it's designed to work with any valid Daily Notes configuration
- This fixes an existing feature, not adding a new one

## Changes

- Add `computeDailyNoteFilePath()` utility function in `dateUtils.ts`
- Add fallback in `getOrCreateDailyNote()`: when the library fails to find the file, compute the path directly and check if it exists in the vault
- Add info logging when fallback is used (helps debugging)
- Add error handling with context for `createDailyNote` failures
- Add 6 unit tests covering fallback scenarios

The fix is minimal (~30 lines) and backwards-compatible—it only triggers when the library's lookup fails.

## Test plan

- [x] All 257 existing tests pass
- [x] New tests cover: simple format fallback, complex subfolder format, file creation when not found, non-TFile handling, error logging
- [x] Manually tested with daily note format `YYYY/MM-MMMM/DD-dddd/_note` - meetings now link correctly to existing daily notes