### PR TITLE
fix: defer frontmatter cross-links until both notes and transcripts are saved

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -538,10 +538,8 @@ export default class GranolaSync extends Plugin {
       }
     }
 
-    // Always sync transcripts first if enabled, so notes can link to them
     const forceOverwrite = mode === "full";
     let transcriptDataMap: Map<string, TranscriptEntry[]> | null = null;
-    let transcriptPathMap: Map<string, string> | null = null;
     if (this.settings.syncTranscripts) {
       const transcriptResult = await this.syncTranscripts(
         documents,
@@ -549,11 +547,14 @@ export default class GranolaSync extends Plugin {
         forceOverwrite
       );
       transcriptDataMap = transcriptResult.transcriptDataMap;
-      transcriptPathMap = transcriptResult.transcriptPathMap;
     }
     if (this.settings.syncNotes) {
-      await this.syncNotes(documents, forceOverwrite, transcriptDataMap, docFolders, transcriptPathMap);
+      await this.syncNotes(documents, forceOverwrite, transcriptDataMap, docFolders);
     }
+
+    // Update frontmatter cross-links between notes and transcripts using
+    // actual on-disk paths (after collision resolution).
+    await this.updateCrossLinks(documents);
 
     // Show success message
     showStatusBarTemporary(this, "Granola sync: Complete");
@@ -563,8 +564,7 @@ export default class GranolaSync extends Plugin {
     documents: GranolaDoc[],
     forceOverwrite: boolean = false,
     transcriptDataMap: Map<string, TranscriptEntry[]> | null = null,
-    docFolders: Record<string, string[]> = {},
-    transcriptPathMap: Map<string, string> | null = null
+    docFolders: Record<string, string[]> = {}
   ): Promise<void> {
     let syncedCount: number;
     log.debug(`syncNotes — mode=${this.settings.saveAsIndividualFiles ? "individual" : "daily-notes"}, docs=${documents.length}`);
@@ -581,8 +581,7 @@ export default class GranolaSync extends Plugin {
         documents,
         forceOverwrite,
         transcriptDataMap,
-        docFolders,
-        transcriptPathMap
+        docFolders
       );
       syncedCount = result.syncedCount;
 
@@ -714,8 +713,7 @@ export default class GranolaSync extends Plugin {
     documents: GranolaDoc[],
     forceOverwrite: boolean = false,
     transcriptDataMap: Map<string, TranscriptEntry[]> | null = null,
-    docFolders: Record<string, string[]> = {},
-    transcriptPathMap: Map<string, string> | null = null
+    docFolders: Record<string, string[]> = {}
   ): Promise<{
     syncedCount: number;
     syncedNotes: Array<{ doc: GranolaDoc; notePath: string }>;
@@ -793,31 +791,13 @@ export default class GranolaSync extends Plugin {
           }
         }
       } else {
-        // Regular mode: save note separately (with optional transcript link)
-        // Use actual transcript path (from save or cache) to handle collision-resolved filenames.
-        // If we cannot resolve the transcript path, we intentionally do not link it.
-        let transcriptPath: string | null = null;
-        if (
-          this.settings.syncTranscripts &&
-          this.settings.transcriptHandling !== "combined"
-        ) {
-          transcriptPath =
-            transcriptPathMap?.get(doc.id) ??
-            this.fileSyncService.findByGranolaId(doc.id, "transcript")?.path ??
-            null;
-
-          if (!transcriptPath) {
-            log.error(
-              `Granola sync: transcript path not resolved for doc ${doc.id} — skipping transcript frontmatter link (will not write a stale/incorrect path).`
-            );
-          }
-        }
-
+        // Save note without cross-links; frontmatter linking is done
+        // in updateCrossLinks() after both notes and transcripts are saved.
         const result = await this.fileSyncService.saveNoteToDisk(
           doc,
           this.documentProcessor,
           forceOverwrite,
-          transcriptPath ?? undefined,
+          undefined,
           folders
         );
         if (result.saved) {
@@ -833,13 +813,115 @@ export default class GranolaSync extends Plugin {
     return { syncedCount, syncedNotes };
   }
 
+  /**
+   * After both notes and transcripts are saved, update frontmatter cross-links
+   * using the actual on-disk paths (which may differ from computed paths due to
+   * collision resolution with date suffixes).
+   */
+  private async updateCrossLinks(documents: GranolaDoc[]): Promise<void> {
+    // Cross-links only apply when both notes and transcripts are synced, and
+    // transcripts are saved as separate files (not combined mode).
+    if (
+      !this.settings.syncNotes ||
+      !this.settings.syncTranscripts ||
+      this.settings.transcriptHandling === "combined"
+    ) {
+      return;
+    }
+
+    let updatedCount = 0;
+    for (const doc of documents) {
+      const transcriptFile = this.fileSyncService.findByGranolaId(doc.id, "transcript");
+      if (!transcriptFile) continue;
+
+      // Resolve the note path for transcript→note linking
+      let noteLinkPath: string | null = null;
+      if (this.settings.saveAsIndividualFiles) {
+        // Individual files: use actual on-disk path from cache
+        const noteFile = this.fileSyncService.findByGranolaId(doc.id, "note");
+        if (noteFile) {
+          noteLinkPath = noteFile.path;
+
+          // Update note frontmatter with transcript link
+          const noteContent = await this.app.vault.read(noteFile);
+          const updatedNote = this.upsertFrontmatterField(
+            noteContent,
+            "transcript",
+            `"[[${transcriptFile.path}]]"`
+          );
+          if (updatedNote !== noteContent) {
+            await this.app.vault.modify(noteFile, updatedNote);
+          }
+        }
+      } else {
+        // Daily notes mode: link to the daily note heading
+        const noteDate = getNoteDate(doc);
+        const noteMoment = moment(noteDate);
+        const dailyNoteFile = getDailyNote(noteMoment, getAllDailyNotes());
+        if (dailyNoteFile) {
+          const title = getTitleOrDefault(doc);
+          noteLinkPath = `${dailyNoteFile.basename}#${title}`;
+        }
+      }
+
+      // Update transcript frontmatter with note link
+      if (noteLinkPath) {
+        const transcriptContent = await this.app.vault.read(transcriptFile);
+        const updatedTranscript = this.upsertFrontmatterField(
+          transcriptContent,
+          "note",
+          `"[[${noteLinkPath}]]"`
+        );
+        if (updatedTranscript !== transcriptContent) {
+          await this.app.vault.modify(transcriptFile, updatedTranscript);
+        }
+      }
+
+      updatedCount++;
+    }
+
+    if (updatedCount > 0) {
+      log.debug(`Updated cross-links in ${updatedCount} note/transcript pair(s)`);
+    }
+  }
+
+  /**
+   * Adds or updates a single YAML frontmatter field. If the field already
+   * exists, its value is replaced; otherwise it is inserted before the
+   * closing `---` delimiter.
+   */
+  private upsertFrontmatterField(
+    content: string,
+    field: string,
+    value: string
+  ): string {
+    const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!frontmatterMatch) return content;
+
+    const frontmatter = frontmatterMatch[1];
+    const fieldRegex = new RegExp(`^${field}:.*$`, "m");
+
+    let updatedFrontmatter: string;
+    if (fieldRegex.test(frontmatter)) {
+      updatedFrontmatter = frontmatter.replace(fieldRegex, `${field}: ${value}`);
+    } else {
+      updatedFrontmatter = frontmatter + `\n${field}: ${value}`;
+    }
+
+    if (updatedFrontmatter === frontmatter) return content;
+
+    return content.replace(
+      /^---\n[\s\S]*?\n---/,
+      `---\n${updatedFrontmatter}\n---`
+    );
+  }
+
   private async syncTranscripts(
     documents: GranolaDoc[],
     accessToken: string,
     forceOverwrite: boolean = false
-  ): Promise<{ transcriptDataMap: Map<string, TranscriptEntry[]>; transcriptPathMap: Map<string, string> }> {
+  ): Promise<{ transcriptDataMap: Map<string, TranscriptEntry[]> }> {
     const transcriptDataMap = new Map<string, TranscriptEntry[]>();
-    const transcriptPathMap = new Map<string, string>();
     const isCombinedMode = this.settings.transcriptHandling === "combined";
 
     let processedCount = 0;
@@ -891,26 +973,9 @@ export default class GranolaSync extends Plugin {
           continue;
         }
 
-        // Compute note path before formatting transcript (for frontmatter linking)
-        // Always add note link when notes are being synced
-        let notePath: string | null = null;
-        if (this.settings.syncNotes) {
-          if (!this.settings.saveAsIndividualFiles) {
-            // For daily notes, link to the daily note file with a heading anchor
-            const noteDate = getNoteDate(doc);
-            const noteMoment = moment(noteDate);
-            const dailyNoteFile = getDailyNote(noteMoment, getAllDailyNotes());
-            if (dailyNoteFile) {
-              // Link to the daily note with the note title as the heading
-              notePath = `${dailyNoteFile.basename}#${title}`;
-            }
-          } else {
-            // For individual files, use the resolved file path
-            notePath = this.pathResolver.computeNotePath(doc);
-          }
-        }
-
-        // Use the extracted formatting function
+        // Save transcript without cross-links; frontmatter linking is done
+        // in updateCrossLinks() after both notes and transcripts are saved,
+        // so the paths reflect any collision-resolved filenames.
         const transcriptMd = formatTranscriptBySpeaker(
           transcriptData,
           title,
@@ -920,7 +985,7 @@ export default class GranolaSync extends Plugin {
           doc.people?.attendees
             ?.map((attendee) => attendee.name || attendee.email || "Unknown")
             .filter((name) => name !== "Unknown"),
-          notePath ?? undefined
+          undefined
         );
         processedCount++;
         this.updateSyncStatus("Transcript", processedCount, documents.length);
@@ -930,9 +995,6 @@ export default class GranolaSync extends Plugin {
           this.documentProcessor,
           forceOverwrite
         );
-        if (transcriptResult.path) {
-          transcriptPathMap.set(docId, transcriptResult.path);
-        }
         if (transcriptResult.saved) {
           syncedCount++;
         }
@@ -947,6 +1009,6 @@ export default class GranolaSync extends Plugin {
     log.debug(
       `syncTranscripts - Completed: ${syncedCount} saved out of ${processedCount} processed`
     );
-    return { transcriptDataMap, transcriptPathMap };
+    return { transcriptDataMap };
   }
 }

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -34,14 +34,16 @@ jest.mock("../../src/utils/statusBar");
 jest.mock("obsidian-daily-notes-interface");
 jest.mock("moment", () => {
   const actualMoment = jest.requireActual("moment");
+  const mockMoment = jest.fn((date?: string | Date) => {
+    if (date) {
+      return actualMoment(date);
+    }
+    return actualMoment();
+  });
   return {
+    __esModule: true,
     ...actualMoment,
-    default: jest.fn((date?: string) => {
-      if (date) {
-        return actualMoment(date);
-      }
-      return actualMoment();
-    }),
+    default: mockMoment,
   };
 });
 
@@ -464,12 +466,11 @@ describe("GranolaSync", () => {
         syncTranscripts: true,
       };
       const mockTranscriptMap = new Map([["doc-1", []]]);
-      const mockTranscriptPathMap = new Map([["doc-1", "Transcripts/test-transcript.md"]]);
       (plugin as any).syncTranscripts = jest.fn().mockResolvedValue({
         transcriptDataMap: mockTranscriptMap,
-        transcriptPathMap: mockTranscriptPathMap,
       });
       (plugin as any).syncNotes = jest.fn().mockResolvedValue(undefined);
+      (plugin as any).updateCrossLinks = jest.fn().mockResolvedValue(undefined);
 
       await plugin.sync();
 
@@ -482,9 +483,9 @@ describe("GranolaSync", () => {
         [mockDoc],
         false,
         mockTranscriptMap,
-        {},
-        mockTranscriptPathMap
+        {}
       );
+      expect((plugin as any).updateCrossLinks).toHaveBeenCalledWith([mockDoc]);
     });
 
     it("should use forceOverwrite in full sync mode", async () => {
@@ -494,12 +495,11 @@ describe("GranolaSync", () => {
         syncTranscripts: true,
       };
       const mockTranscriptMap = new Map([["doc-1", []]]);
-      const mockTranscriptPathMap = new Map([["doc-1", "Transcripts/test-transcript.md"]]);
       (plugin as any).syncTranscripts = jest.fn().mockResolvedValue({
         transcriptDataMap: mockTranscriptMap,
-        transcriptPathMap: mockTranscriptPathMap,
       });
       (plugin as any).syncNotes = jest.fn().mockResolvedValue(undefined);
+      (plugin as any).updateCrossLinks = jest.fn().mockResolvedValue(undefined);
 
       await plugin.sync({ mode: "full" });
 
@@ -512,8 +512,7 @@ describe("GranolaSync", () => {
         [mockDoc],
         true,
         mockTranscriptMap,
-        {},
-        mockTranscriptPathMap
+        {}
       );
     });
 
@@ -534,7 +533,7 @@ describe("GranolaSync", () => {
     });
   });
 
-  describe("syncNotesToIndividualFiles transcript linking", () => {
+  describe("syncNotesToIndividualFiles no longer embeds transcript links", () => {
     const docWithContent: GranolaDoc = {
       id: "doc-link-1",
       title: "Transcript Link Test",
@@ -564,50 +563,14 @@ describe("GranolaSync", () => {
       });
     });
 
-    it("should prefer transcriptPathMap path when linking notes", async () => {
-      mockFileSyncService.findByGranolaId.mockImplementation((granolaId, type) => {
-        if (granolaId === "doc-link-1" && type === "transcript") {
-          return { path: "Transcripts/2024/01/wrong-transcript.md" } as any;
-        }
-        return null;
-      });
-      const transcriptPathMap = new Map<string, string>([
-        ["doc-link-1", "Transcripts/2024/01/collision-transcript-2024-01-15_10-00-00.md"],
-      ]);
-
+    it("should save notes without transcript path (cross-links deferred to updateCrossLinks)", async () => {
       await (plugin as any).syncNotesToIndividualFiles(
         [docWithContent],
         true,
         null,
-        {},
-        transcriptPathMap
+        {}
       );
 
-      expect(mockFileSyncService.saveNoteToDisk).toHaveBeenCalledWith(
-        docWithContent,
-        mockDocumentProcessor,
-        true,
-        "Transcripts/2024/01/collision-transcript-2024-01-15_10-00-00.md",
-        undefined
-      );
-    });
-
-    it("should not link transcript and should log error when unresolved", async () => {
-      mockFileSyncService.findByGranolaId.mockReturnValue(null);
-
-      await (plugin as any).syncNotesToIndividualFiles(
-        [docWithContent],
-        true,
-        null,
-        {},
-        null
-      );
-
-      expect(log.error).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "Granola sync: transcript path not resolved for doc doc-link-1"
-        )
-      );
       expect(mockFileSyncService.saveNoteToDisk).toHaveBeenCalledWith(
         docWithContent,
         mockDocumentProcessor,
@@ -615,6 +578,264 @@ describe("GranolaSync", () => {
         undefined,
         undefined
       );
+    });
+  });
+
+  describe("upsertFrontmatterField", () => {
+    beforeEach(() => {
+      plugin.settings = { ...DEFAULT_SETTINGS };
+      (plugin as any).initializeServices();
+    });
+
+    it("should add a new field before the closing ---", () => {
+      const content = [
+        "---",
+        "granola_id: doc-1",
+        "title: Test",
+        "type: note",
+        "---",
+        "",
+        "Body content",
+      ].join("\n");
+
+      const result = (plugin as any).upsertFrontmatterField(
+        content,
+        "transcript",
+        '"[[Transcripts/test.md]]"'
+      );
+
+      expect(result).toContain('transcript: "[[Transcripts/test.md]]"');
+      expect(result).toMatch(/transcript:.*\n---/);
+      expect(result).toContain("Body content");
+    });
+
+    it("should update an existing field value", () => {
+      const content = [
+        "---",
+        "granola_id: doc-1",
+        'transcript: "[[old-path.md]]"',
+        "type: note",
+        "---",
+        "",
+        "Body",
+      ].join("\n");
+
+      const result = (plugin as any).upsertFrontmatterField(
+        content,
+        "transcript",
+        '"[[new-path.md]]"'
+      );
+
+      expect(result).toContain('transcript: "[[new-path.md]]"');
+      expect(result).not.toContain("old-path.md");
+    });
+
+    it("should return content unchanged when no frontmatter exists", () => {
+      const content = "No frontmatter here";
+      const result = (plugin as any).upsertFrontmatterField(
+        content,
+        "transcript",
+        '"[[path.md]]"'
+      );
+      expect(result).toBe(content);
+    });
+
+    it("should return content unchanged when field already has the target value", () => {
+      const content = [
+        "---",
+        "granola_id: doc-1",
+        'transcript: "[[path.md]]"',
+        "---",
+        "",
+        "Body",
+      ].join("\n");
+
+      const result = (plugin as any).upsertFrontmatterField(
+        content,
+        "transcript",
+        '"[[path.md]]"'
+      );
+
+      expect(result).toBe(content);
+    });
+  });
+
+  describe("updateCrossLinks", () => {
+    const doc: GranolaDoc = {
+      id: "doc-cross-1",
+      title: "Cross Link Test",
+      created_at: "2024-01-15T10:00:00Z",
+      updated_at: "2024-01-15T12:00:00Z",
+      last_viewed_panel: {
+        content: { type: "doc", content: [] },
+      },
+    };
+
+    const noteFrontmatter = [
+      "---",
+      "granola_id: doc-cross-1",
+      "title: Cross Link Test",
+      "type: note",
+      "---",
+      "",
+      "Note body",
+    ].join("\n");
+
+    const transcriptFrontmatter = [
+      "---",
+      "granola_id: doc-cross-1",
+      "title: Cross Link Test - Transcript",
+      "type: transcript",
+      "---",
+      "",
+      "Transcript body",
+    ].join("\n");
+
+    beforeEach(() => {
+      plugin.settings = {
+        ...DEFAULT_SETTINGS,
+        syncNotes: true,
+        syncTranscripts: true,
+        saveAsIndividualFiles: true,
+        transcriptHandling: "custom-location",
+      };
+      (plugin as any).initializeServices();
+      mockApp.vault.read = jest.fn();
+      mockApp.vault.modify = jest.fn().mockResolvedValue(undefined);
+    });
+
+    it("should update both note and transcript frontmatter with cross-links", async () => {
+      const noteFile = { path: "Notes/Cross Link Test.md" };
+      const transcriptFile = { path: "Transcripts/Cross Link Test - Transcript.md" };
+
+      mockFileSyncService.findByGranolaId.mockImplementation((id, type) => {
+        if (id === "doc-cross-1" && type === "note") return noteFile as any;
+        if (id === "doc-cross-1" && type === "transcript") return transcriptFile as any;
+        return null;
+      });
+      (mockApp.vault.read as jest.Mock)
+        .mockResolvedValueOnce(noteFrontmatter)
+        .mockResolvedValueOnce(transcriptFrontmatter);
+
+      await (plugin as any).updateCrossLinks([doc]);
+
+      expect(mockApp.vault.modify).toHaveBeenCalledTimes(2);
+      // Note should get transcript link
+      const noteCall = (mockApp.vault.modify as jest.Mock).mock.calls[0];
+      expect(noteCall[0]).toBe(noteFile);
+      expect(noteCall[1]).toContain(
+        'transcript: "[[Transcripts/Cross Link Test - Transcript.md]]"'
+      );
+      // Transcript should get note link
+      const transcriptCall = (mockApp.vault.modify as jest.Mock).mock.calls[1];
+      expect(transcriptCall[0]).toBe(transcriptFile);
+      expect(transcriptCall[1]).toContain(
+        'note: "[[Notes/Cross Link Test.md]]"'
+      );
+    });
+
+    it("should use collision-resolved paths from cache", async () => {
+      const noteFile = { path: "Notes/Daily Scrum-2024-01-15_10-00-00.md" };
+      const transcriptFile = { path: "Transcripts/Daily Scrum-2024-01-15_10-00-00 - Transcript.md" };
+
+      mockFileSyncService.findByGranolaId.mockImplementation((id, type) => {
+        if (id === "doc-cross-1" && type === "note") return noteFile as any;
+        if (id === "doc-cross-1" && type === "transcript") return transcriptFile as any;
+        return null;
+      });
+      (mockApp.vault.read as jest.Mock)
+        .mockResolvedValueOnce(noteFrontmatter)
+        .mockResolvedValueOnce(transcriptFrontmatter);
+
+      await (plugin as any).updateCrossLinks([doc]);
+
+      const noteCall = (mockApp.vault.modify as jest.Mock).mock.calls[0];
+      expect(noteCall[1]).toContain(
+        'transcript: "[[Transcripts/Daily Scrum-2024-01-15_10-00-00 - Transcript.md]]"'
+      );
+      const transcriptCall = (mockApp.vault.modify as jest.Mock).mock.calls[1];
+      expect(transcriptCall[1]).toContain(
+        'note: "[[Notes/Daily Scrum-2024-01-15_10-00-00.md]]"'
+      );
+    });
+
+    it("should skip documents without both note and transcript files", async () => {
+      mockFileSyncService.findByGranolaId.mockReturnValue(null);
+
+      await (plugin as any).updateCrossLinks([doc]);
+
+      expect(mockApp.vault.modify).not.toHaveBeenCalled();
+    });
+
+    it("should skip when transcriptHandling is combined", async () => {
+      plugin.settings.transcriptHandling = "combined";
+
+      await (plugin as any).updateCrossLinks([doc]);
+
+      expect(mockFileSyncService.findByGranolaId).not.toHaveBeenCalled();
+    });
+
+    it("should not modify files when cross-links already match", async () => {
+      const noteFile = { path: "Notes/Test.md" };
+      const transcriptFile = { path: "Transcripts/Test - Transcript.md" };
+
+      mockFileSyncService.findByGranolaId.mockImplementation((id, type) => {
+        if (type === "note") return noteFile as any;
+        if (type === "transcript") return transcriptFile as any;
+        return null;
+      });
+
+      const noteWithLink = [
+        "---",
+        "granola_id: doc-cross-1",
+        'transcript: "[[Transcripts/Test - Transcript.md]]"',
+        "type: note",
+        "---",
+        "",
+        "Body",
+      ].join("\n");
+      const transcriptWithLink = [
+        "---",
+        "granola_id: doc-cross-1",
+        'note: "[[Notes/Test.md]]"',
+        "type: transcript",
+        "---",
+        "",
+        "Body",
+      ].join("\n");
+
+      (mockApp.vault.read as jest.Mock)
+        .mockResolvedValueOnce(noteWithLink)
+        .mockResolvedValueOnce(transcriptWithLink);
+
+      await (plugin as any).updateCrossLinks([doc]);
+
+      expect(mockApp.vault.modify).not.toHaveBeenCalled();
+    });
+
+    it("should handle daily notes mode with heading links for transcripts", async () => {
+      plugin.settings.saveAsIndividualFiles = false;
+      const transcriptFile = { path: "Transcripts/Test - Transcript.md" };
+
+      mockFileSyncService.findByGranolaId.mockImplementation((id, type) => {
+        if (type === "transcript") return transcriptFile as any;
+        return null;
+      });
+
+      const mockDailyNoteFile = { basename: "2024-01-15" } as any;
+      (getDailyNote as jest.Mock).mockReturnValue(mockDailyNoteFile);
+      (getAllDailyNotes as jest.Mock).mockReturnValue({});
+      (getNoteDate as jest.Mock).mockReturnValue(new Date("2024-01-15T10:00:00Z"));
+
+      (mockApp.vault.read as jest.Mock)
+        .mockResolvedValueOnce(transcriptFrontmatter);
+
+      await (plugin as any).updateCrossLinks([doc]);
+
+      expect(mockApp.vault.modify).toHaveBeenCalledTimes(1);
+      const call = (mockApp.vault.modify as jest.Mock).mock.calls[0];
+      expect(call[0]).toBe(transcriptFile);
+      expect(call[1]).toContain('note: "[[2024-01-15#Cross Link Test]]"');
     });
   });
 
@@ -661,8 +882,7 @@ describe("GranolaSync", () => {
         [docWithContent],
         true,
         null,
-        {},
-        null
+        {}
       );
 
       expect(result.syncedNotes).toEqual([
@@ -680,8 +900,7 @@ describe("GranolaSync", () => {
         [docWithContent],
         true,
         null,
-        {},
-        null
+        {}
       );
 
       expect(result.syncedNotes).toEqual([


### PR DESCRIPTION
## Summary

- Fixes the same collision-resolved filename bug class as #117, but for **frontmatter cross-links** between notes and transcripts
- `syncTranscripts()` previously computed a note path *before* the note was saved — recurring meetings with the same title got the wrong `note: "[[...]]"` link in transcript frontmatter
- Removes all cross-link embedding at save time; adds a post-save `updateCrossLinks()` step that reads actual on-disk paths from the cache
- Eliminates `transcriptPathMap` plumbing entirely — cross-links are now resolved from the single source of truth (the file cache) after both files exist

## How it works

1. Transcripts and notes are saved **without** cross-link frontmatter fields
2. After both syncs complete, `updateCrossLinks()` iterates all documents:
   - Looks up the actual note and transcript paths via `findByGranolaId()`
   - Upserts `transcript: "[[...]]"` in note frontmatter and `note: "[[...]]"` in transcript frontmatter
   - Handles both individual-files mode (file paths) and daily-notes mode (heading anchors)
   - Skips writes when cross-links already match (idempotent)

## Test plan

- [x] New tests for `upsertFrontmatterField` (add, update, no-op, no-frontmatter cases)
- [x] New tests for `updateCrossLinks` (collision-resolved paths, skip conditions, daily-notes heading links, idempotency)
- [x] Updated existing sync orchestration tests for removed `transcriptPathMap`
- [x] `npm test` — 459 passing
- [x] `npm run lint`
- [x] `tsc -p . --noEmit --skipLibCheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)