### PR TITLE
fix: sanitize titles in YAML frontmatter using stringifyYaml

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -13,7 +13,9 @@
       "Bash(gh pr create:*)",
       "Bash(gh pr view:*)",
       "Bash(git log:*)",
-      "Bash(git show:*)"
+      "Bash(git show:*)",
+      "WebFetch(domain:docs.obsidian.md)",
+      "Bash(npx eslint:*)"
     ],
     "deny": [],
     "ask": []

--- a/.cursor/commands/create-issue.md
+++ b/.cursor/commands/create-issue.md
@@ -1,5 +1,7 @@
 You are an expert software engineer creating a GitHub issue for a code change or bug fix.
 
+**Note:** The issue is for local reference only. Do not push it to GitHub—it is simply a useful reference that the work corresponds to a GitHub-style issue.
+
 Review the codebase context and user request carefully.
 
 # Clarification Questions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ The plugin uses a combination of unit and integration tests:
 ## Testing Changes
 
 - Make changes
-- Set env var `DEV_PLUGIN_PATH` to the Obsidian plugin dir. On macOS that is `~/Documents/Obsidian Vault/.obsidian/plugins/obsidian-granola-sync/main.js`
+- Set env var `DEV_PLUGIN_PATH` to the Obsidian plugin dir. On macOS that is `~/obsidian/Everything/.obsidian/plugins/granola-sync/main.js`
 - Use `npm run dev`
 - Either restart Obsidian between changes, or use the [hot reload plugin](https://github.com/pjeby/hot-reload)
 - Test changes worked in Obsidian

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -28,7 +28,7 @@ const DEV_PLUGIN_PATH =
   process.env.DEV_PLUGIN_PATH ||
   path.join(
     process.env.HOME,
-    "Documents/Obsidian Vault/.obsidian/plugins/granola-sync/main.js"
+    "obsidian/Everything/.obsidian/plugins/granola-sync/main.js"
   );
 
 function copyToDevPlugin() {

--- a/src/services/documentProcessor.ts
+++ b/src/services/documentProcessor.ts
@@ -1,3 +1,4 @@
+import { stringifyYaml } from "obsidian";
 import { GranolaDoc } from "./granolaApi";
 import { convertProsemirrorToMarkdown } from "./prosemirrorMarkdown";
 import {
@@ -155,11 +156,10 @@ export class DocumentProcessor {
     const body = this.buildNoteBody(doc, { headingLevel: 2 });
 
     // Prepare frontmatter
-    const escapedTitleForYaml = metadata.title.replace(/"/g, '\\"');
     const frontmatterLines = [
       "---",
       `granola_id: ${metadata.granolaId}`,
-      `title: "${escapedTitleForYaml}"`,
+      `title: ${stringifyYaml(metadata.title).trim()}`,
       `type: ${metadata.type}`,
     ];
     if (metadata.createdAt) frontmatterLines.push(`created: ${metadata.createdAt}`);
@@ -226,11 +226,10 @@ export class DocumentProcessor {
     const body = this.buildNoteBody(doc, { headingLevel: 2 });
 
     // Prepare frontmatter with type: combined
-    const escapedTitleForYaml = metadata.title.replace(/"/g, '\\"');
     const frontmatterLines = [
       "---",
       `granola_id: ${metadata.granolaId}`,
-      `title: "${escapedTitleForYaml}"`,
+      `title: ${stringifyYaml(metadata.title).trim()}`,
       `type: ${metadata.type}`,
     ];
     if (metadata.createdAt) frontmatterLines.push(`created: ${metadata.createdAt}`);

--- a/src/services/transcriptFormatter.ts
+++ b/src/services/transcriptFormatter.ts
@@ -1,3 +1,4 @@
+import { stringifyYaml } from "obsidian";
 import { TranscriptEntry } from "./granolaApi";
 import { formatAttendeesAsYaml } from "../utils/yamlUtils";
 
@@ -83,11 +84,10 @@ export function formatTranscriptBySpeaker(
   }
 
   // Add frontmatter with granola_id for transcript deduplication
-  const escapedTitleForYaml = title.replace(/"/g, '\\"');
   const frontmatterLines = [
     "---",
     `granola_id: ${granolaId}`,
-    `title: "${escapedTitleForYaml} - Transcript"`,
+    `title: ${stringifyYaml(`${title} - Transcript`).trim()}`,
     `type: transcript`,
   ];
   if (createdAt) frontmatterLines.push(`created: ${createdAt}`);

--- a/src/utils/filenameUtils.ts
+++ b/src/utils/filenameUtils.ts
@@ -8,7 +8,7 @@ import { getNoteDate, formatDateForFilename } from "./dateUtils";
  * @returns A sanitized filename safe for filesystem operations
  */
 export function sanitizeFilename(title: string): string {
-  const invalidChars = /[<>:"/\\|?*]/g;
+  const invalidChars = /[<>:"/\\|?*\r\n]/g;
   let filename = title.replace(invalidChars, "_");
   // Truncate filename if too long (e.g., 200 chars, common limit)
   const maxLength = 200;

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -53,14 +53,25 @@ export const Platform = {
  * Converts a JavaScript value to YAML format
  *
  * Note: We assume Obsidian's stringifyYaml handles proper escaping of special characters.
- * This mock simply returns the quoted string without escaping.
+ * This mock approximates real behavior: quotes strings containing special YAML
+ * characters and replaces newlines, and always appends a trailing newline.
  */
 export function stringifyYaml(value: unknown): string {
   if (typeof value === "string") {
-    return `${value}`;
+    // Approximate real YAML: quote if the string contains special characters
+    const needsQuoting = /["'\n\r:#{}[\],&*?|>!%@`]/.test(value);
+    if (needsQuoting) {
+      const escaped = value
+        .replace(/\\/g, "\\\\")
+        .replace(/"/g, '\\"')
+        .replace(/\n/g, "\\n")
+        .replace(/\r/g, "\\r");
+      return `"${escaped}"\n`;
+    }
+    return `${value}\n`;
   }
 
   // For arrays, objects, etc., use JSON stringification as a simple mock
   // In real Obsidian, this would use a proper YAML library
-  return JSON.stringify(value);
+  return JSON.stringify(value) + "\n";
 }

--- a/tests/unit/documentProcessor.test.ts
+++ b/tests/unit/documentProcessor.test.ts
@@ -90,7 +90,7 @@ describe("DocumentProcessor", () => {
       expect(result.filename).toBe("Test Note.md");
       expect(result.content).toContain("---");
       expect(result.content).toContain("granola_id: doc-123");
-      expect(result.content).toContain('title: "Test Note"');
+      expect(result.content).toContain("title: Test Note");
       expect(result.content).toContain("type: note");
       expect(result.content).toContain("created: 2024-01-15T10:00:00Z");
       expect(result.content).toContain("updated: 2024-01-15T12:00:00Z");
@@ -133,6 +133,28 @@ describe("DocumentProcessor", () => {
       const result = documentProcessor.prepareNote(doc);
 
       expect(result.content).toContain('title: "Note with \\"quotes\\""');
+    });
+
+    it("should sanitize newlines in titles for YAML frontmatter", () => {
+      const doc: GranolaDoc = {
+        id: "doc-newline",
+        title: "\nMeeting Title With Leading Newline",
+        last_viewed_panel: {
+          content: {
+            type: "doc",
+            content: [],
+          },
+        },
+      };
+
+      const result = documentProcessor.prepareNote(doc);
+
+      // Title should be on a single line — no raw newlines breaking YAML
+      const frontmatter = result.content.split("---")[1];
+      const titleLine = frontmatter.split("\n").find((l: string) => l.startsWith("title:"));
+      expect(titleLine).toBeDefined();
+      // The title value should not contain a raw newline
+      expect(titleLine).not.toMatch(/title:.*\n.*\n/);
     });
 
     it("should add transcript field to frontmatter when transcripts enabled and path provided", () => {
@@ -285,7 +307,7 @@ describe("DocumentProcessor", () => {
       const result = documentProcessor.prepareNote(doc);
 
       expect(result.content).toContain(
-        'title: "Untitled Granola Note at 2024-01-15 00-00-00"'
+        "title: Untitled Granola Note at 2024-01-15 00-00-00"
       );
     });
 
@@ -506,7 +528,7 @@ describe("DocumentProcessor", () => {
       expect(result.filename).toBe("Test Note.md");
       expect(result.content).toContain("---");
       expect(result.content).toContain("granola_id: doc-123");
-      expect(result.content).toContain('title: "Test Note"');
+      expect(result.content).toContain("title: Test Note");
       expect(result.content).toContain("type: combined");
       expect(result.content).toContain("created: 2024-01-15T10:00:00Z");
       expect(result.content).toContain("updated: 2024-01-15T12:00:00Z");
@@ -649,6 +671,31 @@ describe("DocumentProcessor", () => {
       expect(result.content).toContain('title: "Note with \\"quotes\\""');
     });
 
+    it("should sanitize newlines in titles for YAML frontmatter", () => {
+      const doc: GranolaDoc = {
+        id: "doc-newline",
+        title: "\nMeeting Title With Leading Newline",
+        last_viewed_panel: {
+          content: {
+            type: "doc",
+            content: [],
+          },
+        },
+      };
+
+      const transcriptContent = "## You (00:00:01)\n\nTest.\n\n";
+
+      const result = documentProcessor.prepareCombinedNote(
+        doc,
+        transcriptContent
+      );
+
+      const frontmatter = result.content.split("---")[1];
+      const titleLine = frontmatter.split("\n").find((l: string) => l.startsWith("title:"));
+      expect(titleLine).toBeDefined();
+      expect(titleLine).not.toMatch(/title:.*\n.*\n/);
+    });
+
     it("should place transcript content after note content", () => {
       const doc: GranolaDoc = {
         id: "doc-123",
@@ -710,7 +757,7 @@ describe("DocumentProcessor", () => {
       );
 
       expect(result.content).toContain(
-        'title: "Untitled Granola Note at 2024-01-15 00-00-00"'
+        "title: Untitled Granola Note at 2024-01-15 00-00-00"
       );
     });
   });

--- a/tests/unit/filenameUtils.test.ts
+++ b/tests/unit/filenameUtils.test.ts
@@ -57,6 +57,13 @@ describe("sanitizeFilename", () => {
     expect(result).toBe("file-name_with.special!chars@#$%^&()[]{}");
   });
 
+  it("should replace newlines and carriage returns with underscores", () => {
+    expect(sanitizeFilename("\nLeading newline")).toBe("_Leading newline");
+    expect(sanitizeFilename("Mid\nnewline")).toBe("Mid_newline");
+    expect(sanitizeFilename("CRLF\r\nending")).toBe("CRLF__ending");
+    expect(sanitizeFilename("CR\ronly")).toBe("CR_only");
+  });
+
   it("should handle mixed invalid characters and spaces", () => {
     const filename = "test: file / name * with ? invalid | chars";
     const result = sanitizeFilename(filename);

--- a/tests/unit/transcriptFormatter.test.ts
+++ b/tests/unit/transcriptFormatter.test.ts
@@ -44,7 +44,7 @@ describe("formatTranscriptBySpeaker", () => {
 
     expect(result).toContain("---");
     expect(result).toContain("granola_id: test-id");
-    expect(result).toContain('title: "Test Meeting - Transcript"');
+    expect(result).toContain("title: Test Meeting - Transcript");
     expect(result).toContain("type: transcript");
     expect(result).toContain("# Transcript for: Test Meeting");
     expect(result).toContain("## You (00:00:01)");
@@ -139,6 +139,31 @@ describe("formatTranscriptBySpeaker", () => {
     expect(result).toContain(
       'title: "Meeting \\"Project Alpha\\" - Transcript"'
     );
+  });
+
+  it("should sanitize newlines in title for YAML frontmatter", () => {
+    const transcriptData: TranscriptEntry[] = [
+      {
+        document_id: "doc1",
+        start_timestamp: "00:00:01",
+        end_timestamp: "00:00:05",
+        text: "Test text",
+        source: "microphone",
+        id: "entry1",
+        is_final: true,
+      },
+    ];
+
+    const result = formatTranscriptBySpeaker(
+      transcriptData,
+      "\nMeeting With Newline",
+      "test-id"
+    );
+
+    const frontmatter = result.split("---")[1];
+    const titleLine = frontmatter.split("\n").find((l: string) => l.startsWith("title:"));
+    expect(titleLine).toBeDefined();
+    expect(titleLine).not.toMatch(/title:.*\n.*\n/);
   });
 
   it("should distinguish between microphone and speaker sources", () => {


### PR DESCRIPTION
## Summary
- Replace manual `.replace(/"/g, '\\"')` title escaping with Obsidian's `stringifyYaml()` in all 3 frontmatter generation paths (`prepareNote`, `prepareCombinedNote`, `formatTranscriptBySpeaker`)
- Add newline/carriage return stripping to `sanitizeFilename()` to prevent newlines in derived file paths
- Update `stringifyYaml` mock to approximate real escaping behavior (quoting, newline escaping)

Closes #99

## Test plan
- [x] All 407 tests pass
- [x] Production build succeeds
- [ ] Manual: sync a document with a newline in its title — verify valid single-line YAML frontmatter
- [ ] Manual: verify existing documents with quotes in titles still sync correctly
- [ ] Manual: verify no "File already exists" loop on re-sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)