### PR TITLE
fix: return resolved on-disk path from saveNoteToDisk and saveCombinedNoteToDisk

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -765,31 +765,31 @@ export default class GranolaSync extends Plugin {
         const transcriptData = transcriptDataMap.get(doc.id || "");
         if (transcriptData && transcriptData.length > 0) {
           const transcriptBody = formatTranscriptBody(transcriptData);
-          if (
-            await this.fileSyncService.saveCombinedNoteToDisk(
-              doc,
-              this.documentProcessor,
-              transcriptBody,
-              forceOverwrite,
-              folders
-            )
-          ) {
+          const result = await this.fileSyncService.saveCombinedNoteToDisk(
+            doc,
+            this.documentProcessor,
+            transcriptBody,
+            forceOverwrite,
+            folders
+          );
+          if (result.saved) {
             syncedCount++;
-            syncedNotes.push({ doc, notePath });
+            // Use the actual on-disk path to handle collision-resolved filenames
+            // (recurring meetings share a title, so later saves get a date suffix).
+            syncedNotes.push({ doc, notePath: result.path ?? notePath });
           }
         } else {
           // No transcript available, save as regular note
-          if (
-            await this.fileSyncService.saveNoteToDisk(
-              doc,
-              this.documentProcessor,
-              forceOverwrite,
-              undefined,
-              folders
-            )
-          ) {
+          const result = await this.fileSyncService.saveNoteToDisk(
+            doc,
+            this.documentProcessor,
+            forceOverwrite,
+            undefined,
+            folders
+          );
+          if (result.saved) {
             syncedCount++;
-            syncedNotes.push({ doc, notePath });
+            syncedNotes.push({ doc, notePath: result.path ?? notePath });
           }
         }
       } else {
@@ -813,17 +813,16 @@ export default class GranolaSync extends Plugin {
           }
         }
 
-        if (
-          await this.fileSyncService.saveNoteToDisk(
-            doc,
-            this.documentProcessor,
-            forceOverwrite,
-            transcriptPath ?? undefined,
-            folders
-          )
-        ) {
+        const result = await this.fileSyncService.saveNoteToDisk(
+          doc,
+          this.documentProcessor,
+          forceOverwrite,
+          transcriptPath ?? undefined,
+          folders
+        );
+        if (result.saved) {
           syncedCount++;
-          syncedNotes.push({ doc, notePath });
+          syncedNotes.push({ doc, notePath: result.path ?? notePath });
         }
       }
     }

--- a/src/services/fileSyncService.ts
+++ b/src/services/fileSyncService.ts
@@ -421,10 +421,10 @@ export class FileSyncService {
     transcriptContent: string,
     forceOverwrite: boolean = false,
     folders?: string[]
-  ): Promise<boolean> {
+  ): Promise<{ saved: boolean; path: string | null }> {
     if (!doc.id) {
       log.error("Document missing required id field:", doc);
-      return false;
+      return { saved: false, path: null };
     }
     const prepared = documentProcessor.prepareCombinedNote(
       doc,
@@ -433,7 +433,7 @@ export class FileSyncService {
     );
     if (!prepared) {
       log.debug(`Skipping combined doc ${doc.id} — no parseable content`);
-      return false;
+      return { saved: false, path: null };
     }
     const { filename, content } = prepared;
     const noteDate = getNoteDate(doc);
@@ -441,7 +441,7 @@ export class FileSyncService {
     // Resolve folder path (combined files use note folder path, not transcript folder)
     const folderPath = this.resolveFolderPath(noteDate, false);
     if (!folderPath) {
-      return false;
+      return { saved: false, path: null };
     }
 
     if (!(await this.ensureFolder(folderPath))) {
@@ -449,12 +449,12 @@ export class FileSyncService {
         `Error creating folder: ${folderPath}. Skipping file: ${filename}`,
         7000
       );
-      return false;
+      return { saved: false, path: null };
     }
 
     const filePath = this.resolveFilePath(filename, noteDate, doc.id, false);
     if (!filePath) {
-      return false;
+      return { saved: false, path: null };
     }
 
     const contentWithAttachments = await this.appendImageEmbedsForAttachments(
@@ -464,13 +464,22 @@ export class FileSyncService {
     );
 
     // Save with type "combined"
-    return this.saveFile(
+    const saved = await this.saveFile(
       filePath,
       contentWithAttachments,
       doc.id,
       "combined",
       forceOverwrite
     );
+
+    // Return the actual on-disk path. When we try to rename to the "ideal"
+    // collision-free filename and `vault.rename()` fails, we must not return
+    // the attempted destination path (which would break daily-note links).
+    const savedFile = this.findByGranolaId(doc.id, "combined");
+    const actualPath =
+      savedFile?.path ? normalizePath(savedFile.path) : filePath;
+
+    return { saved, path: actualPath };
   }
 
   /**
@@ -482,10 +491,10 @@ export class FileSyncService {
     forceOverwrite: boolean = false,
     transcriptPath?: string,
     folders?: string[]
-  ): Promise<boolean> {
+  ): Promise<{ saved: boolean; path: string | null }> {
     if (!doc.id) {
       log.error("Document missing required id field:", doc);
-      return false;
+      return { saved: false, path: null };
     }
     const prepared = documentProcessor.prepareNote(
       doc,
@@ -494,14 +503,14 @@ export class FileSyncService {
     );
     if (!prepared) {
       log.debug(`Skipping doc ${doc.id} — no parseable content`);
-      return false;
+      return { saved: false, path: null };
     }
     const { filename, content } = prepared;
     const noteDate = getNoteDate(doc);
 
     const folderPath = this.resolveFolderPath(noteDate, false);
     if (!folderPath) {
-      return false;
+      return { saved: false, path: null };
     }
 
     if (!(await this.ensureFolder(folderPath))) {
@@ -509,12 +518,12 @@ export class FileSyncService {
         `Error creating folder: ${folderPath}. Skipping file: ${filename}`,
         7000
       );
-      return false;
+      return { saved: false, path: null };
     }
 
     const filePath = this.resolveFilePath(filename, noteDate, doc.id, false);
     if (!filePath) {
-      return false;
+      return { saved: false, path: null };
     }
 
     const contentWithAttachments = await this.appendImageEmbedsForAttachments(
@@ -523,13 +532,22 @@ export class FileSyncService {
       filePath
     );
 
-    return this.saveFile(
+    const saved = await this.saveFile(
       filePath,
       contentWithAttachments,
       doc.id,
       "note",
       forceOverwrite
     );
+
+    // Return the actual on-disk path. When we try to rename to the "ideal"
+    // collision-free filename and `vault.rename()` fails, we must not return
+    // the attempted destination path (which would break daily-note links).
+    const savedFile = this.findByGranolaId(doc.id, "note");
+    const actualPath =
+      savedFile?.path ? normalizePath(savedFile.path) : filePath;
+
+    return { saved, path: actualPath };
   }
 
   /**

--- a/tests/unit/fileSyncService.test.ts
+++ b/tests/unit/fileSyncService.test.ts
@@ -697,7 +697,7 @@ describe("FileSyncService", () => {
       } as unknown as jest.Mocked<DocumentProcessor>;
     });
 
-    it("should return false when doc id is missing", async () => {
+    it("should return saved:false and path:null when doc id is missing", async () => {
       const doc = { title: "No ID" } as GranolaDoc;
 
       const result = await fileSyncService.saveNoteToDisk(
@@ -705,8 +705,40 @@ describe("FileSyncService", () => {
         mockDocumentProcessor
       );
 
-      expect(result).toBe(false);
+      expect(result).toEqual({ saved: false, path: null });
       expect(mockDocumentProcessor.prepareNote).not.toHaveBeenCalled();
+    });
+
+    it("should return cached note path after save when rename target conflicts", async () => {
+      const doc = { id: "doc-1" } as GranolaDoc;
+      const noteDate = new Date("2024-01-15T10:00:00Z");
+      mockDocumentProcessor.prepareNote.mockReturnValue({
+        filename: "Daily Scrum.md",
+        content: "content",
+      });
+      jest.spyOn(dateUtils, "getNoteDate").mockReturnValue(noteDate);
+      jest.spyOn(fileSyncService, "saveFile" as any).mockResolvedValue(true);
+      jest
+        .spyOn(fileSyncService, "findByGranolaId")
+        .mockImplementation((granolaId, type) => {
+          if (granolaId === "doc-1" && type === "note") {
+            return {
+              path: "granola-folder/Daily Scrum-2024-01-15_10-00-00.md",
+              extension: "md",
+            } as TFile;
+          }
+          return null;
+        });
+
+      const result = await fileSyncService.saveNoteToDisk(
+        doc,
+        mockDocumentProcessor
+      );
+
+      expect(result).toEqual({
+        saved: true,
+        path: "granola-folder/Daily Scrum-2024-01-15_10-00-00.md",
+      });
     });
 
     it("should prepare note and delegate to saveToDisk", async () => {
@@ -726,7 +758,7 @@ describe("FileSyncService", () => {
         mockDocumentProcessor
       );
 
-      expect(result).toBe(true);
+      expect(result.saved).toBe(true);
       expect(mockDocumentProcessor.prepareNote).toHaveBeenCalledWith(
         doc,
         undefined,
@@ -749,9 +781,7 @@ describe("FileSyncService", () => {
         content: "content",
       });
       jest.spyOn(dateUtils, "getNoteDate").mockReturnValue(noteDate);
-      const saveToDiskSpy = jest
-        .spyOn(fileSyncService, "saveToDisk")
-        .mockResolvedValue(true);
+      jest.spyOn(fileSyncService, "saveFile" as any).mockResolvedValue(true);
 
       const result = await fileSyncService.saveNoteToDisk(
         doc,
@@ -760,7 +790,7 @@ describe("FileSyncService", () => {
         "Transcripts/note-transcript.md"
       );
 
-      expect(result).toBe(true);
+      expect(result.saved).toBe(true);
       expect(mockDocumentProcessor.prepareNote).toHaveBeenCalledWith(
         doc,
         "Transcripts/note-transcript.md",
@@ -1381,7 +1411,7 @@ describe("FileSyncService", () => {
       expect(savedContent).toMatch(/att-gif\.gif/);
     });
 
-    it("should return false when folder path cannot be resolved", async () => {
+    it("should return saved:false and path:null when folder path cannot be resolved", async () => {
       const doc: GranolaDoc = {
         id: "doc-no-folder",
         title: "Note Without Folder",
@@ -1404,10 +1434,10 @@ describe("FileSyncService", () => {
         undefined
       );
 
-      expect(result).toBe(false);
+      expect(result).toEqual({ saved: false, path: null });
     });
 
-    it("should return false when folder creation fails", async () => {
+    it("should return saved:false and path:null when folder creation fails", async () => {
       const doc: GranolaDoc = {
         id: "doc-folder-fail",
         title: "Note With Folder Creation Failure",
@@ -1433,10 +1463,10 @@ describe("FileSyncService", () => {
         undefined
       );
 
-      expect(result).toBe(false);
+      expect(result).toEqual({ saved: false, path: null });
     });
 
-    it("should return false when file path cannot be resolved", async () => {
+    it("should return saved:false and path:null when file path cannot be resolved", async () => {
       const doc: GranolaDoc = {
         id: "doc-no-filepath",
         title: "Note Without File Path",
@@ -1463,7 +1493,7 @@ describe("FileSyncService", () => {
         undefined
       );
 
-      expect(result).toBe(false);
+      expect(result).toEqual({ saved: false, path: null });
     });
   });
 
@@ -2033,7 +2063,8 @@ describe("FileSyncService", () => {
         false
       );
 
-      expect(result).toBe(true);
+      expect(result.saved).toBe(true);
+      expect(result.path).toBe("granola-folder/Test Note.md");
       expect(mockDocumentProcessor.prepareCombinedNote).toHaveBeenCalledWith(
         mockDoc,
         "## Transcript\n\nTranscript content",
@@ -2082,7 +2113,7 @@ describe("FileSyncService", () => {
         false
       );
 
-      expect(result).toBe(true);
+      expect(result.saved).toBe(true);
       expect(mockApp.vault.modify).toHaveBeenCalled();
       expect(fileSyncService.findByGranolaId("doc-123", "combined")).toBe(mockFile);
     });
@@ -2107,11 +2138,11 @@ describe("FileSyncService", () => {
         true // forceOverwrite
       );
 
-      expect(result).toBe(true);
+      expect(result.saved).toBe(true);
       expect(mockApp.vault.modify).toHaveBeenCalled();
     });
 
-    it("should return false when document has no id", async () => {
+    it("should return saved:false and path:null when document has no id", async () => {
       const docWithoutId = { ...mockDoc, id: undefined };
 
       const result = await fileSyncService.saveCombinedNoteToDisk(
@@ -2121,7 +2152,7 @@ describe("FileSyncService", () => {
         false
       );
 
-      expect(result).toBe(false);
+      expect(result).toEqual({ saved: false, path: null });
       expect(mockDocumentProcessor.prepareCombinedNote).not.toHaveBeenCalled();
     });
 
@@ -2173,7 +2204,7 @@ describe("FileSyncService", () => {
       // This test mainly verifies that saveCombinedNoteToDisk works with the collision logic
     });
 
-    it("should return false when resolveFolderPath returns null", async () => {
+    it("should return saved:false and path:null when resolveFolderPath returns null", async () => {
       // Set up a scenario where resolveFolderPath would return null
       // This happens when saveAsIndividualFiles is false (invalid for individual files)
       mockSettings.saveAsIndividualFiles = false;
@@ -2185,11 +2216,11 @@ describe("FileSyncService", () => {
         false
       );
 
-      expect(result).toBe(false);
+      expect(result).toEqual({ saved: false, path: null });
       expect(mockDocumentProcessor.prepareCombinedNote).toHaveBeenCalled();
     });
 
-    it("should return false when ensureFolder fails", async () => {
+    it("should return saved:false and path:null when ensureFolder fails", async () => {
       jest.spyOn(fileSyncService, "ensureFolder").mockResolvedValue(false);
 
       const result = await fileSyncService.saveCombinedNoteToDisk(
@@ -2199,11 +2230,11 @@ describe("FileSyncService", () => {
         false
       );
 
-      expect(result).toBe(false);
+      expect(result).toEqual({ saved: false, path: null });
       expect(mockDocumentProcessor.prepareCombinedNote).toHaveBeenCalled();
     });
 
-    it("should return false when resolveFilePath returns null", async () => {
+    it("should return saved:false and path:null when resolveFilePath returns null", async () => {
       jest.spyOn(fileSyncService, "ensureFolder").mockResolvedValue(true);
       jest.spyOn(fileSyncService, "resolveFilePath").mockReturnValue(null);
 
@@ -2214,7 +2245,7 @@ describe("FileSyncService", () => {
         false
       );
 
-      expect(result).toBe(false);
+      expect(result).toEqual({ saved: false, path: null });
       expect(mockDocumentProcessor.prepareCombinedNote).toHaveBeenCalled();
     });
   });

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -82,9 +82,9 @@ describe("GranolaSync", () => {
       buildCache: jest.fn().mockResolvedValue(undefined),
       findByGranolaId: jest.fn().mockReturnValue(null),
       isRemoteNewer: jest.fn().mockReturnValue(true),
-      saveNoteToDisk: jest.fn().mockResolvedValue(true),
+      saveNoteToDisk: jest.fn().mockResolvedValue({ saved: true, path: "Notes/test-note.md" }),
       saveTranscriptToDisk: jest.fn().mockResolvedValue({ saved: true, path: "Transcripts/test-transcript.md" }),
-      saveCombinedNoteToDisk: jest.fn().mockResolvedValue(true),
+      saveCombinedNoteToDisk: jest.fn().mockResolvedValue({ saved: true, path: "Notes/test-note.md" }),
     } as any;
 
     mockDocumentProcessor = {
@@ -558,7 +558,10 @@ describe("GranolaSync", () => {
       };
       (plugin as any).initializeServices();
       mockPathResolver.computeNotePath.mockReturnValue("daily-notes/Transcript Link Test.md");
-      mockFileSyncService.saveNoteToDisk.mockResolvedValue(true);
+      mockFileSyncService.saveNoteToDisk.mockResolvedValue({
+        saved: true,
+        path: "daily-notes/Transcript Link Test.md",
+      });
     });
 
     it("should prefer transcriptPathMap path when linking notes", async () => {
@@ -612,6 +615,81 @@ describe("GranolaSync", () => {
         undefined,
         undefined
       );
+    });
+  });
+
+  describe("syncNotesToIndividualFiles synced note paths", () => {
+    const docWithContent: GranolaDoc = {
+      id: "doc-recurring-1",
+      title: "Daily Scrum",
+      created_at: "2024-01-15T10:00:00Z",
+      updated_at: "2024-01-15T12:00:00Z",
+      last_viewed_panel: {
+        content: {
+          type: "doc",
+          content: [],
+        },
+      },
+    };
+
+    beforeEach(() => {
+      plugin.settings = {
+        ...DEFAULT_SETTINGS,
+        syncNotes: true,
+        syncTranscripts: false,
+        saveAsIndividualFiles: true,
+      };
+      (plugin as any).initializeServices();
+      mockPathResolver.computeNotePath.mockReturnValue(
+        "Granola/Notes/2024-01/Daily Scrum.md"
+      );
+    });
+
+    // Simulates a recurring meeting: a prior occurrence in the month already
+    // owns the clean filename, so this save was collision-resolved with a date
+    // suffix. `syncedNotes` must carry the path returned by `saveNoteToDisk` so
+    // that daily-note links resolve to this note and not the earlier one.
+    it("should use the path returned by saveNoteToDisk for collision-resolved filenames", async () => {
+      const actualSavedPath =
+        "Granola/Notes/2024-01/Daily Scrum-2024-01-15_10-00-00.md";
+      mockFileSyncService.saveNoteToDisk.mockResolvedValue({
+        saved: true,
+        path: actualSavedPath,
+      });
+
+      const result = await (plugin as any).syncNotesToIndividualFiles(
+        [docWithContent],
+        true,
+        null,
+        {},
+        null
+      );
+
+      expect(result.syncedNotes).toEqual([
+        { doc: docWithContent, notePath: actualSavedPath },
+      ]);
+    });
+
+    it("should fall back to the computed path when saveNoteToDisk returns a null path", async () => {
+      mockFileSyncService.saveNoteToDisk.mockResolvedValue({
+        saved: true,
+        path: null,
+      });
+
+      const result = await (plugin as any).syncNotesToIndividualFiles(
+        [docWithContent],
+        true,
+        null,
+        {},
+        null
+      );
+
+      expect(result.syncedNotes).toEqual([
+        {
+          doc: docWithContent,
+          notePath: "Granola/Notes/2024-01/Daily Scrum.md",
+        },
+      ]);
     });
   });
 


### PR DESCRIPTION
This is the signature-consistency form of the fix proposed in #116. Same bug, different shape; happy to go with whichever you prefer and close the other.

## Summary

Same bug class as `7492c89` (transcripts), for notes. Recurring meetings share a title, so the first occurrence in a folder owns the clean filename and later saves are collision-resolved with a date suffix by `FileSyncService.resolveFilePath`. `syncNotesToIndividualFiles` had no way to learn the resolved path because `saveNoteToDisk` / `saveCombinedNoteToDisk` returned only `boolean`, so it pushed the pre-save computed path into `syncedNotes`. Every "Link from Daily Notes" wikilink for a recurring meeting then resolved to the first occurrence of the month.

## Repro

- Individual files + "Link from Daily Notes" enabled; monthly subfolders
- Recurring meeting "Daily Scrum", twice in January
- First save: `Granola/Notes/2024-01/Daily Scrum.md`
- Second save is collision-resolved: `Granola/Notes/2024-01/Daily Scrum-2024-01-15_10-00-00.md`
- Second day's daily note contains `[[Granola/Notes/2024-01/Daily Scrum|...]]`, pointing at the first occurrence

## Fix shape

Align `saveNoteToDisk` and `saveCombinedNoteToDisk` with `saveTranscriptToDisk`:

```ts
async saveNoteToDisk(...): Promise<{ saved: boolean; path: string | null }>
async saveCombinedNoteToDisk(...): Promise<{ saved: boolean; path: string | null }>
```

`path` is resolved from the cache after save, falling back to the attempted path if the cache lookup fails. Same rationale as the transcript rename-failure comment.

`syncNotesToIndividualFiles` now consumes `result.path`, falling back to the pre-save computed path only when the save returned a null path.

## Relationship to #116

#116 fixes the same bug with a smaller diff by calling `findByGranolaId` in the caller after each save. This PR applies the broader refactor so the three save functions share one shape. Functionally equivalent; I have no preference on which ships.

## Test plan

- [x] New failing test for `saveNoteToDisk` returning resolved path after collision
- [x] Updated existing `saveNoteToDisk` / `saveCombinedNoteToDisk` assertions to the new return shape
- [x] End-to-end test that `syncedNotes` carries the `result.path` from the save
- [x] Regression test for the null-path fallback
- [x] `npm test` (450 passing, was 447)
- [x] `npm run lint`
- [x] `tsc -p . -noEmit -skipLibCheck`