### PR TITLE
feat: Download and embed image attachments in notes

### DIFF
--- a/src/services/granolaApi.ts
+++ b/src/services/granolaApi.ts
@@ -21,6 +21,18 @@ export interface ProseMirrorDoc {
 }
 
 // GranolaDoc type (defined explicitly due to recursive nature of ProseMirrorDoc)
+export interface GranolaAttachment {
+  id: string;
+  url: string;
+  type?: string;
+  width?: number;
+  height?: number;
+  // Allow additional metadata fields without forcing callers to model them
+  // explicitly. This keeps the type aligned with the API while remaining
+  // forward-compatible.
+  [key: string]: unknown;
+}
+
 export interface GranolaDoc {
   id: string;
   title: string | null;
@@ -37,6 +49,10 @@ export interface GranolaDoc {
     content?: ProseMirrorDoc | string | null;
   } | null;
   notes_markdown?: string;
+   // Optional attachments array as returned by the Granola API.
+   // Currently used primarily for image attachments which are synced into
+   // the Obsidian vault and embedded at the end of the note.
+  attachments?: GranolaAttachment[];
 }
 
 // Infer TypeScript type from validation schema

--- a/src/services/validationSchemas.ts
+++ b/src/services/validationSchemas.ts
@@ -21,6 +21,17 @@ export const GranolaDocSchema = v.object({
   title: v.nullish(v.string()),
   created_at: v.nullish(v.string()),
   updated_at: v.nullish(v.string()),
+  attachments: v.optional(
+    v.array(
+      v.object({
+        id: v.string(),
+        url: v.string(),
+        type: v.optional(v.string()),
+        width: v.optional(v.number()),
+        height: v.optional(v.number()),
+      })
+    )
+  ),
   people: v.nullish(
     v.object({
       attendees: v.optional(

--- a/tests/unit/granolaApi.test.ts
+++ b/tests/unit/granolaApi.test.ts
@@ -45,6 +45,15 @@ describe("fetchGranolaDocuments", () => {
         title: "Test Note",
         created_at: "2024-01-15T10:00:00Z",
         updated_at: "2024-01-15T12:00:00Z",
+        attachments: [
+          {
+            id: "att-1",
+            url: "https://example.com/image-1",
+            type: "image",
+            width: 100,
+            height: 200,
+          },
+        ],
         last_viewed_panel: {
           content: {
             type: "doc",
@@ -115,6 +124,58 @@ describe("fetchGranolaDocuments", () => {
       "Invalid response from Granola API"
     );
     expect(log.error).toHaveBeenCalled();
+  });
+
+  it("should parse documents with attachments field", async () => {
+    const responseWithAttachments = {
+      docs: [
+        {
+          id: "doc-with-attachments",
+          title: "Note With Attachments",
+          created_at: "2024-01-15T10:00:00Z",
+          updated_at: "2024-01-15T12:00:00Z",
+          attachments: [
+            {
+              id: "attachment-1",
+              url: "https://example.com/image-1",
+              type: "image",
+              width: 1084,
+              height: 1036,
+            },
+            {
+              id: "attachment-2",
+              url: "https://example.com/image-2",
+              type: "image",
+              width: 1676,
+              height: 1042,
+            },
+          ],
+          last_viewed_panel: {
+            content: {
+              type: "doc",
+              content: [],
+            },
+          },
+        },
+      ],
+    };
+
+    (requestUrl as jest.Mock).mockResolvedValue({
+      json: responseWithAttachments,
+    });
+
+    const result = await fetchGranolaDocuments(mockAccessToken, 100, 0);
+
+    expect(result).toHaveLength(1);
+    const [doc] = result;
+    expect(doc.id).toBe("doc-with-attachments");
+    expect(doc.attachments).toBeDefined();
+    expect(doc.attachments!.length).toBe(2);
+    expect(doc.attachments![0]).toMatchObject({
+      id: "attachment-1",
+      url: "https://example.com/image-1",
+      type: "image",
+    });
   });
 
   it("should handle network errors", async () => {


### PR DESCRIPTION
## Image attachment support
- Download and embed image attachments from Granola documents
- Determine file extensions from Content-Type headers or URL paths
- Save images to attachments folder using Obsidian's file manager
- Append image embeds at end of note content

## API changes
- Add GranolaAttachment interface for typed attachment metadata
- Add attachments field to GranolaDoc interface and validation schema
- Use requestUrl for downloading images and createBinary for storage

## Implementation details
- Parallel image downloads with Promise.allSettled for performance
- Skip re-downloading if file already exists in vault
- Only embed successfully downloaded images
- Support common image formats (png, jpg, gif, webp, svg)

## Testing
- Add unit tests for attachment download and embed functionality
- Mock requestUrl and vault binary operations for isolated testing

Closes https://github.com/tomelliot/obsidian-granola-sync/issues/85
