### PR TITLE
Fix missing comma in manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,6 @@
   "description": "Sync Granola notes to your vault.",
   "author": "Tom Elliot",
   "authorUrl": "https://www.tomelliot.net/",
-  "isDesktopOnly": true
+  "isDesktopOnly": true,
   "fundingUrl": "https://buymeacoffee.com/tomelliot"
 }


### PR DESCRIPTION
## Summary
- Commit 8f33a72 added `fundingUrl` without a trailing comma on the prior `isDesktopOnly` line, leaving `manifest.json` invalid.
- `eslint-plugin-obsidianmd` parses `manifest.json` at config load time, so the parse failure caused ESLint to fall back to a config without the plugin's overrides — surfacing spurious `import/no-nodejs-modules` and `no-undef` errors in CI.
- Adds the missing comma so JSON parses and lint passes.

## Test plan
- [x] `node -e "JSON.parse(require('fs').readFileSync('manifest.json','utf8'))"` succeeds locally
- [ ] CI build job on this PR passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)