### PR TITLE
feat: Add setting to include/exclude shared notes from sync

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -435,13 +435,16 @@ export default class GranolaSync extends Plugin {
 
     // Fetch documents
     let documents: GranolaDoc[] = [];
+    const includeShared = this.settings.includeSharedNotes;
     try {
       if (mode === "full") {
-        documents = await getAllDocuments(accessToken);
+        documents = await getAllDocuments(accessToken, 100, includeShared);
       } else {
         documents = await getRecentDocuments(
           accessToken,
-          this.settings.syncDaysBack
+          this.settings.syncDaysBack,
+          100,
+          includeShared
         );
       }
     } catch (error: unknown) {

--- a/src/services/granolaApi.ts
+++ b/src/services/granolaApi.ts
@@ -389,30 +389,39 @@ export async function fetchDocumentsBatch(
 // ---------------------------------------------------------------------------
 
 /**
- * Fetches all documents the user has access to, including shared documents.
+ * Fetches all documents the user has access to.
  *
+ * When includeShared is true (default):
  * 1. Paginates through v2/get-documents (owned docs with full data)
  * 2. Fetches the document set to discover shared doc IDs
  * 3. Batch-fetches any documents present in the set but missing from step 1
+ *
+ * When includeShared is false, only owned documents are returned.
  */
 export async function getAllDocuments(
   accessToken: string,
-  pageSize: number = 100
+  pageSize: number = 100,
+  includeShared: boolean = true
 ): Promise<GranolaDoc[]> {
   const ownedDocs = await fetchAllGranolaDocuments(accessToken, pageSize);
+  if (!includeShared) return ownedDocs;
   return mergeSharedDocuments(accessToken, ownedDocs);
 }
 
 /**
- * Fetches recent documents (within daysBack), including shared documents.
+ * Fetches recent documents (within daysBack).
  * Pass daysBack=0 for a full sync.
+ *
+ * When includeShared is false, only owned documents are returned.
  */
 export async function getRecentDocuments(
   accessToken: string,
   daysBack: number,
-  pageSize: number = 100
+  pageSize: number = 100,
+  includeShared: boolean = true
 ): Promise<GranolaDoc[]> {
   const ownedDocs = await fetchGranolaDocumentsByDaysBack(accessToken, daysBack, pageSize);
+  if (!includeShared) return ownedDocs;
 
   const cutoffDate = daysBack > 0 ? new Date() : null;
   if (cutoffDate) cutoffDate.setDate(cutoffDate.getDate() - daysBack);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -31,6 +31,7 @@ export enum TranscriptDestination {
 export interface NoteSettings {
   syncNotes: boolean;
   includePrivateNotes: boolean;
+  includeSharedNotes: boolean;
   saveAsIndividualFiles: boolean; // true = files, false = sections
 
   // Only if saveAsIndividualFiles = true:
@@ -104,6 +105,7 @@ export const DEFAULT_SETTINGS: GranolaSyncSettings = {
   // NoteSettings
   syncNotes: true,
   includePrivateNotes: false,
+  includeSharedNotes: true,
   saveAsIndividualFiles: false, // Default to daily notes (sections)
   baseFolderType: "custom",
   customBaseFolder: "Granola",
@@ -326,6 +328,21 @@ export class GranolaSyncSettingTab extends PluginSettingTab {
               await this.plugin.saveSettings();
             })
         );
+
+      new Setting(containerEl)
+        .setName("Include shared notes")
+        .setDesc(
+          "Include notes that have been shared with you by others. When disabled, only notes you own will be synced."
+        )
+        .addToggle((toggle) =>
+          toggle
+            .setValue(this.plugin.settings.includeSharedNotes)
+            .onChange(async (value) => {
+              this.plugin.settings.includeSharedNotes = value;
+              await this.plugin.saveSettings();
+            })
+        );
+
       // How to package notes: individual files or sections in daily notes
       new Setting(containerEl)
         .setName("Save notes as")

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -434,7 +434,7 @@ describe("GranolaSync", () => {
 
       await plugin.sync({ mode: "full" });
 
-      expect(getAllDocuments).toHaveBeenCalledWith(mockAccessToken);
+      expect(getAllDocuments).toHaveBeenCalledWith(mockAccessToken, 100, true);
       expect(getRecentDocuments).not.toHaveBeenCalled();
     });
 
@@ -450,7 +450,9 @@ describe("GranolaSync", () => {
 
       expect(getRecentDocuments).toHaveBeenCalledWith(
         mockAccessToken,
-        7
+        7,
+        100,
+        true
       );
       expect(getAllDocuments).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## Summary

- Adds an **"Include shared notes"** toggle under the Notes settings section
- When disabled, shared documents are never fetched — the `mergeSharedDocuments` step is skipped entirely
- Default is **on** (existing behavior unchanged)

## Changes

Based on the idea from #112 by @TheBigLou, reimplemented to:

1. **Move the toggle** from Automatic Sync to the Notes section (below "Include Private Notes"), since it's a content filter not a sync-timing setting
2. **Rename to positive form** (`includeSharedNotes`, default `true`) instead of `excludeSharedNotes` (default `false`)
3. **Push filtering into the API layer** — `getAllDocuments`/`getRecentDocuments` accept an `includeShared` param. When `false`, the `mergeSharedDocuments` call is skipped entirely, avoiding a redundant `fetchDocumentSet` + batch fetch for docs that would be immediately discarded

Closes #112

## Test plan

- [x] All 437 existing tests pass
- [x] Build passes (`npm run build`)
- [x] Updated test assertions to match new function signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)