### PR TITLE
fix: Filter deleted documents from shared document batch during sync

### DIFF
--- a/src/services/granolaApi.ts
+++ b/src/services/granolaApi.ts
@@ -459,8 +459,14 @@ async function mergeSharedDocuments(
 
   try {
     const sharedDocs = await fetchDocumentsBatch(accessToken, missingIds);
-    log.debug(`Merged ${sharedDocs.length} shared document(s)`);
-    return [...ownedDocs, ...sharedDocs];
+    const activeDocs = sharedDocs.filter((doc) => !doc.deleted_at);
+    if (activeDocs.length < sharedDocs.length) {
+      log.debug(
+        `Filtered out ${sharedDocs.length - activeDocs.length} deleted document(s) from batch`
+      );
+    }
+    log.debug(`Merged ${activeDocs.length} shared document(s)`);
+    return [...ownedDocs, ...activeDocs];
   } catch (error) {
     log.error("Failed to fetch shared documents batch, continuing with owned docs only:", error);
     return ownedDocs;

--- a/src/services/granolaTypes.ts
+++ b/src/services/granolaTypes.ts
@@ -37,6 +37,7 @@ export interface GranolaDoc {
   title: string | null;
   created_at?: string;
   updated_at?: string;
+  deleted_at?: string | null;
   attendees?: string[];
   people?: {
     attendees?: Array<{

--- a/src/services/validationSchemas.ts
+++ b/src/services/validationSchemas.ts
@@ -21,6 +21,7 @@ export const GranolaDocSchema = v.object({
   title: v.nullish(v.string()),
   created_at: v.nullish(v.string()),
   updated_at: v.nullish(v.string()),
+  deleted_at: v.nullish(v.string()),
   // API may return null for docs with no attachments; optional allows key to be absent
   attachments: v.optional(
     v.nullish(

--- a/tests/unit/granolaApi.test.ts
+++ b/tests/unit/granolaApi.test.ts
@@ -798,6 +798,76 @@ describe("getAllDocuments", () => {
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("owned-1");
   });
+
+  it("should exclude deleted documents from batch results", async () => {
+    const deletedDoc = {
+      id: "deleted-1",
+      title: null,
+      deleted_at: "2024-01-14T10:00:00Z",
+      last_viewed_panel: { content: { type: "doc", content: [] } },
+    };
+    const activeSharedDoc = {
+      id: "shared-1",
+      title: "Active Shared Note",
+      deleted_at: null,
+      last_viewed_panel: { content: { type: "doc", content: [] } },
+    };
+
+    (requestUrl as jest.Mock)
+      .mockResolvedValueOnce({ json: { docs: [makeDoc("owned-1")] } })
+      .mockResolvedValueOnce({
+        json: {
+          documents: {
+            "owned-1": { updated_at: "2024-01-15T10:00:00Z", owner: true },
+            "shared-1": { updated_at: "2024-01-16T10:00:00Z", shared: true },
+            "deleted-1": { updated_at: "2024-01-14T10:00:00Z", shared: true },
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        json: { docs: [activeSharedDoc, deletedDoc] },
+      });
+
+    const result = await getAllDocuments(mockAccessToken);
+
+    expect(result).toHaveLength(2);
+    const ids = result.map((d) => d.id).sort();
+    expect(ids).toEqual(["owned-1", "shared-1"]);
+    expect(result.find((d) => d.id === "deleted-1")).toBeUndefined();
+  });
+
+  it("should exclude all batch docs when all are deleted", async () => {
+    const deletedDoc1 = {
+      id: "deleted-1",
+      title: null,
+      deleted_at: "2024-01-14T10:00:00Z",
+    };
+    const deletedDoc2 = {
+      id: "deleted-2",
+      title: null,
+      deleted_at: "2024-01-13T10:00:00Z",
+    };
+
+    (requestUrl as jest.Mock)
+      .mockResolvedValueOnce({ json: { docs: [makeDoc("owned-1")] } })
+      .mockResolvedValueOnce({
+        json: {
+          documents: {
+            "owned-1": { updated_at: "2024-01-15T10:00:00Z", owner: true },
+            "deleted-1": { updated_at: "2024-01-14T10:00:00Z" },
+            "deleted-2": { updated_at: "2024-01-13T10:00:00Z" },
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        json: { docs: [deletedDoc1, deletedDoc2] },
+      });
+
+    const result = await getAllDocuments(mockAccessToken);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("owned-1");
+  });
 });
 
 describe("getRecentDocuments", () => {
@@ -846,6 +916,36 @@ describe("getRecentDocuments", () => {
     expect(result).toHaveLength(2);
     const ids = result.map((d) => d.id).sort();
     expect(ids).toEqual(["owned-1", "shared-recent"]);
+  });
+
+  it("should exclude deleted shared docs from recent results", async () => {
+    const ownedDoc = makeDoc("owned-1", "2024-01-18T10:00:00Z");
+
+    (requestUrl as jest.Mock)
+      .mockResolvedValueOnce({ json: { docs: [ownedDoc] } })
+      .mockResolvedValueOnce({
+        json: {
+          documents: {
+            "owned-1": { updated_at: "2024-01-18T10:00:00Z", owner: true },
+            "shared-active": { updated_at: "2024-01-19T10:00:00Z", shared: true },
+            "shared-deleted": { updated_at: "2024-01-19T10:00:00Z", shared: true },
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        json: {
+          docs: [
+            { ...makeDoc("shared-active", "2024-01-19T10:00:00Z"), deleted_at: null },
+            { ...makeDoc("shared-deleted", "2024-01-19T10:00:00Z"), deleted_at: "2024-01-19T12:00:00Z" },
+          ],
+        },
+      });
+
+    const result = await getRecentDocuments(mockAccessToken, 7);
+
+    expect(result).toHaveLength(2);
+    const ids = result.map((d) => d.id).sort();
+    expect(ids).toEqual(["owned-1", "shared-active"]);
   });
 
   it("should delegate to getAllDocuments when daysBack is 0", async () => {


### PR DESCRIPTION
Filter deleted/trashed documents from shared document merging

- The document set endpoint (v1/get-document-set) includes IDs for deleted documents, causing the batch fetch to retrieve them and syncTranscripts() to fail with "Error fetching transcript for document" notices
- Added deleted_at field to GranolaDocSchema and GranolaDoc interface so the field survives API response validation
- Filter out any documents with deleted_at set after fetchDocumentsBatch() returns, before merging into the owned documents list

Test coverage
- Added tests verifying deleted docs are excluded when mixed with active shared docs
- Added test verifying all-deleted batch results in only owned docs returned
- Added test verifying deleted filtering works through the getRecentDocuments path with date cutoff