### PR TITLE
feat: Add debug logging and Granola folder metadata

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,3 +1,6 @@
+/* eslint-env node */
+/* global console */
+
 import esbuild from "esbuild";
 import process from "process";
 import builtins from "builtin-modules";
@@ -25,7 +28,7 @@ const DEV_PLUGIN_PATH =
   process.env.DEV_PLUGIN_PATH ||
   path.join(
     process.env.HOME,
-    "Documents/Obsidian Vault/.obsidian/plugins/obsidian-granola-sync/main.js"
+    "Documents/Obsidian Vault/.obsidian/plugins/granola-sync/main.js"
   );
 
 function copyToDevPlugin() {
@@ -34,6 +37,7 @@ function copyToDevPlugin() {
   try {
     const outputPath = path.join(__dirname, "output/main.js");
     const targetDir = path.dirname(DEV_PLUGIN_PATH);
+    const manifestTargetPath = path.join(targetDir, "manifest.json");
 
     // Check if target directory exists
     if (!fs.existsSync(targetDir)) {
@@ -41,9 +45,18 @@ function copyToDevPlugin() {
       return;
     }
 
-    // Copy the file
+    // Copy the built main.js
     fs.copyFileSync(outputPath, DEV_PLUGIN_PATH);
-    console.log(`✓ Copied to ${DEV_PLUGIN_PATH}`);
+    console.log(`✓ Copied main.js to ${DEV_PLUGIN_PATH}`);
+
+    // Write a dev manifest with a fixed version so it doesn't override production
+    const devManifest = { ...manifest, version: "1.0.0" };
+    fs.writeFileSync(
+      manifestTargetPath,
+      `${JSON.stringify(devManifest, null, 2)}\n`,
+      "utf-8"
+    );
+    console.log(`✓ Wrote dev manifest.json to ${manifestTargetPath}`);
   } catch (error) {
     console.error(`Failed to copy to dev plugin directory: ${error.message}`);
   }

--- a/scripts/fetch-document.sh
+++ b/scripts/fetch-document.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Fetch a single document from the Granola API and save the response to a JSON file.
+# Usage: ./scripts/fetch-document.sh <document-id>
+
+set -euo pipefail
+
+DOC_ID="${1:?Usage: $0 <document-id>}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OUTPUT_DIR="$SCRIPT_DIR/../docs/api-response"
+CREDS_PATH="$HOME/Library/Application Support/Granola/supabase.json"
+
+mkdir -p "$OUTPUT_DIR"
+
+# Extract access token from Granola credentials
+if [ ! -f "$CREDS_PATH" ]; then
+  echo "Error: Credentials file not found at $CREDS_PATH" >&2
+  exit 1
+fi
+
+ACCESS_TOKEN=$(python3 -c "
+import json, sys
+data = json.load(open(sys.argv[1]))
+tokens = json.loads(data['workos_tokens'])
+print(tokens['access_token'])
+" "$CREDS_PATH")
+
+echo "Fetching documents from Granola API..."
+
+# Fetch all documents and filter for the target ID using jq
+RESPONSE=$(curl -s --compressed -X POST "https://api.granola.ai/v2/get-documents" \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: */*" \
+  -H "User-Agent: Undefined" \
+  -H "X-Client-Version: 1.0.0" \
+  -d "{\"limit\": 100, \"offset\": 0, \"include_last_viewed_panel\": true}")
+
+# Save the full response
+echo "$RESPONSE" | python3 -m json.tool > "$OUTPUT_DIR/get-documents-response.json"
+echo "Saved full get-documents response to $OUTPUT_DIR/get-documents-response.json"
+
+# Extract the single document by ID
+FILTERED=$(echo "$RESPONSE" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+docs = data.get('docs', [])
+match = [d for d in docs if d.get('id') == '$DOC_ID']
+if not match:
+    print(f'Warning: Document $DOC_ID not found in response ({len(docs)} docs checked)', file=sys.stderr)
+    json.dump(data, sys.stdout, indent=2)
+else:
+    json.dump(match[0], sys.stdout, indent=2)
+")
+
+DOC_OUTPUT="$OUTPUT_DIR/get-document-$DOC_ID.json"
+echo "$FILTERED" > "$DOC_OUTPUT"
+echo "Saved document to $DOC_OUTPUT"
+
+# Also fetch the transcript
+echo "Fetching transcript..."
+TRANSCRIPT=$(curl -s --compressed -X POST "https://api.granola.ai/v1/get-document-transcript" \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: */*" \
+  -H "User-Agent: Undefined" \
+  -H "X-Client-Version: 1.0.0" \
+  -d "{\"document_id\": \"$DOC_ID\"}")
+
+TRANSCRIPT_OUTPUT="$OUTPUT_DIR/get-document-transcript-$DOC_ID.json"
+echo "$TRANSCRIPT" | python3 -m json.tool > "$TRANSCRIPT_OUTPUT"
+echo "Saved transcript to $TRANSCRIPT_OUTPUT"

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,10 @@ import {
   TranscriptEntry,
 } from "./services/granolaApi";
 import {
+  buildFolderMap,
+  diffFolderMaps,
+} from "./services/folderMapBuilder";
+import {
   loadCredentials as loadGranolaCredentials,
 } from "./services/credentials";
 import {
@@ -30,6 +34,7 @@ import { FileSyncService } from "./services/fileSyncService";
 import { DocumentProcessor } from "./services/documentProcessor";
 import { DailyNoteBuilder } from "./services/dailyNoteBuilder";
 import { configureLogger, log } from "./utils/logger";
+import { formatStringListAsYaml } from "./utils/yamlUtils";
 import {
   showStatusBar,
   hideStatusBar,
@@ -267,9 +272,129 @@ export default class GranolaSync extends Plugin {
     showStatusBar(this, `Granola sync: ${label} ${clampedCurrent}/${total}`);
   }
 
-  // Build the Granola ID cache by scanning all markdown files in the vault
+  /**
+   * Updates frontmatter on all vault notes affected by folder renames.
+   * Scans all markdown files for folders entries matching old paths
+   * and replaces them with new paths.
+   */
+  private async updateRenamedFolders(
+    renamedPaths: Map<string, string>
+  ): Promise<void> {
+    const files = this.app.vault.getMarkdownFiles();
+    let updatedCount = 0;
 
-  // Compute the folder path for a note based on daily note settings
+    for (const file of files) {
+      const cache = this.app.metadataCache.getFileCache(file);
+      const folders = cache?.frontmatter?.folders as
+        | string[]
+        | undefined;
+      if (!folders || !Array.isArray(folders)) continue;
+
+      let changed = false;
+      const updatedFolders = folders.map((folder) => {
+        const newPath = renamedPaths.get(folder);
+        if (newPath) {
+          changed = true;
+          return newPath;
+        }
+        return folder;
+      });
+
+      if (changed) {
+        const content = await this.app.vault.read(file);
+        const updatedContent = this.replaceFrontmatterFolders(
+          content,
+          updatedFolders
+        );
+        if (updatedContent !== content) {
+          await this.app.vault.modify(file, updatedContent);
+          updatedCount++;
+        }
+      }
+    }
+
+    if (updatedCount > 0) {
+      log.debug(
+        `Updated folders in ${updatedCount} file(s) due to folder renames`
+      );
+    }
+  }
+
+  /**
+   * Replaces the folders list in YAML frontmatter with updated values.
+   */
+  private replaceFrontmatterFolders(
+    content: string,
+    newFolders: string[]
+  ): string {
+    const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!frontmatterMatch) return content;
+
+    const frontmatter = frontmatterMatch[1];
+
+    const folderBlockRegex =
+      /folders:\s*\n((?:\s+-\s+.*\n?)*)/;
+    const match = frontmatter.match(folderBlockRegex);
+    if (!match) return content;
+
+    const newBlock =
+      "folders:\n" +
+      newFolders.map((f) => `  - "${f}"`).join("\n") +
+      "\n";
+    const updatedFrontmatter = frontmatter.replace(folderBlockRegex, newBlock);
+
+    return content.replace(
+      /^---\n[\s\S]*?\n---/,
+      `---\n${updatedFrontmatter}\n---`
+    );
+  }
+
+  /**
+   * Backfills the `folders` frontmatter field on existing vault notes that have
+   * a `granola_id` but are missing folder metadata. This ensures previously
+   * synced documents get folder paths added when the feature is first enabled.
+   */
+  private async backfillFolderMetadata(
+    docFolders: Record<string, string[]>
+  ): Promise<void> {
+    const files = this.app.vault.getMarkdownFiles();
+    let updatedCount = 0;
+
+    for (const file of files) {
+      const cache = this.app.metadataCache.getFileCache(file);
+      if (!cache?.frontmatter?.granola_id) continue;
+
+      // Skip files that already have a folders field
+      if (cache.frontmatter.folders !== undefined) continue;
+
+      const granolaId = cache.frontmatter.granola_id as string;
+      const folders = docFolders[granolaId];
+      if (!folders || folders.length === 0) continue;
+
+      const content = await this.app.vault.read(file);
+      const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+      if (!frontmatterMatch) continue;
+
+      const frontmatter = frontmatterMatch[1];
+      const foldersYaml = `folders: ${formatStringListAsYaml(folders)}`;
+      const updatedFrontmatter = frontmatter + "\n" + foldersYaml;
+      const updatedContent = content.replace(
+        /^---\n[\s\S]*?\n---/,
+        `---\n${updatedFrontmatter}\n---`
+      );
+
+      if (updatedContent !== content) {
+        await this.app.vault.modify(file, updatedContent);
+        updatedCount++;
+      }
+    }
+
+    if (updatedCount > 0) {
+      log.debug(
+        `Backfilled folders metadata on ${updatedCount} existing note(s)`
+      );
+    }
+  }
 
   // Top-level sync function that handles common setup once
   async sync(options: { mode?: "standard" | "full" } = {}) {
@@ -354,6 +479,37 @@ export default class GranolaSync extends Plugin {
         : `Granola API: fetched ${documents.length} documents within ${this.settings.syncDaysBack} day(s)`
     );
 
+    // Build folder map (document → folder paths)
+    let docFolders: Record<string, string[]> = {};
+    try {
+      showStatusBar(this, "Granola sync: Fetching folders...");
+      const freshFolderMap = await buildFolderMap(accessToken);
+      const previousFolderMap = this.settings._folderMapCache ?? null;
+
+      // Detect folder renames and update affected notes
+      const diff = diffFolderMaps(previousFolderMap, freshFolderMap);
+      if (diff.renamedPaths.size > 0) {
+        log.debug(`Detected ${diff.renamedPaths.size} folder rename(s)`);
+        await this.updateRenamedFolders(diff.renamedPaths);
+      }
+
+      // Persist the fresh folder map
+      this.settings._folderMapCache = freshFolderMap;
+      await this.saveData(this.settings);
+
+      docFolders = freshFolderMap.docFolders;
+
+      // Backfill folders on existing notes that don't have the field yet
+      await this.backfillFolderMetadata(docFolders);
+    } catch (error) {
+      log.error("Failed to build folder map, continuing sync without folder data:", error);
+      // Use previously cached data if available
+      if (this.settings._folderMapCache) {
+        docFolders = this.settings._folderMapCache.docFolders;
+        log.debug("Using cached folder map from previous sync");
+      }
+    }
+
     // Always sync transcripts first if enabled, so notes can link to them
     const forceOverwrite = mode === "full";
     let transcriptDataMap: Map<string, TranscriptEntry[]> | null = null;
@@ -365,7 +521,7 @@ export default class GranolaSync extends Plugin {
       );
     }
     if (this.settings.syncNotes) {
-      await this.syncNotes(documents, forceOverwrite, transcriptDataMap);
+      await this.syncNotes(documents, forceOverwrite, transcriptDataMap, docFolders);
     }
 
     // Show success message
@@ -375,7 +531,8 @@ export default class GranolaSync extends Plugin {
   private async syncNotes(
     documents: GranolaDoc[],
     forceOverwrite: boolean = false,
-    transcriptDataMap: Map<string, TranscriptEntry[]> | null = null
+    transcriptDataMap: Map<string, TranscriptEntry[]> | null = null,
+    docFolders: Record<string, string[]> = {}
   ): Promise<void> {
     let syncedCount: number;
     log.debug(`syncNotes — mode=${this.settings.saveAsIndividualFiles ? "individual" : "daily-notes"}, docs=${documents.length}`);
@@ -384,13 +541,15 @@ export default class GranolaSync extends Plugin {
       syncedCount = await this.syncNotesToDailyNotes(
         documents,
         forceOverwrite,
-        transcriptDataMap
+        transcriptDataMap,
+        docFolders
       );
     } else {
       const result = await this.syncNotesToIndividualFiles(
         documents,
         forceOverwrite,
-        transcriptDataMap
+        transcriptDataMap,
+        docFolders
       );
       syncedCount = result.syncedCount;
 
@@ -420,9 +579,10 @@ export default class GranolaSync extends Plugin {
   private async syncNotesToDailyNotes(
     documents: GranolaDoc[],
     forceOverwrite: boolean = false,
-    transcriptDataMap: Map<string, TranscriptEntry[]> | null = null
+    transcriptDataMap: Map<string, TranscriptEntry[]> | null = null,
+    docFolders: Record<string, string[]> = {}
   ): Promise<number> {
-    const dailyNotesMap = this.dailyNoteBuilder.buildDailyNotesMap(documents);
+    const dailyNotesMap = this.dailyNoteBuilder.buildDailyNotesMap(documents, docFolders);
     const sectionHeadingSetting = (
       this.settings.dailyNoteSectionHeading ||
       DEFAULT_SETTINGS.dailyNoteSectionHeading!
@@ -520,7 +680,8 @@ export default class GranolaSync extends Plugin {
   private async syncNotesToIndividualFiles(
     documents: GranolaDoc[],
     forceOverwrite: boolean = false,
-    transcriptDataMap: Map<string, TranscriptEntry[]> | null = null
+    transcriptDataMap: Map<string, TranscriptEntry[]> | null = null,
+    docFolders: Record<string, string[]> = {}
   ): Promise<{
     syncedCount: number;
     syncedNotes: Array<{ doc: GranolaDoc; notePath: string }>;
@@ -572,6 +733,8 @@ export default class GranolaSync extends Plugin {
       processedCount++;
       this.updateSyncStatus("Note", processedCount, documents.length);
 
+      const folders = docFolders[doc.id];
+
       // Handle combined mode: save note and transcript together
       if (isCombinedMode && transcriptDataMap) {
         const transcriptData = transcriptDataMap.get(doc.id || "");
@@ -582,7 +745,8 @@ export default class GranolaSync extends Plugin {
               doc,
               this.documentProcessor,
               transcriptBody,
-              forceOverwrite
+              forceOverwrite,
+              folders
             )
           ) {
             syncedCount++;
@@ -594,7 +758,9 @@ export default class GranolaSync extends Plugin {
             await this.fileSyncService.saveNoteToDisk(
               doc,
               this.documentProcessor,
-              forceOverwrite
+              forceOverwrite,
+              undefined,
+              folders
             )
           ) {
             syncedCount++;
@@ -618,7 +784,8 @@ export default class GranolaSync extends Plugin {
             doc,
             this.documentProcessor,
             forceOverwrite,
-            transcriptPath ?? undefined
+            transcriptPath ?? undefined,
+            folders
           )
         ) {
           syncedCount++;

--- a/src/main.ts
+++ b/src/main.ts
@@ -359,21 +359,40 @@ export default class GranolaSync extends Plugin {
   ): Promise<void> {
     const files = this.app.vault.getMarkdownFiles();
     let updatedCount = 0;
+    let scannedCount = 0;
+    let alreadyHasFoldersCount = 0;
+    let noFolderDataCount = 0;
+    let noFrontmatterCount = 0;
+
+    log.debug(`backfillFolderMetadata — scanning ${files.length} markdown file(s), docFolders has ${Object.keys(docFolders).length} mapping(s)`);
 
     for (const file of files) {
       const cache = this.app.metadataCache.getFileCache(file);
       if (!cache?.frontmatter?.granola_id) continue;
 
+      scannedCount++;
+
       // Skip files that already have a folders field
-      if (cache.frontmatter.folders !== undefined) continue;
+      if (cache.frontmatter.folders !== undefined) {
+        alreadyHasFoldersCount++;
+        continue;
+      }
 
       const granolaId = cache.frontmatter.granola_id as string;
       const folders = docFolders[granolaId];
-      if (!folders || folders.length === 0) continue;
+      if (!folders || folders.length === 0) {
+        noFolderDataCount++;
+        log.debug(`backfill skip — no folder data for granolaId=${granolaId} (${file.path})`);
+        continue;
+      }
 
       const content = await this.app.vault.read(file);
       const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
-      if (!frontmatterMatch) continue;
+      if (!frontmatterMatch) {
+        noFrontmatterCount++;
+        log.debug(`backfill skip — no parseable frontmatter in ${file.path}`);
+        continue;
+      }
 
       const frontmatter = frontmatterMatch[1];
       const foldersYaml = `folders: ${formatStringListAsYaml(folders)}`;
@@ -386,14 +405,11 @@ export default class GranolaSync extends Plugin {
       if (updatedContent !== content) {
         await this.app.vault.modify(file, updatedContent);
         updatedCount++;
+        log.debug(`backfill updated — ${file.path} (granolaId=${granolaId}, folders=${JSON.stringify(folders)})`);
       }
     }
 
-    if (updatedCount > 0) {
-      log.debug(
-        `Backfilled folders metadata on ${updatedCount} existing note(s)`
-      );
-    }
+    log.debug(`backfillFolderMetadata — scanned=${scannedCount} granola files, updated=${updatedCount}, alreadyHasFolders=${alreadyHasFoldersCount}, noFolderData=${noFolderDataCount}, noFrontmatter=${noFrontmatterCount}`);
   }
 
   // Top-level sync function that handles common setup once
@@ -498,6 +514,7 @@ export default class GranolaSync extends Plugin {
       await this.saveData(this.settings);
 
       docFolders = freshFolderMap.docFolders;
+      log.debug(`Folder map built — ${Object.keys(freshFolderMap.folders).length} folder(s), ${Object.keys(docFolders).length} document(s) with folder data`);
 
       // Backfill folders on existing notes that don't have the field yet
       await this.backfillFolderMetadata(docFolders);
@@ -734,6 +751,7 @@ export default class GranolaSync extends Plugin {
       this.updateSyncStatus("Note", processedCount, documents.length);
 
       const folders = docFolders[doc.id];
+      log.debug(`Syncing doc ${doc.id} — folders=${folders ? JSON.stringify(folders) : "none"}`);
 
       // Handle combined mode: save note and transcript together
       if (isCombinedMode && transcriptDataMap) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,6 @@
-import { Notice, Plugin } from "obsidian";
+import { FileSystemAdapter, Notice, Plugin } from "obsidian";
+import fs from "fs";
+import path from "path";
 import moment from "moment";
 import { getDailyNote, getAllDailyNotes } from "obsidian-daily-notes-interface";
 import { getTitleOrDefault } from "./utils/filenameUtils";
@@ -27,7 +29,7 @@ import { PathResolver } from "./services/pathResolver";
 import { FileSyncService } from "./services/fileSyncService";
 import { DocumentProcessor } from "./services/documentProcessor";
 import { DailyNoteBuilder } from "./services/dailyNoteBuilder";
-import { log } from "./utils/logger";
+import { configureLogger, log } from "./utils/logger";
 import {
   showStatusBar,
   hideStatusBar,
@@ -46,6 +48,8 @@ export default class GranolaSync extends Plugin {
 
   async onload() {
     await this.loadSettings();
+
+    this.initializeLogger();
 
     // Initialize services
     this.initializeServices();
@@ -165,6 +169,90 @@ export default class GranolaSync extends Plugin {
     }
   }
 
+  private debugLogFilePath: string | null = null;
+
+  private getPluginDirPath(): string | null {
+    const adapter = this.app.vault.adapter;
+
+    if (adapter instanceof FileSystemAdapter) {
+      const basePath = adapter.getBasePath();
+      const configDir = this.app.vault.configDir;
+      return path.join(basePath, configDir, "plugins", this.manifest.id);
+    }
+
+    return null;
+  }
+
+  private initializeLogger(): void {
+    const pluginDir = this.getPluginDirPath();
+
+    if (!pluginDir) {
+      configureLogger(null);
+      return;
+    }
+
+    // Generate a timestamped log filename once per session
+    const timestamp = new Date()
+      .toISOString()
+      .replace(/:/g, "-")
+      .replace(/\.\d{3}Z$/, "");
+    this.debugLogFilePath = path.join(
+      pluginDir,
+      "logs",
+      `${timestamp}.log`
+    );
+
+    configureLogger({
+      isDebugEnabled: () => this.settings.enableDebugLogging,
+      appendLine: async (line: string) => {
+        if (!this.debugLogFilePath) return;
+        try {
+          await fs.promises.mkdir(path.dirname(this.debugLogFilePath), {
+            recursive: true,
+          });
+          await fs.promises.appendFile(this.debugLogFilePath, line, "utf-8");
+        } catch {
+          // Swallow all errors to avoid affecting plugin behavior
+        }
+      },
+    });
+  }
+
+  async copyDebugLogsToClipboard(): Promise<void> {
+    const debugLogPath = this.debugLogFilePath;
+
+    if (!debugLogPath) {
+      new Notice(
+        "Copying debug logs is not available in this environment."
+      );
+      return;
+    }
+
+    try {
+      const contents = await fs.promises.readFile(debugLogPath, "utf-8");
+
+      if (!contents) {
+        new Notice("Debug log file is empty.");
+        return;
+      }
+
+      await navigator.clipboard.writeText(contents);
+      new Notice("Debug logs copied to clipboard.");
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") {
+        new Notice(
+          "Debug log file not found. Enable debug logging and try again."
+        );
+      } else {
+        new Notice(
+          "Failed to copy debug logs: " +
+            (error instanceof Error ? error.message : String(error))
+        );
+      }
+    }
+  }
+
   private updateSyncStatus(
     kind: "Note" | "Transcript",
     current: number,
@@ -186,6 +274,7 @@ export default class GranolaSync extends Plugin {
   // Top-level sync function that handles common setup once
   async sync(options: { mode?: "standard" | "full" } = {}) {
     const mode = options.mode ?? "standard";
+    log.debug(`Sync started — mode=${mode}, daysBack=${this.settings.syncDaysBack}`);
     showStatusBar(this, "Granola sync: Syncing...");
 
     // Load credentials at the start of each sync
@@ -289,6 +378,7 @@ export default class GranolaSync extends Plugin {
     transcriptDataMap: Map<string, TranscriptEntry[]> | null = null
   ): Promise<void> {
     let syncedCount: number;
+    log.debug(`syncNotes — mode=${this.settings.saveAsIndividualFiles ? "individual" : "daily-notes"}, docs=${documents.length}`);
 
     if (!this.settings.saveAsIndividualFiles) {
       syncedCount = await this.syncNotesToDailyNotes(
@@ -367,7 +457,7 @@ export default class GranolaSync extends Plugin {
         });
 
         if (allNotesUpToDate && existingNotes.size === notesForDay.length) {
-          // All notes are present and up-to-date, skip this date
+          log.debug(`Daily notes for ${dateKey} — all ${notesForDay.length} note(s) up-to-date, skipping`);
           processedCount += notesForDay.length;
           this.updateSyncStatus("Note", processedCount, documents.length);
           continue;
@@ -452,6 +542,7 @@ export default class GranolaSync extends Plugin {
         typeof contentToParse === "string" ||
         contentToParse.type !== "doc"
       ) {
+        log.debug(`Skipping doc ${doc.id} — no parseable content (type=${typeof contentToParse === "object" && contentToParse ? (contentToParse as { type?: string }).type : typeof contentToParse})`);
         continue;
       }
 
@@ -472,7 +563,7 @@ export default class GranolaSync extends Plugin {
               isCombinedMode ? "combined" : "note"
             )
           ) {
-            // Note is up-to-date, skip syncing (and don't add to syncedNotes for daily note linking)
+            log.debug(`Skipping doc ${doc.id} — local copy is up-to-date`);
             continue;
           }
         }
@@ -572,6 +663,7 @@ export default class GranolaSync extends Plugin {
                 isCombinedMode ? "combined" : "transcript"
               )
             ) {
+              log.debug(`Skipping transcript for doc ${docId} — local copy is up-to-date`);
               continue;
             }
           }
@@ -582,6 +674,7 @@ export default class GranolaSync extends Plugin {
           docId
         );
         if (transcriptData.length === 0) {
+          log.debug(`Skipping transcript for doc ${docId} — API returned empty transcript`);
           continue;
         }
 

--- a/src/services/dailyNoteBuilder.ts
+++ b/src/services/dailyNoteBuilder.ts
@@ -19,6 +19,7 @@ export interface NoteData {
   updatedAt?: string;
   attendees: string[];
   transcript?: string;
+  folders?: string[];
   markdown: string;
 }
 
@@ -119,7 +120,8 @@ export class DailyNoteBuilder {
    * @returns Map of date keys (YYYY-MM-DD) to arrays of note data with their source documents
    */
   buildDailyNotesMap(
-    documents: GranolaDoc[]
+    documents: GranolaDoc[],
+    docFolders: Record<string, string[]> = {}
   ): Map<string, Array<{ noteData: NoteData; doc: GranolaDoc }>> {
     const dailyNotesMap = new Map<
       string,
@@ -127,7 +129,12 @@ export class DailyNoteBuilder {
     >();
 
     for (const doc of documents) {
-      const noteData = this.documentProcessor.extractNoteForDailyNote(doc);
+      const folders = docFolders[doc.id];
+      const noteData = this.documentProcessor.extractNoteForDailyNote(
+        doc,
+        undefined,
+        folders
+      );
       if (!noteData) {
         continue;
       }
@@ -206,6 +213,10 @@ export class DailyNoteBuilder {
 
       if (note.transcript) {
         content += `**Transcript:** ${note.transcript}\n`;
+      }
+
+      if (note.folders && note.folders.length > 0) {
+        content += `**Folders:** ${note.folders.join(", ")}\n`;
       }
 
       content += `\n${note.markdown}\n`;

--- a/src/services/documentProcessor.ts
+++ b/src/services/documentProcessor.ts
@@ -5,7 +5,10 @@ import {
   resolveFilenamePattern,
 } from "../utils/filenameUtils";
 import { PathResolver } from "./pathResolver";
-import { formatAttendeesAsYaml } from "../utils/yamlUtils";
+import {
+  formatAttendeesAsYaml,
+  formatStringListAsYaml,
+} from "../utils/yamlUtils";
 
 export interface DocumentProcessorSettings {
   syncTranscripts: boolean;
@@ -23,6 +26,7 @@ export interface NoteMetadata {
   updatedAt?: string;
   attendees: string[];
   transcript?: string;
+  folders?: string[];
 }
 
 /**
@@ -31,6 +35,7 @@ export interface NoteMetadata {
 export interface MetadataOptions {
   type: "note" | "combined" | "transcript";
   transcriptPath?: string;
+  folders?: string[];
 }
 
 /**
@@ -77,6 +82,11 @@ export class DocumentProcessor {
     // Add transcript link if provided (only for individual note files)
     if (this.settings.syncTranscripts && options.transcriptPath) {
       metadata.transcript = options.transcriptPath;
+    }
+
+    // Add folder paths if provided and non-empty
+    if (options.folders && options.folders.length > 0) {
+      metadata.folders = options.folders;
     }
 
     return metadata;
@@ -131,12 +141,14 @@ export class DocumentProcessor {
    */
   prepareNote(
     doc: GranolaDoc,
-    transcriptPath?: string
+    transcriptPath?: string,
+    folders?: string[]
   ): { filename: string; content: string } {
     // Build metadata using shared builder
     const metadata = this.buildNoteMetadata(doc, {
       type: "note",
       transcriptPath,
+      folders,
     });
 
     // Build body using shared builder
@@ -157,6 +169,13 @@ export class DocumentProcessor {
     // Add transcript link to frontmatter if provided
     if (metadata.transcript) {
       frontmatterLines.push(`transcript: "[[${metadata.transcript}]]"`);
+    }
+
+    // Add folder paths if present
+    if (metadata.folders && metadata.folders.length > 0) {
+      frontmatterLines.push(
+        `folders: ${formatStringListAsYaml(metadata.folders)}`
+      );
     }
 
     frontmatterLines.push("---", "");
@@ -197,10 +216,11 @@ export class DocumentProcessor {
    */
   prepareCombinedNote(
     doc: GranolaDoc,
-    transcriptContent: string
+    transcriptContent: string,
+    folders?: string[]
   ): { filename: string; content: string } {
     // Build metadata using shared builder
-    const metadata = this.buildNoteMetadata(doc, { type: "combined" });
+    const metadata = this.buildNoteMetadata(doc, { type: "combined", folders });
 
     // Build body using shared builder
     const body = this.buildNoteBody(doc, { headingLevel: 2 });
@@ -218,6 +238,14 @@ export class DocumentProcessor {
     frontmatterLines.push(`attendees: ${formatAttendeesAsYaml(metadata.attendees)}`);
 
     // Note: Combined files do NOT include transcript or note link fields in frontmatter
+
+    // Add folder paths if present
+    if (metadata.folders && metadata.folders.length > 0) {
+      frontmatterLines.push(
+        `folders: ${formatStringListAsYaml(metadata.folders)}`
+      );
+    }
+
     frontmatterLines.push("---", "");
 
     let finalMarkdown = frontmatterLines.join("\n");
@@ -255,7 +283,8 @@ export class DocumentProcessor {
    */
   extractNoteForDailyNote(
     doc: GranolaDoc,
-    transcriptLink?: string
+    transcriptLink?: string,
+    folders?: string[]
   ): {
     title: string;
     docId: string;
@@ -264,6 +293,7 @@ export class DocumentProcessor {
     updatedAt?: string;
     attendees: string[];
     transcript?: string;
+    folders?: string[];
     markdown: string;
   } | null {
     try {
@@ -271,6 +301,7 @@ export class DocumentProcessor {
       const metadata = this.buildNoteMetadata(doc, {
         type: "note",
         transcriptPath: transcriptLink,
+        folders,
       });
 
       // Build body using shared builder with heading level 3
@@ -285,6 +316,7 @@ export class DocumentProcessor {
         updatedAt: metadata.updatedAt,
         attendees: metadata.attendees,
         transcript: metadata.transcript,
+        folders: metadata.folders,
         markdown: body,
       };
     } catch {

--- a/src/services/fileSyncService.ts
+++ b/src/services/fileSyncService.ts
@@ -419,7 +419,8 @@ export class FileSyncService {
     doc: GranolaDoc,
     documentProcessor: DocumentProcessor,
     transcriptContent: string,
-    forceOverwrite: boolean = false
+    forceOverwrite: boolean = false,
+    folders?: string[]
   ): Promise<boolean> {
     if (!doc.id) {
       log.error("Document missing required id field:", doc);
@@ -427,7 +428,8 @@ export class FileSyncService {
     }
     const { filename, content } = documentProcessor.prepareCombinedNote(
       doc,
-      transcriptContent
+      transcriptContent,
+      folders
     );
     const noteDate = getNoteDate(doc);
 
@@ -473,7 +475,8 @@ export class FileSyncService {
     doc: GranolaDoc,
     documentProcessor: DocumentProcessor,
     forceOverwrite: boolean = false,
-    transcriptPath?: string
+    transcriptPath?: string,
+    folders?: string[]
   ): Promise<boolean> {
     if (!doc.id) {
       log.error("Document missing required id field:", doc);
@@ -481,7 +484,8 @@ export class FileSyncService {
     }
     const { filename, content } = documentProcessor.prepareNote(
       doc,
-      transcriptPath
+      transcriptPath,
+      folders
     );
     const noteDate = getNoteDate(doc);
 

--- a/src/services/fileSyncService.ts
+++ b/src/services/fileSyncService.ts
@@ -248,6 +248,7 @@ export class FileSyncService {
   ): Promise<boolean> {
     const newFile = await this.app.vault.create(normalizedPath, content);
     this.updateCache(granolaId, newFile, type);
+    log.debug(`Created ${type} file: ${normalizedPath} (granolaId=${granolaId})`);
     return true;
   }
 
@@ -267,6 +268,7 @@ export class FileSyncService {
     // Skip update if content unchanged and not forcing overwrite
     if (!forceOverwrite && existingContent === content) {
       this.updateCache(granolaId, existingFile, type);
+      log.debug(`Skipped ${type} file — content unchanged: ${existingFile.path} (granolaId=${granolaId})`);
       return false;
     }
 
@@ -274,9 +276,11 @@ export class FileSyncService {
 
     // Handle path change (e.g., title changed)
     if (existingFile.path !== normalizedPath) {
+      log.debug(`Renaming ${type} file: ${existingFile.path} → ${normalizedPath} (granolaId=${granolaId})`);
       await this.attemptRename(existingFile, normalizedPath, granolaId, type);
     }
 
+    log.debug(`Updated ${type} file: ${existingFile.path} (granolaId=${granolaId})`);
     this.updateCache(granolaId, existingFile, type);
     return true;
   }
@@ -334,6 +338,7 @@ export class FileSyncService {
         const filenameWithoutExtension = resolvedFilename.replace(/\.md$/, "");
         const dateSuffix = formatDateForFilename(noteDate).replace(/\s+/g, "_");
         resolvedFilename = `${filenameWithoutExtension}-${dateSuffix}.md`;
+        log.debug(`Filename collision for granolaId=${granolaId} at ${filePath} — using suffix: ${resolvedFilename}`);
         filePath = normalizePath(`${folderPath}/${resolvedFilename}`);
       }
     }
@@ -356,10 +361,12 @@ export class FileSyncService {
   ): Promise<boolean> {
     const folderPath = this.resolveFolderPath(noteDate, isTranscript);
     if (!folderPath) {
+      log.debug(`Cannot resolve folder path for ${filename} (granolaId=${granolaId}, isTranscript=${isTranscript})`);
       return false;
     }
 
     if (!(await this.ensureFolder(folderPath))) {
+      log.debug(`Failed to create folder: ${folderPath} — skipping ${filename}`);
       new Notice(
         `Error creating folder: ${folderPath}. Skipping file: ${filename}`,
         7000
@@ -374,6 +381,7 @@ export class FileSyncService {
       isTranscript
     );
     if (!filePath) {
+      log.debug(`Cannot resolve file path for ${filename} (granolaId=${granolaId})`);
       return false;
     }
 
@@ -714,6 +722,7 @@ export class FileSyncService {
       // Save the downloaded image
       const buffer = response.arrayBuffer;
       await this.app.vault.createBinary(normalizedPath, buffer);
+      log.debug(`Saved image attachment: ${normalizedPath} (granolaId=${doc.id})`);
       return normalizedPath;
     } catch (error) {
       log.warn("Failed to download or save attachment image", {

--- a/src/services/folderMapBuilder.ts
+++ b/src/services/folderMapBuilder.ts
@@ -77,6 +77,8 @@ export async function buildFolderMap(
     };
   }
 
+  log.debug(`buildFolderMap — found ${Object.keys(folders).length} folder(s)`);
+
   // Step 2: Fetch document memberships for each folder
   const docFolders: Record<string, string[]> = {};
   const folderIds = Object.keys(folders);
@@ -85,6 +87,8 @@ export async function buildFolderMap(
     try {
       const listData = await fetchDocumentList(accessToken, folderId);
       const folderPath = resolveFolderPath(folderId, folders);
+      const docCount = listData.documents?.length ?? 0;
+      log.debug(`Folder "${folderPath}" (${folderId}) — ${docCount} document(s)`);
 
       for (const doc of listData.documents ?? []) {
         if (!docFolders[doc.id]) {
@@ -97,6 +101,9 @@ export async function buildFolderMap(
       // Continue with other folders — don't let one failure block everything
     }
   }
+
+  const docCount = Object.keys(docFolders).length;
+  log.debug(`buildFolderMap — ${docCount} document(s) mapped to folders`);
 
   return {
     folders,

--- a/src/services/folderMapBuilder.ts
+++ b/src/services/folderMapBuilder.ts
@@ -1,0 +1,156 @@
+import {
+  fetchDocumentListsMetadata,
+  fetchDocumentList,
+} from "./granolaApi";
+import { log } from "../utils/logger";
+
+/**
+ * Metadata for a single folder, used for hierarchy resolution and rename detection.
+ */
+export interface FolderInfo {
+  title: string;
+  parentId: string | null;
+}
+
+/**
+ * Persisted folder map data. Stored in plugin data.json across reloads.
+ */
+export interface FolderMapData {
+  /** Folder ID → folder metadata (for detecting renames/moves) */
+  folders: Record<string, FolderInfo>;
+  /** Document ID → array of full folder path strings */
+  docFolders: Record<string, string[]>;
+  /** Timestamp of when this map was last built */
+  lastUpdated: number;
+}
+
+/**
+ * Result of comparing a fresh folder map against a previously persisted one.
+ */
+export interface FolderMapDiff {
+  /** Map of old full path → new full path for all renamed/moved folders */
+  renamedPaths: Map<string, string>;
+}
+
+/**
+ * Resolves the full path for a folder by walking up the parent chain.
+ * e.g. "Good2Go" with parent "Clients" → "Clients/Good2Go"
+ */
+export function resolveFolderPath(
+  folderId: string,
+  folders: Record<string, FolderInfo>
+): string {
+  const parts: string[] = [];
+  let currentId: string | null = folderId;
+
+  // Walk up the parent chain, guarding against circular references
+  const visited = new Set<string>();
+  while (currentId && folders[currentId]) {
+    if (visited.has(currentId)) {
+      log.error(`Circular folder hierarchy detected at folder ${currentId}`);
+      break;
+    }
+    visited.add(currentId);
+    parts.unshift(folders[currentId].title);
+    currentId = folders[currentId].parentId;
+  }
+
+  return parts.join("/");
+}
+
+/**
+ * Builds a fresh FolderMapData by fetching all folder metadata and memberships
+ * from the Granola API.
+ */
+export async function buildFolderMap(
+  accessToken: string
+): Promise<FolderMapData> {
+  // Step 1: Fetch all folder metadata
+  const listsMetadata = await fetchDocumentListsMetadata(accessToken);
+
+  // Build folders record
+  const folders: Record<string, FolderInfo> = {};
+  for (const [id, meta] of Object.entries(listsMetadata)) {
+    folders[id] = {
+      title: meta.title,
+      parentId: meta.parent_document_list_id ?? null,
+    };
+  }
+
+  // Step 2: Fetch document memberships for each folder
+  const docFolders: Record<string, string[]> = {};
+  const folderIds = Object.keys(folders);
+
+  for (const folderId of folderIds) {
+    try {
+      const listData = await fetchDocumentList(accessToken, folderId);
+      const folderPath = resolveFolderPath(folderId, folders);
+
+      for (const doc of listData.documents ?? []) {
+        if (!docFolders[doc.id]) {
+          docFolders[doc.id] = [];
+        }
+        docFolders[doc.id].push(folderPath);
+      }
+    } catch (error) {
+      log.error(`Failed to fetch document list ${folderId}:`, error);
+      // Continue with other folders — don't let one failure block everything
+    }
+  }
+
+  return {
+    folders,
+    docFolders,
+    lastUpdated: Date.now(),
+  };
+}
+
+/**
+ * Compares a fresh folder map against a previously persisted one to detect
+ * folder renames and moves. Returns a map of old paths to new paths.
+ */
+export function diffFolderMaps(
+  previous: FolderMapData | null,
+  current: FolderMapData
+): FolderMapDiff {
+  const renamedPaths = new Map<string, string>();
+
+  if (!previous) {
+    return { renamedPaths };
+  }
+
+  // Check each folder that exists in both old and new maps
+  for (const folderId of Object.keys(current.folders)) {
+    const oldFolder = previous.folders[folderId];
+    if (!oldFolder) {
+      continue; // New folder, no rename to detect
+    }
+
+    const newFolder = current.folders[folderId];
+    const titleChanged = oldFolder.title !== newFolder.title;
+    const parentChanged = oldFolder.parentId !== newFolder.parentId;
+
+    if (titleChanged || parentChanged) {
+      const oldPath = resolveFolderPath(folderId, previous.folders);
+      const newPath = resolveFolderPath(folderId, current.folders);
+      if (oldPath !== newPath) {
+        renamedPaths.set(oldPath, newPath);
+      }
+    }
+  }
+
+  // A parent rename affects all children's resolved paths, even if the child
+  // folder itself didn't change. Check for any folder whose resolved path
+  // differs between old and new maps.
+  for (const folderId of Object.keys(current.folders)) {
+    if (!previous.folders[folderId]) continue;
+
+    const oldPath = resolveFolderPath(folderId, previous.folders);
+    const newPath = resolveFolderPath(folderId, current.folders);
+    if (oldPath !== newPath && !renamedPaths.has(oldPath)) {
+      renamedPaths.set(oldPath, newPath);
+    }
+  }
+
+  return { renamedPaths };
+}

--- a/src/services/granolaApi.ts
+++ b/src/services/granolaApi.ts
@@ -114,6 +114,7 @@ export async function fetchGranolaDocuments(
   limit: number = 100,
   offset: number = 0
 ): Promise<GranolaDoc[]> {
+  log.debug(`Fetching documents — offset=${offset}, limit=${limit}`);
   const response = await requestUrl({
     url: "https://api.granola.ai/v2/get-documents",
     method: "POST",
@@ -136,6 +137,7 @@ export async function fetchGranolaDocuments(
   const result = v.safeParse(GranolaApiResponseSchema, jsonResponse);
   if (!result.success) {
     log.error("Validation failed for GranolaApiResponseSchema:");
+    log.debug("Response keys:", Object.keys(jsonResponse ?? {}));
     printValidationIssuePaths(result);
     log.error(JSON.stringify(result.issues, null, 2));
 
@@ -143,6 +145,7 @@ export async function fetchGranolaDocuments(
       `Invalid response from Granola API (GranolaApiResponseSchema)`
     );
   }
+  log.debug(`Fetched ${result.output.docs.length} document(s) at offset=${offset}`);
   return result.output.docs as GranolaDoc[];
 }
 
@@ -227,6 +230,7 @@ export async function fetchGranolaTranscript(
   accessToken: string,
   docId: string
 ): Promise<TranscriptEntry[]> {
+  log.debug(`Fetching transcript for doc ${docId}`);
   const transcriptResp = await requestUrl({
     url: "https://api.granola.ai/v1/get-document-transcript",
     method: "POST",
@@ -243,6 +247,7 @@ export async function fetchGranolaTranscript(
   const result = v.safeParse(TranscriptResponseSchema, transcriptResp.json);
   if (!result.success) {
     log.error("Validation failed for TranscriptResponseSchema:");
+    log.debug("Transcript response type:", typeof transcriptResp.json, Array.isArray(transcriptResp.json) ? `length=${transcriptResp.json.length}` : "");
     printValidationIssuePaths(result);
     log.error(JSON.stringify(result.issues, null, 2));
 
@@ -250,5 +255,6 @@ export async function fetchGranolaTranscript(
       `Invalid transcript response from Granola API (TranscriptResponseSchema)`
     );
   }
+  log.debug(`Fetched ${result.output.length} transcript entry/entries for doc ${docId}`);
   return result.output as TranscriptEntry[];
 }

--- a/src/services/granolaApi.ts
+++ b/src/services/granolaApi.ts
@@ -2,61 +2,29 @@ import { requestUrl } from "obsidian";
 import * as v from "valibot";
 import {
   GranolaApiResponseSchema,
-  TranscriptEntrySchema,
   TranscriptResponseSchema,
+  DocumentListsMetadataResponseSchema,
+  DocumentListWithDocsResponseSchema,
 } from "./validationSchemas";
 import { log } from "../utils/logger";
 
-// ProseMirror types (defined explicitly due to recursive nature)
-export interface ProseMirrorNode {
-  type: string;
-  content?: ProseMirrorNode[];
-  text?: string;
-  attrs?: { [key: string]: unknown };
-}
+// Re-export all types so existing imports from "./granolaApi" continue to work
+export type {
+  ProseMirrorNode,
+  ProseMirrorDoc,
+  GranolaAttachment,
+  GranolaDoc,
+  TranscriptEntry,
+  DocumentListMetadata,
+  DocumentListWithDocs,
+} from "./granolaTypes";
 
-export interface ProseMirrorDoc {
-  type: "doc";
-  content: ProseMirrorNode[];
-}
-
-// GranolaDoc type (defined explicitly due to recursive nature of ProseMirrorDoc)
-export interface GranolaAttachment {
-  id: string;
-  url: string;
-  type?: string;
-  width?: number;
-  height?: number;
-  // Allow additional metadata fields without forcing callers to model them
-  // explicitly. This keeps the type aligned with the API while remaining
-  // forward-compatible.
-  [key: string]: unknown;
-}
-
-export interface GranolaDoc {
-  id: string;
-  title: string | null;
-  created_at?: string;
-  updated_at?: string;
-  attendees?: string[];
-  people?: {
-    attendees?: Array<{
-      name?: string;
-      email?: string;
-    }>;
-  };
-  last_viewed_panel?: {
-    content?: ProseMirrorDoc | string | null;
-  } | null;
-  notes_markdown?: string;
-   // Optional attachments array as returned by the Granola API. May be null when
-   // the doc has no attachments. Used primarily for image attachments synced
-   // into the Obsidian vault and embedded at the end of the note.
-  attachments?: GranolaAttachment[] | null;
-}
-
-// Infer TypeScript type from validation schema
-export type TranscriptEntry = v.InferOutput<typeof TranscriptEntrySchema>;
+import type {
+  GranolaDoc,
+  TranscriptEntry,
+  DocumentListMetadata,
+  DocumentListWithDocs,
+} from "./granolaTypes";
 
 /**
  * Helper function to print validation issue paths from a Valibot safeParse result.
@@ -257,4 +225,84 @@ export async function fetchGranolaTranscript(
   }
   log.debug(`Fetched ${result.output.length} transcript entry/entries for doc ${docId}`);
   return result.output as TranscriptEntry[];
+}
+
+/**
+ * Fetches metadata for all document lists (folders) the user has access to.
+ * Returns a record keyed by list ID.
+ */
+export async function fetchDocumentListsMetadata(
+  accessToken: string
+): Promise<Record<string, DocumentListMetadata>> {
+  log.debug("Fetching document lists metadata");
+  const response = await requestUrl({
+    url: "https://api.granola.ai/v1/get-document-lists-metadata",
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+      Accept: "*/*",
+      "User-Agent": `GranolaObsidianPlugin/${PLUGIN_VERSION}`,
+      "X-Client-Version": `GranolaObsidianPlugin/${PLUGIN_VERSION}`,
+    },
+    body: JSON.stringify({}),
+  });
+
+  const result = v.safeParse(
+    DocumentListsMetadataResponseSchema,
+    response.json
+  );
+  if (!result.success) {
+    log.error("Validation failed for DocumentListsMetadataResponseSchema:");
+    log.error(JSON.stringify(result.issues, null, 2));
+    throw new Error(
+      "Invalid response from Granola API (DocumentListsMetadataResponseSchema)"
+    );
+  }
+
+  const listCount = Object.keys(result.output.lists).length;
+  log.debug(`Fetched metadata for ${listCount} document list(s)`);
+  return result.output.lists as Record<string, DocumentListMetadata>;
+}
+
+/**
+ * Fetches a single document list (folder) including its document memberships.
+ * Only document IDs are extracted from the response.
+ */
+export async function fetchDocumentList(
+  accessToken: string,
+  listId: string
+): Promise<DocumentListWithDocs> {
+  log.debug(`Fetching document list ${listId}`);
+  const response = await requestUrl({
+    url: "https://api.granola.ai/v1/get-document-list",
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+      Accept: "*/*",
+      "User-Agent": `GranolaObsidianPlugin/${PLUGIN_VERSION}`,
+      "X-Client-Version": `GranolaObsidianPlugin/${PLUGIN_VERSION}`,
+    },
+    body: JSON.stringify({ list_id: listId }),
+  });
+
+  const result = v.safeParse(
+    DocumentListWithDocsResponseSchema,
+    response.json
+  );
+  if (!result.success) {
+    log.error(
+      `Validation failed for DocumentListWithDocsResponseSchema (list ${listId}):`
+    );
+    log.error(JSON.stringify(result.issues, null, 2));
+    throw new Error(
+      `Invalid response from Granola API (DocumentListWithDocsResponseSchema) for list ${listId}`
+    );
+  }
+
+  log.debug(
+    `Fetched document list "${result.output.title}" with ${result.output.documents?.length ?? 0} document(s)`
+  );
+  return result.output as DocumentListWithDocs;
 }

--- a/src/services/granolaTypes.ts
+++ b/src/services/granolaTypes.ts
@@ -1,0 +1,66 @@
+import * as v from "valibot";
+import {
+  TranscriptEntrySchema,
+  DocumentListMetadataEntrySchema,
+  DocumentListWithDocsResponseSchema,
+} from "./validationSchemas";
+
+// ProseMirror types (defined explicitly due to recursive nature)
+export interface ProseMirrorNode {
+  type: string;
+  content?: ProseMirrorNode[];
+  text?: string;
+  attrs?: { [key: string]: unknown };
+}
+
+export interface ProseMirrorDoc {
+  type: "doc";
+  content: ProseMirrorNode[];
+}
+
+// GranolaDoc type (defined explicitly due to recursive nature of ProseMirrorDoc)
+export interface GranolaAttachment {
+  id: string;
+  url: string;
+  type?: string;
+  width?: number;
+  height?: number;
+  // Allow additional metadata fields without forcing callers to model them
+  // explicitly. This keeps the type aligned with the API while remaining
+  // forward-compatible.
+  [key: string]: unknown;
+}
+
+export interface GranolaDoc {
+  id: string;
+  title: string | null;
+  created_at?: string;
+  updated_at?: string;
+  attendees?: string[];
+  people?: {
+    attendees?: Array<{
+      name?: string;
+      email?: string;
+    }>;
+  };
+  last_viewed_panel?: {
+    content?: ProseMirrorDoc | string | null;
+  } | null;
+  notes_markdown?: string;
+  // Optional attachments array as returned by the Granola API. May be null when
+  // the doc has no attachments. Used primarily for image attachments synced
+  // into the Obsidian vault and embedded at the end of the note.
+  attachments?: GranolaAttachment[] | null;
+}
+
+// Infer TypeScript types from validation schemas
+export type TranscriptEntry = v.InferOutput<typeof TranscriptEntrySchema>;
+
+// Document list (folder) types
+export type DocumentListMetadata = v.InferOutput<
+  typeof DocumentListMetadataEntrySchema
+>;
+
+export type DocumentListWithDocs = v.InferOutput<
+  typeof DocumentListWithDocsResponseSchema
+>;

--- a/src/services/validationSchemas.ts
+++ b/src/services/validationSchemas.ts
@@ -71,3 +71,30 @@ export const TranscriptEntrySchema = v.object({
 });
 
 export const TranscriptResponseSchema = v.array(TranscriptEntrySchema);
+
+// Document list (folder) validation schemas
+export const DocumentListMetadataEntrySchema = v.object({
+  id: v.string(),
+  title: v.string(),
+  parent_document_list_id: v.nullish(v.string()),
+  created_at: v.nullish(v.string()),
+  updated_at: v.nullish(v.string()),
+  is_default_folder: v.optional(v.boolean()),
+  sort_order: v.optional(v.number()),
+});
+
+export const DocumentListsMetadataResponseSchema = v.object({
+  lists: v.record(v.string(), DocumentListMetadataEntrySchema),
+});
+
+// For get-document-list response, we only need document IDs from the documents array
+const DocumentListDocRefSchema = v.object({
+  id: v.string(),
+});
+
+export const DocumentListWithDocsResponseSchema = v.object({
+  id: v.string(),
+  title: v.string(),
+  parent_document_list_id: v.nullish(v.string()),
+  documents: v.optional(v.array(DocumentListDocRefSchema), []),
+});

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,6 @@
 import { App, PluginSettingTab, Setting, Notice } from "obsidian";
 import type GranolaSync from "./main";
+import type { FolderMapData } from "./services/folderMapBuilder";
 
 /**
  * @deprecated These enums will be removed in version 3.0.0.
@@ -78,6 +79,8 @@ export type GranolaSyncSettings = NoteSettings &
   TranscriptSettings &
   AutomaticSyncSettings & {
     enableDebugLogging: boolean;
+    // Persisted folder map for detecting renames across syncs
+    _folderMapCache?: FolderMapData;
     // Legacy settings preserved for potential rollback
     _legacySettings?: {
       syncDestination?: SyncDestination;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -77,6 +77,7 @@ export interface AutomaticSyncSettings {
 export type GranolaSyncSettings = NoteSettings &
   TranscriptSettings &
   AutomaticSyncSettings & {
+    enableDebugLogging: boolean;
     // Legacy settings preserved for potential rollback
     _legacySettings?: {
       syncDestination?: SyncDestination;
@@ -110,6 +111,8 @@ export const DEFAULT_SETTINGS: GranolaSyncSettings = {
   customTranscriptBaseFolder: "Granola/Transcripts",
   transcriptSubfolderPattern: "none",
   transcriptFilenamePattern: "{title}-transcript",
+  // Debug / diagnostics
+  enableDebugLogging: false,
 };
 
 /**
@@ -648,6 +651,42 @@ export class GranolaSyncSettingTab extends PluginSettingTab {
             );
           }
         })
+      );
+
+    new Setting(containerEl)
+      .setName("Enable debug logging")
+      .setDesc(
+        "When enabled, writes detailed plugin logs to a granola-sync-debug.log file in the plugin folder. Disable when not needed."
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.enableDebugLogging)
+          .onChange(async (value) => {
+            this.plugin.settings.enableDebugLogging = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(containerEl)
+      .setName("Copy logs to clipboard")
+      .setDesc(
+        "Copy the current contents of the debug log file to your clipboard for debugging or bug reports."
+      )
+      .addButton((button) =>
+        button
+          .setButtonText("Copy logs to clipboard")
+          .onClick(async () => {
+            // Delegate to plugin so it can handle filesystem access and error handling
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const pluginWithMethod = this.plugin as any;
+            if (typeof pluginWithMethod.copyDebugLogsToClipboard === "function") {
+              await pluginWithMethod.copyDebugLogsToClipboard();
+            } else {
+              new Notice(
+                "Copying debug logs is not available in this environment."
+              );
+            }
+          })
       );
   }
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,40 +1,108 @@
-// Logger utility for consistent logging throughout the application
-// Uses console methods with consistent "[Granola Sync]" prefix
-// Debug and info messages are only shown in development mode
+// Logger utility for consistent logging throughout the application.
+// Uses console methods with a consistent "[Granola Sync]" prefix.
+// Debug and info messages are only shown in development mode for console output.
 
 const isDevelopment =
   !process.env.NODE_ENV || process.env.NODE_ENV === "development";
 
+type LogLevel = "debug" | "info" | "warn" | "error";
+
+interface FileLoggerConfig {
+  /**
+   * Returns true when debug logging to file should be active.
+   * This should typically read the current settings at call time so it always
+   * reflects the latest configuration without needing to reconfigure.
+   */
+  isDebugEnabled: () => boolean;
+
+  /**
+   * Append a single, already-formatted log line to the debug log file.
+   * This function is responsible for any filesystem concerns, including
+   * rotation and error handling. It must never throw.
+   */
+  appendLine: (line: string) => void | Promise<void>;
+}
+
+let fileLoggerConfig: FileLoggerConfig | null = null;
+
+export function configureLogger(config: FileLoggerConfig | null): void {
+  fileLoggerConfig = config;
+}
+
+function serializeArg(arg: unknown): string {
+  if (arg instanceof Error) {
+    return arg.stack || arg.message;
+  }
+
+  if (typeof arg === "object") {
+    try {
+      return JSON.stringify(arg);
+    } catch {
+      return String(arg);
+    }
+  }
+
+  return String(arg);
+}
+
+function logToFile(level: LogLevel, args: unknown[]): void {
+  if (!fileLoggerConfig || !fileLoggerConfig.isDebugEnabled()) {
+    return;
+  }
+
+  const timestamp = new Date().toISOString();
+  const message = args.map(serializeArg).join(" ");
+  const line = `${timestamp} [${level.toUpperCase()}] ${message}\n`;
+
+  try {
+    const result = fileLoggerConfig.appendLine(line);
+    if (result && typeof (result as Promise<void>).catch === "function") {
+      (result as Promise<void>).catch(() => {
+        // Swallow any async errors to avoid affecting plugin behavior
+      });
+    }
+  } catch {
+    // Swallow synchronous errors from appendLine as well
+  }
+}
+
 export const log = {
   /**
-   * Logs debug messages (only in development mode)
+   * Logs debug messages (only in development mode for console),
+   * but always eligible for file logging when debug logging is enabled.
    */
   debug: (...args: unknown[]) => {
-    if (isDevelopment) {
+    if (isDevelopment || fileLoggerConfig?.isDebugEnabled()) {
       console.debug("[Granola Sync]", ...args);
     }
+    logToFile("debug", args);
   },
 
   /**
-   * Logs informational messages (only in development mode)
+   * Logs informational messages (only in development mode for console),
+   * but always eligible for file logging when debug logging is enabled.
    */
   info: (...args: unknown[]) => {
-    if (isDevelopment) {
+    if (isDevelopment || fileLoggerConfig?.isDebugEnabled()) {
       console.info("[Granola Sync]", ...args);
     }
+    logToFile("info", args);
   },
 
   /**
-   * Logs warning messages
+   * Logs warning messages.
    */
   warn: (...args: unknown[]) => {
     console.warn("[Granola Sync]", ...args);
+    logToFile("warn", args);
   },
 
   /**
-   * Logs error messages (always shown, not filtered by development mode)
+   * Logs error messages (always shown, not filtered by development mode).
    */
   error: (...args: unknown[]) => {
     console.error("[Granola Sync]", ...args);
+    logToFile("error", args);
   },
 };
+

--- a/src/utils/yamlUtils.ts
+++ b/src/utils/yamlUtils.ts
@@ -1,19 +1,28 @@
 import { stringifyYaml } from "obsidian";
 
 /**
- * Formats an array of attendee names as a YAML value.
- * Each attendee is properly escaped and formatted with proper indentation.
+ * Formats an array of strings as a YAML list value.
+ * Each item is properly escaped and formatted with proper indentation.
  *
- * @param attendees - Array of attendee names
+ * @param items - Array of strings
  * @returns YAML-formatted string: "[]" for empty array, or newline + list items for non-empty array
  */
-export function formatAttendeesAsYaml(attendees: string[]): string {
-  if (attendees.length === 0) {
+export function formatStringListAsYaml(items: string[]): string {
+  if (items.length === 0) {
     return "[]";
   }
 
   return (
     "\n" +
-    attendees.map((name) => `  - ${stringifyYaml(name).trim()}`).join("\n")
+    items.map((item) => `  - ${stringifyYaml(item).trim()}`).join("\n")
   );
+}
+
+/**
+ * Formats an array of attendee names as a YAML value.
+ * @param attendees - Array of attendee names
+ * @returns YAML-formatted string
+ */
+export function formatAttendeesAsYaml(attendees: string[]): string {
+  return formatStringListAsYaml(attendees);
 }

--- a/tests/unit/fileSyncService.test.ts
+++ b/tests/unit/fileSyncService.test.ts
@@ -730,6 +730,7 @@ describe("FileSyncService", () => {
       expect(result).toBe(true);
       expect(mockDocumentProcessor.prepareNote).toHaveBeenCalledWith(
         doc,
+        undefined,
         undefined
       );
       expect(saveFileSpy).toHaveBeenCalledWith(
@@ -763,7 +764,8 @@ describe("FileSyncService", () => {
       expect(result).toBe(true);
       expect(mockDocumentProcessor.prepareNote).toHaveBeenCalledWith(
         doc,
-        "Transcripts/note-transcript.md"
+        "Transcripts/note-transcript.md",
+        undefined
       );
     });
 
@@ -820,6 +822,7 @@ describe("FileSyncService", () => {
 
       expect(mockDocumentProcessor.prepareNote).toHaveBeenCalledWith(
         doc,
+        undefined,
         undefined
       );
       expect(requestUrlSpy).toHaveBeenCalledTimes(1);
@@ -2007,7 +2010,8 @@ describe("FileSyncService", () => {
       expect(result).toBe(true);
       expect(mockDocumentProcessor.prepareCombinedNote).toHaveBeenCalledWith(
         mockDoc,
-        "## Transcript\n\nTranscript content"
+        "## Transcript\n\nTranscript content",
+        undefined
       );
       expect(mockApp.vault.create).toHaveBeenCalled();
       expect(fileSyncService.findByGranolaId("doc-123", "combined")).toBe(mockFile);

--- a/tests/unit/folderMapBuilder.test.ts
+++ b/tests/unit/folderMapBuilder.test.ts
@@ -1,0 +1,316 @@
+import {
+  resolveFolderPath,
+  buildFolderMap,
+  diffFolderMaps,
+  FolderMapData,
+  FolderInfo,
+} from "../../src/services/folderMapBuilder";
+import {
+  fetchDocumentListsMetadata,
+  fetchDocumentList,
+} from "../../src/services/granolaApi";
+
+jest.mock("../../src/services/granolaApi");
+jest.mock("../../src/utils/logger", () => ({
+  log: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe("folderMapBuilder", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("resolveFolderPath", () => {
+    it("should resolve a top-level folder path", () => {
+      const folders: Record<string, FolderInfo> = {
+        "folder-1": { title: "Marlu", parentId: null },
+      };
+
+      expect(resolveFolderPath("folder-1", folders)).toBe("Marlu");
+    });
+
+    it("should resolve a nested folder path", () => {
+      const folders: Record<string, FolderInfo> = {
+        "parent-1": { title: "Clients", parentId: null },
+        "child-1": { title: "Good2Go", parentId: "parent-1" },
+      };
+
+      expect(resolveFolderPath("child-1", folders)).toBe("Clients/Good2Go");
+    });
+
+    it("should resolve a deeply nested folder path", () => {
+      const folders: Record<string, FolderInfo> = {
+        "grandparent": { title: "Top", parentId: null },
+        "parent": { title: "Middle", parentId: "grandparent" },
+        "child": { title: "Bottom", parentId: "parent" },
+      };
+
+      expect(resolveFolderPath("child", folders)).toBe("Top/Middle/Bottom");
+    });
+
+    it("should handle missing parent gracefully", () => {
+      const folders: Record<string, FolderInfo> = {
+        "child-1": { title: "Orphan", parentId: "missing-parent" },
+      };
+
+      // Should just return the child title since parent is not in the map
+      expect(resolveFolderPath("child-1", folders)).toBe("Orphan");
+    });
+
+    it("should handle circular references", () => {
+      const folders: Record<string, FolderInfo> = {
+        "a": { title: "A", parentId: "b" },
+        "b": { title: "B", parentId: "a" },
+      };
+
+      // Should not infinite loop — just return whatever it can resolve
+      const result = resolveFolderPath("a", folders);
+      expect(result).toBeTruthy();
+      expect(result.split("/").length).toBeLessThanOrEqual(2);
+    });
+
+    it("should return empty string for unknown folder ID", () => {
+      const folders: Record<string, FolderInfo> = {};
+      expect(resolveFolderPath("unknown", folders)).toBe("");
+    });
+  });
+
+  describe("buildFolderMap", () => {
+    it("should build a complete folder map from API data", async () => {
+      (fetchDocumentListsMetadata as jest.Mock).mockResolvedValue({
+        "folder-1": {
+          id: "folder-1",
+          title: "Marlu",
+          parent_document_list_id: null,
+        },
+        "folder-2": {
+          id: "folder-2",
+          title: "Good2Go",
+          parent_document_list_id: "folder-3",
+        },
+        "folder-3": {
+          id: "folder-3",
+          title: "Clients",
+          parent_document_list_id: null,
+        },
+      });
+
+      (fetchDocumentList as jest.Mock)
+        .mockResolvedValueOnce({
+          id: "folder-1",
+          title: "Marlu",
+          parent_document_list_id: null,
+          documents: [{ id: "doc-1" }, { id: "doc-2" }],
+        })
+        .mockResolvedValueOnce({
+          id: "folder-2",
+          title: "Good2Go",
+          parent_document_list_id: "folder-3",
+          documents: [{ id: "doc-2" }, { id: "doc-3" }],
+        })
+        .mockResolvedValueOnce({
+          id: "folder-3",
+          title: "Clients",
+          parent_document_list_id: null,
+          documents: [],
+        });
+
+      const result = await buildFolderMap("test-token");
+
+      expect(result.folders).toEqual({
+        "folder-1": { title: "Marlu", parentId: null },
+        "folder-2": { title: "Good2Go", parentId: "folder-3" },
+        "folder-3": { title: "Clients", parentId: null },
+      });
+
+      // doc-1 is only in Marlu
+      expect(result.docFolders["doc-1"]).toEqual(["Marlu"]);
+      // doc-2 is in both Marlu and Clients/Good2Go
+      expect(result.docFolders["doc-2"]).toEqual(
+        expect.arrayContaining(["Marlu", "Clients/Good2Go"])
+      );
+      // doc-3 is only in Clients/Good2Go
+      expect(result.docFolders["doc-3"]).toEqual(["Clients/Good2Go"]);
+
+      expect(result.lastUpdated).toBeGreaterThan(0);
+    });
+
+    it("should handle empty folder list", async () => {
+      (fetchDocumentListsMetadata as jest.Mock).mockResolvedValue({});
+
+      const result = await buildFolderMap("test-token");
+
+      expect(result.folders).toEqual({});
+      expect(result.docFolders).toEqual({});
+      expect(fetchDocumentList).not.toHaveBeenCalled();
+    });
+
+    it("should continue when a single folder fetch fails", async () => {
+      (fetchDocumentListsMetadata as jest.Mock).mockResolvedValue({
+        "folder-1": {
+          id: "folder-1",
+          title: "Working",
+          parent_document_list_id: null,
+        },
+        "folder-2": {
+          id: "folder-2",
+          title: "Broken",
+          parent_document_list_id: null,
+        },
+      });
+
+      (fetchDocumentList as jest.Mock)
+        .mockResolvedValueOnce({
+          id: "folder-1",
+          title: "Working",
+          parent_document_list_id: null,
+          documents: [{ id: "doc-1" }],
+        })
+        .mockRejectedValueOnce(new Error("API error"));
+
+      const result = await buildFolderMap("test-token");
+
+      expect(result.docFolders["doc-1"]).toEqual(["Working"]);
+      expect(Object.keys(result.folders)).toHaveLength(2);
+    });
+
+    it("should handle folders with no documents array", async () => {
+      (fetchDocumentListsMetadata as jest.Mock).mockResolvedValue({
+        "folder-1": {
+          id: "folder-1",
+          title: "Empty",
+          parent_document_list_id: null,
+        },
+      });
+
+      (fetchDocumentList as jest.Mock).mockResolvedValue({
+        id: "folder-1",
+        title: "Empty",
+        parent_document_list_id: null,
+        documents: [],
+      });
+
+      const result = await buildFolderMap("test-token");
+
+      expect(result.docFolders).toEqual({});
+    });
+  });
+
+  describe("diffFolderMaps", () => {
+    it("should return empty diff when previous is null", () => {
+      const current: FolderMapData = {
+        folders: { "f1": { title: "Folder", parentId: null } },
+        docFolders: {},
+        lastUpdated: Date.now(),
+      };
+
+      const diff = diffFolderMaps(null, current);
+      expect(diff.renamedPaths.size).toBe(0);
+    });
+
+    it("should detect a simple folder rename", () => {
+      const previous: FolderMapData = {
+        folders: { "f1": { title: "Old Name", parentId: null } },
+        docFolders: { "doc-1": ["Old Name"] },
+        lastUpdated: Date.now() - 1000,
+      };
+
+      const current: FolderMapData = {
+        folders: { "f1": { title: "New Name", parentId: null } },
+        docFolders: { "doc-1": ["New Name"] },
+        lastUpdated: Date.now(),
+      };
+
+      const diff = diffFolderMaps(previous, current);
+      expect(diff.renamedPaths.get("Old Name")).toBe("New Name");
+    });
+
+    it("should detect a folder move (parent change)", () => {
+      const previous: FolderMapData = {
+        folders: {
+          "parent-1": { title: "Parent1", parentId: null },
+          "parent-2": { title: "Parent2", parentId: null },
+          "child": { title: "Child", parentId: "parent-1" },
+        },
+        docFolders: {},
+        lastUpdated: Date.now() - 1000,
+      };
+
+      const current: FolderMapData = {
+        folders: {
+          "parent-1": { title: "Parent1", parentId: null },
+          "parent-2": { title: "Parent2", parentId: null },
+          "child": { title: "Child", parentId: "parent-2" },
+        },
+        docFolders: {},
+        lastUpdated: Date.now(),
+      };
+
+      const diff = diffFolderMaps(previous, current);
+      expect(diff.renamedPaths.get("Parent1/Child")).toBe("Parent2/Child");
+    });
+
+    it("should detect cascade rename when parent is renamed", () => {
+      const previous: FolderMapData = {
+        folders: {
+          "parent": { title: "OldParent", parentId: null },
+          "child": { title: "Child", parentId: "parent" },
+        },
+        docFolders: {},
+        lastUpdated: Date.now() - 1000,
+      };
+
+      const current: FolderMapData = {
+        folders: {
+          "parent": { title: "NewParent", parentId: null },
+          "child": { title: "Child", parentId: "parent" },
+        },
+        docFolders: {},
+        lastUpdated: Date.now(),
+      };
+
+      const diff = diffFolderMaps(previous, current);
+      expect(diff.renamedPaths.get("OldParent")).toBe("NewParent");
+      expect(diff.renamedPaths.get("OldParent/Child")).toBe("NewParent/Child");
+    });
+
+    it("should not report unchanged folders", () => {
+      const data: FolderMapData = {
+        folders: {
+          "f1": { title: "Same", parentId: null },
+          "f2": { title: "AlsoSame", parentId: "f1" },
+        },
+        docFolders: {},
+        lastUpdated: Date.now(),
+      };
+
+      const diff = diffFolderMaps(data, data);
+      expect(diff.renamedPaths.size).toBe(0);
+    });
+
+    it("should handle new folders (no rename)", () => {
+      const previous: FolderMapData = {
+        folders: { "f1": { title: "Existing", parentId: null } },
+        docFolders: {},
+        lastUpdated: Date.now() - 1000,
+      };
+
+      const current: FolderMapData = {
+        folders: {
+          "f1": { title: "Existing", parentId: null },
+          "f2": { title: "NewFolder", parentId: null },
+        },
+        docFolders: {},
+        lastUpdated: Date.now(),
+      };
+
+      const diff = diffFolderMaps(previous, current);
+      expect(diff.renamedPaths.size).toBe(0);
+    });
+  });
+});

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -114,4 +114,131 @@ describe("logger", () => {
     });
   });
 
+  describe("file logging integration", () => {
+    it("should append a formatted line when debug logging is enabled", () => {
+      process.env.NODE_ENV = "production";
+      jest.resetModules();
+      const { log: prodLog, configureLogger } = require("../../src/utils/logger");
+      const appendLine = jest.fn();
+
+      configureLogger({
+        isDebugEnabled: () => true,
+        appendLine,
+      });
+
+      prodLog.debug("Debug message", { foo: "bar" });
+
+      expect(appendLine).toHaveBeenCalledTimes(1);
+      const line = appendLine.mock.calls[0][0] as string;
+      expect(line).toMatch(/^\d{4}-\d{2}-\d{2}T/); // ISO timestamp prefix
+      expect(line).toContain("[DEBUG]");
+      expect(line).toContain("Debug message");
+      expect(line).toContain('"foo":"bar"');
+      expect(line.endsWith("\n")).toBe(true);
+
+      configureLogger(null);
+    });
+
+    it("should not append when debug logging is disabled", () => {
+      process.env.NODE_ENV = "production";
+      jest.resetModules();
+      const { log: prodLog, configureLogger } = require("../../src/utils/logger");
+      const appendLine = jest.fn();
+
+      configureLogger({
+        isDebugEnabled: () => false,
+        appendLine,
+      });
+
+      prodLog.info("Info message");
+
+      expect(appendLine).not.toHaveBeenCalled();
+
+      configureLogger(null);
+    });
+
+    it("should log debug to console when isDebugEnabled returns true in production", () => {
+      process.env.NODE_ENV = "production";
+      jest.resetModules();
+      const { log: prodLog, configureLogger } = require("../../src/utils/logger");
+      const appendLine = jest.fn();
+
+      configureLogger({
+        isDebugEnabled: () => true,
+        appendLine,
+      });
+
+      prodLog.debug("Debug visible in prod");
+
+      expect(consoleDebugSpy).toHaveBeenCalledWith(
+        "[Granola Sync]",
+        "Debug visible in prod"
+      );
+
+      configureLogger(null);
+    });
+
+    it("should log info to console when isDebugEnabled returns true in production", () => {
+      process.env.NODE_ENV = "production";
+      jest.resetModules();
+      const { log: prodLog, configureLogger } = require("../../src/utils/logger");
+      const appendLine = jest.fn();
+
+      configureLogger({
+        isDebugEnabled: () => true,
+        appendLine,
+      });
+
+      prodLog.info("Info visible in prod");
+
+      expect(consoleInfoSpy).toHaveBeenCalledWith(
+        "[Granola Sync]",
+        "Info visible in prod"
+      );
+
+      configureLogger(null);
+    });
+
+    it("should not log debug to console when isDebugEnabled returns false in production", () => {
+      process.env.NODE_ENV = "production";
+      jest.resetModules();
+      const { log: prodLog, configureLogger } = require("../../src/utils/logger");
+      const appendLine = jest.fn();
+
+      configureLogger({
+        isDebugEnabled: () => false,
+        appendLine,
+      });
+
+      prodLog.debug("Should not appear");
+
+      expect(consoleDebugSpy).not.toHaveBeenCalled();
+
+      configureLogger(null);
+    });
+
+    it("should serialize Error instances in file logs", () => {
+      process.env.NODE_ENV = "production";
+      jest.resetModules();
+      const { log: prodLog, configureLogger } = require("../../src/utils/logger");
+      const appendLine = jest.fn();
+
+      configureLogger({
+        isDebugEnabled: () => true,
+        appendLine,
+      });
+
+      const error = new Error("Something went wrong");
+      prodLog.error("Error occurred", error);
+
+      expect(appendLine).toHaveBeenCalledTimes(1);
+      const line = appendLine.mock.calls[0][0] as string;
+      expect(line).toContain("[ERROR]");
+      expect(line).toContain("Error occurred");
+      expect(line).toContain("Something went wrong");
+
+      configureLogger(null);
+    });
+  });
+
 });

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -12,6 +12,7 @@ import { DocumentProcessor } from "../../src/services/documentProcessor";
 import { DailyNoteBuilder } from "../../src/services/dailyNoteBuilder";
 import { PathResolver } from "../../src/services/pathResolver";
 import { formatTranscriptBySpeaker } from "../../src/services/transcriptFormatter";
+import { buildFolderMap, diffFolderMaps } from "../../src/services/folderMapBuilder";
 import { getNoteDate } from "../../src/utils/dateUtils";
 import { showStatusBar, hideStatusBar, showStatusBarTemporary } from "../../src/utils/statusBar";
 import { Notice, App } from "obsidian";
@@ -26,6 +27,7 @@ jest.mock("../../src/services/documentProcessor");
 jest.mock("../../src/services/dailyNoteBuilder");
 jest.mock("../../src/services/pathResolver");
 jest.mock("../../src/services/transcriptFormatter");
+jest.mock("../../src/services/folderMapBuilder");
 jest.mock("../../src/utils/dateUtils");
 jest.mock("../../src/utils/statusBar");
 jest.mock("obsidian-daily-notes-interface");
@@ -119,6 +121,17 @@ describe("GranolaSync", () => {
 
     // Mock Notice
     (Notice as jest.Mock).mockImplementation(() => ({}));
+
+    // Mock folder map builder
+    (buildFolderMap as jest.Mock).mockResolvedValue({
+      folders: {},
+      docFolders: {},
+      lastUpdated: Date.now(),
+    });
+    (diffFolderMaps as jest.Mock).mockReturnValue({ renamedPaths: new Map() });
+
+    // Mock saveData to prevent actual writes
+    plugin.saveData = jest.fn().mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -462,7 +475,8 @@ describe("GranolaSync", () => {
       expect((plugin as any).syncNotes).toHaveBeenCalledWith(
         [mockDoc],
         false,
-        mockTranscriptMap
+        mockTranscriptMap,
+        {}
       );
     });
 
@@ -486,7 +500,8 @@ describe("GranolaSync", () => {
       expect((plugin as any).syncNotes).toHaveBeenCalledWith(
         [mockDoc],
         true,
-        mockTranscriptMap
+        mockTranscriptMap,
+        {}
       );
     });
 


### PR DESCRIPTION
## Summary

- Add configurable debug logging with timestamped log files for troubleshooting sync issues
- Add Granola folder/document list metadata to synced notes, showing folder hierarchy in frontmatter
- Persist folder map across plugin reloads to detect folder renames and update affected notes
- Extract API types to separate `granolaTypes.ts` for cleaner code organization

## Key changes

### Debug logging (#98)
- New `configureLogger()` with file-based log output to plugin directory
- Toggle via settings; logs include timestamps and structured context
- "Copy logs to clipboard" button in settings for easy bug reporting

### Folder metadata (#102)
- Fetch folder hierarchy from `get-document-lists-metadata` + `get-document-list` API endpoints
- Build `docId → folderPaths[]` map with full hierarchy resolution (e.g. `Clients/Good2Go`)
- Add `granola_folders` YAML list to note frontmatter; omit for docs with no folder
- Detect folder renames/moves by diffing persisted vs fresh folder map; update affected notes
- Thread folder data through entire sync pipeline (individual files, combined mode, daily notes)

### Refactoring
- Extract all API types from `granolaApi.ts` → `granolaTypes.ts` (re-exported for backward compat)
- Extract `formatStringListAsYaml()` helper in `yamlUtils.ts`

## Test plan
- [x] 16 new tests for `folderMapBuilder` (path resolution, map building, rename/move detection, edge cases)
- [x] New tests for logger configuration and output
- [x] Updated existing tests for new parameter signatures
- [x] All 403 tests pass, lint clean, TypeScript clean, production build clean

Closes #102
Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)