### PR TITLE
feat: Add setting to exclude shared notes from sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This plugin allows you to synchronize your notes and transcripts from Granola (h
 - Automatic bidirectional linking between notes and transcripts when using individual files
 - Periodic automatic syncing with customizable interval
 - Granular settings for notes and transcripts
+- Option to exclude shared notes and only sync notes you own
 - Customizable sync settings and destinations
 - **Platform support:** This plugin only works on desktop. It is not supported on mobile.
 
@@ -36,7 +37,8 @@ This plugin allows you to synchronize your notes and transcripts from Granola (h
 2. Configure transcript syncing:
    - Choose whether to sync transcripts
    - Select the destination: a dedicated transcripts folder or daily note folder structure
-3. Set up periodic sync and adjust the interval as desired
+3. Optionally enable "Exclude shared notes" to only sync notes you own
+4. Set up periodic sync and adjust the interval as desired
 
 ## Frontmatter Structure
 

--- a/docs/sync-process.md
+++ b/docs/sync-process.md
@@ -32,12 +32,6 @@ flowchart TD
     P --> H
 ```
 
-## Shared Document Filtering
-
-When the **"Exclude shared notes"** setting is enabled, the plugin filters out documents that have been shared with the user by others. After fetching all documents (owned and shared), it calls the document set API (`/v1/get-document-set`) to determine ownership. Only documents where the user is the owner are kept; shared-only documents are discarded before syncing notes or transcripts.
-
-If the document set API call fails, the plugin logs the error and continues with all fetched documents unfiltered.
-
 ## Credentials Loading
 
 The plugin loads credentials by reading directly from the filesystem. This approach provides secure access to credentials stored in the Granola application's data directory without requiring a temporary HTTP server.
@@ -124,6 +118,12 @@ The plugin handles various HTTP error codes:
 - **404**: API endpoint not found
 - **500+**: Server errors
 - **Other**: Network or connection errors
+
+## Shared Document Filtering
+
+When the **"Exclude shared notes"** setting is enabled, the plugin filters out documents that have been shared with the user by others. After fetching all documents (owned and shared), it calls the document set API (`/v1/get-document-set`) to determine ownership. Only documents where the user is the owner are kept; shared-only documents are discarded before syncing notes or transcripts.
+
+If the document set API call fails, the plugin logs the error and continues with all fetched documents unfiltered.
 
 ## Granola ID Cache
 

--- a/docs/sync-process.md
+++ b/docs/sync-process.md
@@ -17,7 +17,10 @@ flowchart TD
     E --> F[Fetch Documents from API]
     F --> G{Documents Found?}
     G -->|No| H[End Sync]
-    G -->|Yes| I{Transcripts Enabled?}
+    G -->|Yes| G2{Exclude Shared Notes?}
+    G2 -->|Yes| G3[Filter to Owned Documents]
+    G2 -->|No| I
+    G3 --> I{Transcripts Enabled?}
     I -->|Yes| J[Sync Transcripts]
     I -->|No| K[Skip Transcripts]
     J --> L{Notes Enabled?}
@@ -28,6 +31,12 @@ flowchart TD
     O --> P[Update Status Bar]
     P --> H
 ```
+
+## Shared Document Filtering
+
+When the **"Exclude shared notes"** setting is enabled, the plugin filters out documents that have been shared with the user by others. After fetching all documents (owned and shared), it calls the document set API (`/v1/get-document-set`) to determine ownership. Only documents where the user is the owner are kept; shared-only documents are discarded before syncing notes or transcripts.
+
+If the document set API call fails, the plugin logs the error and continues with all fetched documents unfiltered.
 
 ## Credentials Loading
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import {
 import {
   getAllDocuments,
   getRecentDocuments,
+  fetchDocumentSet,
   fetchGranolaTranscript,
   GranolaDoc,
   TranscriptEntry,
@@ -486,6 +487,20 @@ export default class GranolaSync extends Plugin {
       );
       hideStatusBar(this);
       return;
+    }
+
+    // Filter out shared documents if setting is enabled
+    if (this.settings.excludeSharedNotes) {
+      try {
+        const documentSet = await fetchDocumentSet(accessToken);
+        documents = documents.filter((doc) => {
+          const entry = documentSet[doc.id];
+          return !entry || entry.owner === true;
+        });
+        log.debug(`Filtered to ${documents.length} owned document(s)`);
+      } catch (error) {
+        log.error("Failed to fetch document set for filtering, continuing with all docs:", error);
+      }
     }
 
     showStatusBar(this, `Granola sync: Syncing ${documents.length} documents`);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -77,6 +77,7 @@ export interface AutomaticSyncSettings {
   syncInterval: number;
   latestSyncTime: number;
   syncDaysBack: number;
+  excludeSharedNotes: boolean;
 }
 
 export type GranolaSyncSettings = NoteSettings &
@@ -101,6 +102,7 @@ export const DEFAULT_SETTINGS: GranolaSyncSettings = {
   isSyncEnabled: false,
   syncInterval: 30 * 60, // every 30 minutes
   syncDaysBack: 7, // sync notes from last 7 days
+  excludeSharedNotes: false,
   // NoteSettings
   syncNotes: true,
   includePrivateNotes: false,
@@ -289,6 +291,20 @@ export class GranolaSyncSettingTab extends PluginSettingTab {
             } else {
               new Notice("Please enter a valid number for sync days.");
             }
+          })
+      );
+
+    new Setting(containerEl)
+      .setName("Exclude shared notes")
+      .setDesc(
+        "Skip notes that have been shared with you by others. When enabled, only notes you own will be synced."
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.excludeSharedNotes)
+          .onChange(async (value) => {
+            this.plugin.settings.excludeSharedNotes = value;
+            await this.plugin.saveSettings();
           })
       );
 

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -3,6 +3,7 @@ import { DEFAULT_SETTINGS, migrateSettingsToNewFormat } from "../../src/settings
 import {
   getAllDocuments,
   getRecentDocuments,
+  fetchDocumentSet,
   fetchGranolaTranscript,
   GranolaDoc,
 } from "../../src/services/granolaApi";
@@ -512,6 +513,67 @@ describe("GranolaSync", () => {
         mockTranscriptMap,
         {},
         mockTranscriptPathMap
+      );
+    });
+
+    it("should filter out shared documents when excludeSharedNotes is enabled", async () => {
+      const ownedDoc: GranolaDoc = {
+        id: "owned-1",
+        title: "My Note",
+        created_at: "2024-01-15T10:00:00Z",
+        last_viewed_panel: { content: { type: "doc", content: [] } },
+      };
+      const sharedDoc: GranolaDoc = {
+        id: "shared-1",
+        title: "Shared Note",
+        created_at: "2024-01-15T11:00:00Z",
+        last_viewed_panel: { content: { type: "doc", content: [] } },
+      };
+      plugin.settings = {
+        ...DEFAULT_SETTINGS,
+        syncNotes: true,
+        syncTranscripts: false,
+        excludeSharedNotes: true,
+      };
+      (getRecentDocuments as jest.Mock).mockResolvedValue([ownedDoc, sharedDoc]);
+      (fetchDocumentSet as jest.Mock).mockResolvedValue({
+        "owned-1": { updated_at: "2024-01-15T10:00:00Z", owner: true },
+        "shared-1": { updated_at: "2024-01-15T11:00:00Z", shared: true },
+      });
+      (plugin as any).syncNotes = jest.fn().mockResolvedValue(undefined);
+
+      await plugin.sync();
+
+      // syncNotes should only receive the owned document
+      expect((plugin as any).syncNotes).toHaveBeenCalledWith(
+        [ownedDoc],
+        false,
+        null,
+        {},
+        null
+      );
+    });
+
+    it("should not filter documents when excludeSharedNotes is disabled", async () => {
+      plugin.settings = {
+        ...DEFAULT_SETTINGS,
+        syncNotes: true,
+        syncTranscripts: false,
+        excludeSharedNotes: false,
+      };
+      (plugin as any).syncNotes = jest.fn().mockResolvedValue(undefined);
+
+      await plugin.sync();
+
+      // fetchDocumentSet should not be called at all
+      expect(fetchDocumentSet).not.toHaveBeenCalled();
+      // syncNotes receives the full doc list unchanged
+      expect((plugin as any).syncNotes).toHaveBeenCalledWith(
+        [mockDoc],
+        false,
+        null,
+        {},
+        null
       );
     });
 


### PR DESCRIPTION
## Summary

- Adds an **"Exclude shared notes"** toggle in the Automatic Sync settings section
- When enabled, documents shared with the user are filtered out after fetching — only notes the user owns are synced
- Default is off (existing behavior unchanged)

## How it works

After fetching all documents (owned + shared) via the existing `getAllDocuments`/`getRecentDocuments` flow, the plugin calls `fetchDocumentSet` to get ownership info and filters out any documents where the user is not the owner. This follows the same pattern used for `syncNotes`/`syncTranscripts` — fetch everything, then filter downstream based on settings.

## Changes

- `src/settings.ts` — New `excludeSharedNotes` boolean on `AutomaticSyncSettings` (default `false`), plus UI toggle
- `src/main.ts` — Post-fetch filter using `fetchDocumentSet` when setting is enabled
- `tests/unit/main.test.ts` — 2 new tests:
     - Verifies shared docs are filtered out and only owned docs reach `syncNotes` when `excludeSharedNotes` is enabled
     - Verifies `fetchDocumentSet` is not called and all docs pass through when the setting is disabled 

<img width="650" height="457" alt="image" src="https://github.com/user-attachments/assets/87de53fa-146a-444f-a1d2-8deb4e4a4837" />


## Test plan

- [x] All 437 existing tests pass
- [x] Build passes (`npm run build`)
- [x] Manually verified in Obsidian — toggle appears in settings, sync correctly excludes shared notes when enabled
- [x] 2 added tests pass