### PR TITLE
fix: link to actual saved path for collision-resolved note filenames

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -775,7 +775,12 @@ export default class GranolaSync extends Plugin {
             )
           ) {
             syncedCount++;
-            syncedNotes.push({ doc, notePath });
+            // Use the actual on-disk path to handle collision-resolved filenames
+            // (recurring meetings share a title, so later saves get a date suffix).
+            const actualPath =
+              this.fileSyncService.findByGranolaId(doc.id, "combined")?.path ??
+              notePath;
+            syncedNotes.push({ doc, notePath: actualPath });
           }
         } else {
           // No transcript available, save as regular note
@@ -789,7 +794,10 @@ export default class GranolaSync extends Plugin {
             )
           ) {
             syncedCount++;
-            syncedNotes.push({ doc, notePath });
+            const actualPath =
+              this.fileSyncService.findByGranolaId(doc.id, "note")?.path ??
+              notePath;
+            syncedNotes.push({ doc, notePath: actualPath });
           }
         }
       } else {
@@ -823,7 +831,10 @@ export default class GranolaSync extends Plugin {
           )
         ) {
           syncedCount++;
-          syncedNotes.push({ doc, notePath });
+          const actualPath =
+            this.fileSyncService.findByGranolaId(doc.id, "note")?.path ??
+            notePath;
+          syncedNotes.push({ doc, notePath: actualPath });
         }
       }
     }

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -615,4 +615,81 @@ describe("GranolaSync", () => {
     });
   });
 
+  describe("syncNotesToIndividualFiles synced note paths", () => {
+    const docWithContent: GranolaDoc = {
+      id: "doc-recurring-1",
+      title: "Daily Scrum",
+      created_at: "2024-01-15T10:00:00Z",
+      updated_at: "2024-01-15T12:00:00Z",
+      last_viewed_panel: {
+        content: {
+          type: "doc",
+          content: [],
+        },
+      },
+    };
+
+    beforeEach(() => {
+      plugin.settings = {
+        ...DEFAULT_SETTINGS,
+        syncNotes: true,
+        syncTranscripts: false,
+        saveAsIndividualFiles: true,
+      };
+      (plugin as any).initializeServices();
+      mockPathResolver.computeNotePath.mockReturnValue(
+        "Granola/Notes/2024-01/Daily Scrum.md"
+      );
+      mockFileSyncService.saveNoteToDisk.mockResolvedValue(true);
+    });
+
+    // Simulates a recurring meeting: a prior occurrence in the month already
+    // owns the clean filename, so this save was collision-resolved with a
+    // date suffix. syncedNotes must carry the actual saved path so daily-note
+    // links resolve to this note and not the earlier one.
+    it("should use the actual on-disk path for collision-resolved note filenames", async () => {
+      const actualSavedPath =
+        "Granola/Notes/2024-01/Daily Scrum-2024-01-15_10-00-00.md";
+      mockFileSyncService.findByGranolaId.mockImplementation(
+        (granolaId, type) => {
+          if (granolaId === "doc-recurring-1" && type === "note") {
+            return { path: actualSavedPath } as any;
+          }
+          return null;
+        }
+      );
+
+      const result = await (plugin as any).syncNotesToIndividualFiles(
+        [docWithContent],
+        true,
+        null,
+        {},
+        null
+      );
+
+      expect(result.syncedNotes).toEqual([
+        { doc: docWithContent, notePath: actualSavedPath },
+      ]);
+    });
+
+    it("should fall back to the computed path when the note is not yet in the cache", async () => {
+      mockFileSyncService.findByGranolaId.mockReturnValue(null);
+
+      const result = await (plugin as any).syncNotesToIndividualFiles(
+        [docWithContent],
+        true,
+        null,
+        {},
+        null
+      );
+
+      expect(result.syncedNotes).toEqual([
+        {
+          doc: docWithContent,
+          notePath: "Granola/Notes/2024-01/Daily Scrum.md",
+        },
+      ]);
+    });
+  });
+
 });


### PR DESCRIPTION
## Summary

"Link from Daily Notes" writes wikilinks to the wrong meeting note when a note title has collided on filename. For recurring meetings (same title multiple times per month), every day's daily note links back to the first occurrence of the month instead of that day's meeting.

## Repro

- Individual files + "Link from Daily Notes" enabled; monthly subfolders
- Recurring meeting "Daily Scrum", twice in January
- First save: `Granola/Notes/2024-01/Daily Scrum.md`
- Second save is collision-resolved by `FileSyncService.resolveFilePath`: `Granola/Notes/2024-01/Daily Scrum-2024-01-15_10-00-00.md`
- The second day's daily note still contains `[[Granola/Notes/2024-01/Daily Scrum|...]]`, pointing at the first occurrence

## Root cause

`syncNotesToIndividualFiles` (`src/main.ts`) precomputes `notePath` from `pathResolver.computeNotePath(doc)` before save and pushes that path into `syncedNotes`. But `saveNoteToDisk` / `saveCombinedNoteToDisk` call `resolveFilePath` internally, which applies the collision suffix -- and the resolved path is lost because those functions return `boolean`.

`addLinksToDailyNotes` then builds the wikilink directly from the stale path. Because recurring meetings share a title, `computeNotePath` returns the same path for every occurrence, so every link resolves to the first file that won the clean filename.

## Fix

After a successful save, look up the actual on-disk path via `findByGranolaId`, falling back to the computed path if the cache lookup fails. This mirrors the transcript fallback pattern already present in this same function (#transcripts collision work, commit `7492c89`). Applied at all three push sites: combined save, combined-mode-no-transcript save, and regular save.

## Alternative

I'm preparing a follow-up PR that changes `saveNoteToDisk` / `saveCombinedNoteToDisk` to return `{ saved, path }` consistent with `saveTranscriptToDisk`. Same bug fix, broader touch; happy with whichever shape you prefer.

## Test plan

- [x] New failing test covering collision-resolved paths
- [x] Regression test for fallback to the computed path when cache lookup returns null
- [x] `npm test` (449 passing, was 447)
- [x] `npm run lint`
- [x] `tsc -p . -noEmit -skipLibCheck`