### PR TITLE
feat: handle HTML string content from Granola API

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -449,8 +449,7 @@ export default class GranolaSync extends Plugin {
       const contentToParse = doc.last_viewed_panel?.content;
       if (
         !contentToParse ||
-        typeof contentToParse === "string" ||
-        contentToParse.type !== "doc"
+        (typeof contentToParse !== "string" && contentToParse.type !== "doc")
       ) {
         continue;
       }

--- a/src/services/documentProcessor.ts
+++ b/src/services/documentProcessor.ts
@@ -1,5 +1,6 @@
 import { GranolaDoc } from "./granolaApi";
 import { convertProsemirrorToMarkdown } from "./prosemirrorMarkdown";
+import { convertHtmlToMarkdown } from "./htmlMarkdown";
 import {
   getTitleOrDefault,
   resolveFilenamePattern,
@@ -91,15 +92,20 @@ export class DocumentProcessor {
    */
   buildNoteBody(doc: GranolaDoc, options: BodyOptions): string {
     const contentToParse = doc.last_viewed_panel?.content;
-    if (
-      !contentToParse ||
-      typeof contentToParse === "string" ||
-      contentToParse.type !== "doc"
-    ) {
+    if (!contentToParse) {
       throw new Error("Document has no valid content to parse");
     }
 
-    const markdownContent = convertProsemirrorToMarkdown(contentToParse);
+    // The Granola API may return content as either a ProseMirror JSON document
+    // or an HTML string. Handle both formats.
+    let markdownContent: string;
+    if (typeof contentToParse === "string") {
+      markdownContent = convertHtmlToMarkdown(contentToParse);
+    } else if (contentToParse.type === "doc") {
+      markdownContent = convertProsemirrorToMarkdown(contentToParse);
+    } else {
+      throw new Error("Document has no valid content to parse");
+    }
     const headingPrefix = "#".repeat(options.headingLevel);
 
     // Add private notes section if enabled and content exists

--- a/src/services/htmlMarkdown.ts
+++ b/src/services/htmlMarkdown.ts
@@ -1,0 +1,211 @@
+/**
+ * Converts an HTML string to Markdown.
+ *
+ * The Granola API sometimes returns note content as an HTML string instead of
+ * a ProseMirror JSON document. This module handles that case by converting the
+ * HTML into Markdown that matches the output of the ProseMirror converter.
+ *
+ * Runs in Obsidian's Electron environment where DOMParser is available.
+ */
+
+/**
+ * Convert an HTML string to Markdown.
+ *
+ * @param html - The HTML string to convert
+ * @returns Markdown string
+ */
+export function convertHtmlToMarkdown(html: string): string {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, "text/html");
+  const output = processChildren(doc.body, 0);
+  return output.replace(/\n{3,}/g, "\n\n").trimEnd() + "\n";
+}
+
+function processChildren(element: Node, indentLevel: number): string {
+  let result = "";
+  for (const child of Array.from(element.childNodes)) {
+    result += processNode(child, indentLevel);
+  }
+  return result;
+}
+
+function processNode(node: Node, indentLevel: number): string {
+  // Text nodes
+  if (node.nodeType === Node.TEXT_NODE) {
+    return node.textContent || "";
+  }
+
+  // Element nodes
+  if (node.nodeType !== Node.ELEMENT_NODE) {
+    return "";
+  }
+
+  const el = node as HTMLElement;
+  const tag = el.tagName.toLowerCase();
+
+  switch (tag) {
+    case "h1":
+    case "h2":
+    case "h3":
+    case "h4":
+    case "h5":
+    case "h6": {
+      const level = parseInt(tag.charAt(1), 10);
+      const text = getInlineContent(el).trim();
+      return `${"#".repeat(level)} ${text}\n\n`;
+    }
+    case "p": {
+      const text = getInlineContent(el);
+      return text + "\n\n";
+    }
+    case "ul":
+      return processListItems(el, indentLevel) + "\n\n";
+    case "ol":
+      return processOrderedListItems(el, indentLevel) + "\n\n";
+    case "br":
+      return "\n";
+    case "strong":
+    case "b":
+      return `**${getInlineContent(el)}**`;
+    case "em":
+    case "i":
+      return `*${getInlineContent(el)}*`;
+    case "a": {
+      const href = el.getAttribute("href") || "";
+      const text = getInlineContent(el);
+      return `[${text}](${href})`;
+    }
+    case "code":
+      return `\`${el.textContent || ""}\``;
+    case "pre":
+      return `\`\`\`\n${el.textContent || ""}\n\`\`\`\n\n`;
+    case "blockquote": {
+      const content = processChildren(el, indentLevel).trim();
+      return (
+        content
+          .split("\n")
+          .map((line) => `> ${line}`)
+          .join("\n") + "\n\n"
+      );
+    }
+    case "div":
+    case "section":
+    case "article":
+      return processChildren(el, indentLevel);
+    default:
+      return processChildren(el, indentLevel);
+  }
+}
+
+/**
+ * Get inline content from an element, handling nested inline elements like
+ * strong, em, a, code, etc.
+ */
+function getInlineContent(el: HTMLElement): string {
+  let result = "";
+  for (const child of Array.from(el.childNodes)) {
+    if (child.nodeType === Node.TEXT_NODE) {
+      result += child.textContent || "";
+    } else if (child.nodeType === Node.ELEMENT_NODE) {
+      const childEl = child as HTMLElement;
+      const tag = childEl.tagName.toLowerCase();
+      switch (tag) {
+        case "strong":
+        case "b":
+          result += `**${getInlineContent(childEl)}**`;
+          break;
+        case "em":
+        case "i":
+          result += `*${getInlineContent(childEl)}*`;
+          break;
+        case "a": {
+          const href = childEl.getAttribute("href") || "";
+          result += `[${getInlineContent(childEl)}](${href})`;
+          break;
+        }
+        case "code":
+          result += `\`${childEl.textContent || ""}\``;
+          break;
+        case "br":
+          result += "\n";
+          break;
+        default:
+          result += getInlineContent(childEl);
+      }
+    }
+  }
+  return result;
+}
+
+function processListItems(ul: HTMLElement, indentLevel: number): string {
+  const items: string[] = [];
+  for (const child of Array.from(ul.children)) {
+    if (child.tagName.toLowerCase() === "li") {
+      const indent = "\t".repeat(indentLevel);
+      const parts: string[] = [];
+      let nestedLists = "";
+
+      for (const liChild of Array.from(child.childNodes)) {
+        if (liChild.nodeType === Node.TEXT_NODE) {
+          const text = (liChild.textContent || "").trim();
+          if (text) parts.push(text);
+        } else if (liChild.nodeType === Node.ELEMENT_NODE) {
+          const liChildEl = liChild as HTMLElement;
+          const tag = liChildEl.tagName.toLowerCase();
+          if (tag === "ul") {
+            nestedLists +=
+              "\n" + processListItems(liChildEl, indentLevel + 1);
+          } else if (tag === "ol") {
+            nestedLists +=
+              "\n" + processOrderedListItems(liChildEl, indentLevel + 1);
+          } else {
+            parts.push(getInlineContent(liChildEl));
+          }
+        }
+      }
+
+      items.push(`${indent}- ${parts.join(" ").trim()}${nestedLists}`);
+    }
+  }
+  return items.join("\n");
+}
+
+function processOrderedListItems(
+  ol: HTMLElement,
+  indentLevel: number
+): string {
+  const items: string[] = [];
+  let index = 1;
+  for (const child of Array.from(ol.children)) {
+    if (child.tagName.toLowerCase() === "li") {
+      const indent = "\t".repeat(indentLevel);
+      const parts: string[] = [];
+      let nestedLists = "";
+
+      for (const liChild of Array.from(child.childNodes)) {
+        if (liChild.nodeType === Node.TEXT_NODE) {
+          const text = (liChild.textContent || "").trim();
+          if (text) parts.push(text);
+        } else if (liChild.nodeType === Node.ELEMENT_NODE) {
+          const liChildEl = liChild as HTMLElement;
+          const tag = liChildEl.tagName.toLowerCase();
+          if (tag === "ul") {
+            nestedLists +=
+              "\n" + processListItems(liChildEl, indentLevel + 1);
+          } else if (tag === "ol") {
+            nestedLists +=
+              "\n" + processOrderedListItems(liChildEl, indentLevel + 1);
+          } else {
+            parts.push(getInlineContent(liChildEl));
+          }
+        }
+      }
+
+      items.push(
+        `${indent}${index}. ${parts.join(" ").trim()}${nestedLists}`
+      );
+      index++;
+    }
+  }
+  return items.join("\n");
+}


### PR DESCRIPTION
The problem: Some notes are not synced and silently skipped, which cc believes is due to the HTML. It is not clear why these notes are formatted differently. This attempts to address the issue by handling HTML, but it may not be the approach you prefer to use. A better option may be to address it upstream by ensuring Granola has a bug report to address the inconsistent note format. May address similar issues reported in https://github.com/tomelliot/obsidian-granola-sync/issues/97


## Summary

- The Granola API sometimes returns note content as an HTML string instead of a ProseMirror JSON document. When this happens, the plugin silently skips those documents during sync.
- This PR adds an HTML-to-markdown conversion path so documents with HTML content are synced correctly instead of being dropped.
- In my vault, 6 out of 20 recent meetings were affected by this -- they never appeared in Obsidian despite syncing normally in Granola.

## What changed

- **New file: `src/services/htmlMarkdown.ts`** -- `convertHtmlToMarkdown()` using DOMParser (available in Obsidian's Electron environment). Handles h1-h6, p, ul/ol with nesting, strong/em, links, code, blockquotes, and br tags. Output format matches the existing ProseMirror converter (tab-indented nested lists, double newlines between blocks).
- **`src/services/documentProcessor.ts`** -- `buildNoteBody()` now checks `typeof contentToParse` and routes to the appropriate converter instead of throwing on string content.
- **`src/main.ts`** -- `syncNotesToIndividualFiles()` filter updated to allow string content through (previously `typeof === "string"` triggered a `continue`).

## Context

The validation schema in `validationSchemas.ts` already accepts both formats (`v.union([ProseMirrorDocSchema, v.string()])`), so the API contract acknowledges this can happen. The sync logic just didn't have a code path to handle it.

## Test plan

- [ ] Verify documents with ProseMirror JSON content continue to sync as before (no regression)
- [ ] Verify documents with HTML string content now sync with correct markdown formatting
- [ ] Verify documents with no content are still skipped
- [ ] Check nested list indentation matches ProseMirror converter output

closes https://github.com/tomelliot/obsidian-granola-sync/issues/97