### PR TITLE
Credentials filesystem reading

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,6 @@ import {
 } from "./services/granolaApi";
 import {
   loadCredentials as loadGranolaCredentials,
-  stopCredentialsServer,
 } from "./services/credentials";
 import {
   formatTranscriptBySpeaker,
@@ -95,7 +94,6 @@ export default class GranolaSync extends Plugin {
   }
 
   async onunload() {
-    stopCredentialsServer();
     // Clean up status bar (includes clearing timeout)
     hideStatusBar(this);
   }


### PR DESCRIPTION
## Description
Replaces the local HTTP server used for loading credentials with direct filesystem reading. This change removes unnecessary complexity and potential port conflicts by streamlining the credential retrieval process.

The `loadCredentials()` function now directly reads `supabase.json` from the filesystem, enhancing error handling for file not found, permission issues, invalid JSON format, and missing required fields. The token refresh logic remains unchanged.

Closes: https://github.com/tomelliot/obsidian-granola-sync/issues/79

## PR Best Practices
- Keep the set of changes to the smallest set possible
- Keep changes aligned with the focus of the PR or issue it's resolving
- Split large changes into multiple smaller PRs when appropriate

## Testing
- [x] Tests added/updated
- [ ] Manual testing completed
- [x] All tests pass

## Checklist
- [x] Self-review completed (it works on your machine)
- [ ] Documentation updated
- [ ] No new warnings introduced

---
<a href="https://cursor.com/background-agent?bcId=bc-882b63e7-ec0c-4660-89d2-46ffad9070d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-882b63e7-ec0c-4660-89d2-46ffad9070d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

