### PR TITLE
fix: load credentials from stored-accounts.json

### DIFF
--- a/src/services/credentials.ts
+++ b/src/services/credentials.ts
@@ -14,8 +14,12 @@ interface WorkosTokens {
   external_id: string;
 }
 
-interface TokenData {
-  workos_tokens: string;
+interface StoredAccount {
+  tokens: string | WorkosTokens;
+}
+
+interface StoredAccountsData {
+  accounts: string | StoredAccount[];
 }
 
 interface RefreshTokenResponse {
@@ -32,164 +36,160 @@ function getTokenFilePath(): string {
       "AppData",
       "Roaming",
       "Granola",
-      "supabase.json"
-    );
-  } else if (Platform.isLinux) {
-    return path.join(os.homedir(), ".config", "Granola", "supabase.json");
-  } else {
-    return path.join(
-      os.homedir(),
-      "Library",
-      "Application Support",
-      "Granola",
-      "supabase.json"
+      "stored-accounts.json"
     );
   }
+  if (Platform.isLinux) {
+    return path.join(os.homedir(), ".config", "Granola", "stored-accounts.json");
+  }
+  return path.join(
+    os.homedir(),
+    "Library",
+    "Application Support",
+    "Granola",
+    "stored-accounts.json"
+  );
 }
 
 const filePath = getTokenFilePath();
 
 /**
- * Checks if the access token has expired.
- * Returns true if the token has expired or will expire in the next 5 minutes.
+ * Returns true if the access token has expired or expires within 5 minutes.
  */
 function isTokenExpired(workosTokens: WorkosTokens): boolean {
-  const currentTime = Date.now();
-  const tokenObtainedAt = workosTokens.obtained_at;
-  const expiresIn = workosTokens.expires_in * 1000; // Convert seconds to milliseconds
-  const expirationTime = tokenObtainedAt + expiresIn;
+  const expirationTime = workosTokens.obtained_at + workosTokens.expires_in * 1000;
+  const bufferMs = 5 * 60 * 1000;
+  return Date.now() >= expirationTime - bufferMs;
+}
 
-  // Add 5-minute buffer to refresh before actual expiration
-  const bufferTime = 5 * 60 * 1000; // 5 minutes in milliseconds
+async function refreshAccessToken(workosTokens: WorkosTokens): Promise<WorkosTokens> {
+  log.debug("Attempting to refresh access token");
 
-  return currentTime >= expirationTime - bufferTime;
+  const response = await requestUrl({
+    url: "https://api.granola.ai/v1/refresh-access-token",
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${workosTokens.access_token}`,
+      "Content-Type": "application/json",
+      "User-Agent": `GranolaObsidianPlugin/${PLUGIN_VERSION}`,
+      "X-Client-Version": `GranolaObsidianPlugin/${PLUGIN_VERSION}`,
+    },
+    body: JSON.stringify({
+      refresh_token: workosTokens.refresh_token,
+      provider: "workos",
+    }),
+  });
+
+  const refreshResponse = response.json as RefreshTokenResponse;
+
+  return {
+    ...workosTokens,
+    access_token: refreshResponse.access_token,
+    expires_in: refreshResponse.expires_in,
+    token_type: refreshResponse.token_type,
+    obtained_at: Date.now(),
+    refresh_token: refreshResponse.refresh_token ?? workosTokens.refresh_token,
+  };
 }
 
 /**
- * Refreshes the access token using the refresh token.
+ * Parses stored-accounts.json. `accounts` is a JSON-encoded string holding an
+ * array; each account's `tokens` field is itself a JSON-encoded string of the
+ * token object.
  */
-async function refreshAccessToken(
-  workosTokens: WorkosTokens
-): Promise<WorkosTokens> {
-  log.debug("Attempting to refresh access token");
+function parseTokens(fileContents: string): WorkosTokens {
+  const data = JSON.parse(fileContents) as StoredAccountsData;
 
-  try {
-    const response = await requestUrl({
-      url: "https://api.granola.ai/v1/refresh-access-token",
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${workosTokens.access_token}`,
-        "Content-Type": "application/json",
-        "User-Agent": `GranolaObsidianPlugin/${PLUGIN_VERSION}`,
-        "X-Client-Version": `GranolaObsidianPlugin/${PLUGIN_VERSION}`,
-      },
-      body: JSON.stringify({
-        refresh_token: workosTokens.refresh_token,
-        provider: "workos",
-      }),
-    });
+  if (!data.accounts) {
+    throw new Error(`Missing 'accounts' field in credentials file at ${filePath}.`);
+  }
 
-    const refreshResponse = response.json as RefreshTokenResponse;
+  const accounts: StoredAccount[] =
+    typeof data.accounts === "string" ? JSON.parse(data.accounts) : data.accounts;
 
-    // Update the tokens with new values
-    const updatedTokens: WorkosTokens = {
-      ...workosTokens,
-      access_token: refreshResponse.access_token,
-      expires_in: refreshResponse.expires_in,
-      token_type: refreshResponse.token_type,
-      obtained_at: Date.now(),
-      // Keep the same refresh_token if not provided in response
-      refresh_token:
-        refreshResponse.refresh_token ?? workosTokens.refresh_token,
-    };
-
-    log.debug("Successfully refreshed access token");
-    return updatedTokens;
-  } catch (error) {
-    log.error("Failed to refresh access token:", error);
+  if (!Array.isArray(accounts) || accounts.length === 0) {
     throw new Error(
-      `Failed to refresh access token: ${
-        error instanceof Error ? error.message : String(error)
-      }`
+      `No accounts found in credentials file at ${filePath}. Please sign in via the Granola app.`
     );
   }
+
+  const account = accounts[0];
+  if (!account.tokens) {
+    throw new Error(
+      `Missing 'tokens' field on first account in credentials file at ${filePath}.`
+    );
+  }
+
+  return typeof account.tokens === "string"
+    ? (JSON.parse(account.tokens) as WorkosTokens)
+    : account.tokens;
 }
 
 export async function loadCredentials(): Promise<{
   accessToken: string | null;
   error: string | null;
 }> {
-  let accessToken: string | null = null;
-  let tokenLoadError: string | null = null;
-
+  let fileContents: string;
   try {
-    // Read credentials file directly from filesystem
-    const fileContents = await fs.promises.readFile(filePath, "utf-8");
-    log.debug("Successfully read credentials file");
-
-    try {
-      const tokenData = JSON.parse(fileContents) as TokenData;
-      
-      // Validate that workos_tokens field exists
-      if (!tokenData.workos_tokens || typeof tokenData.workos_tokens !== "string") {
-        tokenLoadError = `Missing or invalid 'workos_tokens' field in credentials file at ${filePath}. Please ensure the file contains a valid 'workos_tokens' string.`;
-        log.error("Invalid credentials file structure:", tokenLoadError);
-        return { accessToken, error: tokenLoadError };
-      }
-
-      let workosTokens = JSON.parse(tokenData.workos_tokens) as WorkosTokens;
-
-      // Validate required fields in workosTokens
-      if (!workosTokens.access_token) {
-        tokenLoadError = `Missing 'access_token' field in credentials file at ${filePath}. The token may have expired.`;
-        log.error("Missing access token:", tokenLoadError);
-        return { accessToken, error: tokenLoadError };
-      }
-
-      // Check if token has expired
-      if (isTokenExpired(workosTokens)) {
-        log.debug(
-          "Access token has expired or will expire soon, refreshing..."
-        );
-        try {
-          workosTokens = await refreshAccessToken(workosTokens);
-          log.debug("Token refresh completed successfully");
-        } catch (refreshError) {
-          log.error("Failed to refresh token:", refreshError);
-          tokenLoadError =
-            "Access token has expired and refresh failed. Please re-authenticate in the Granola app.";
-          return { accessToken, error: tokenLoadError };
-        }
-      }
-
-      accessToken = workosTokens.access_token;
-      if (!accessToken) {
-        log.debug("No access token found in credentials file");
-        tokenLoadError =
-          "No access token found in credentials file. The token may have expired.";
-      }
-    } catch (parseError) {
-      const parseErrorMessage = parseError instanceof Error ? parseError.message : String(parseError);
-      tokenLoadError = `Invalid JSON format in credentials file at ${filePath}: ${parseErrorMessage}. Please ensure the file contains valid JSON.`;
-      log.error("Failed to parse credentials file:", parseError);
-      return { accessToken, error: tokenLoadError };
-    }
+    fileContents = await fs.promises.readFile(filePath, "utf-8");
   } catch (error) {
-    // Handle filesystem errors
-    if (error instanceof Error) {
-      const errorCode = (error as NodeJS.ErrnoException).code;
-      if (errorCode === "ENOENT") {
-        tokenLoadError = `Credentials file not found at ${filePath}. Please ensure the Granola app has created the credentials file.`;
-      } else if (errorCode === "EACCES") {
-        tokenLoadError = `Permission denied reading credentials file at ${filePath}. Please check file permissions.`;
-      } else {
-        tokenLoadError = `Failed to read credentials file at ${filePath}: ${error.message}`;
-      }
-    } else {
-      tokenLoadError = `Failed to read credentials file at ${filePath}: ${String(error)}`;
-    }
+    const code = (error as NodeJS.ErrnoException).code;
     log.error("Credentials file read error:", error);
+    if (code === "ENOENT") {
+      return {
+        accessToken: null,
+        error: `Credentials file not found at ${filePath}. Please ensure the Granola app has created the credentials file.`,
+      };
+    }
+    if (code === "EACCES") {
+      return {
+        accessToken: null,
+        error: `Permission denied reading credentials file at ${filePath}. Please check file permissions.`,
+      };
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      accessToken: null,
+      error: `Failed to read credentials file at ${filePath}: ${message}`,
+    };
   }
 
-  return { accessToken, error: tokenLoadError };
+  log.debug("Successfully read credentials file");
+
+  let workosTokens: WorkosTokens;
+  try {
+    workosTokens = parseTokens(fileContents);
+  } catch (parseError) {
+    const message = parseError instanceof Error ? parseError.message : String(parseError);
+    log.error("Failed to parse credentials file:", parseError);
+    return {
+      accessToken: null,
+      error: message.startsWith("Missing") || message.startsWith("No accounts")
+        ? message
+        : `Invalid JSON format in credentials file at ${filePath}: ${message}. Please ensure the file contains valid JSON.`,
+    };
+  }
+
+  if (!workosTokens.access_token) {
+    const error = `Missing 'access_token' field in credentials file at ${filePath}. The token may have expired.`;
+    log.error("Missing access token:", error);
+    return { accessToken: null, error };
+  }
+
+  if (isTokenExpired(workosTokens)) {
+    log.debug("Access token has expired or will expire soon, refreshing...");
+    try {
+      workosTokens = await refreshAccessToken(workosTokens);
+      log.debug("Token refresh completed successfully");
+    } catch (refreshError) {
+      log.error("Failed to refresh token:", refreshError);
+      return {
+        accessToken: null,
+        error:
+          "Access token has expired and refresh failed. Please re-authenticate in the Granola app.",
+      };
+    }
+  }
+
+  return { accessToken: workosTokens.access_token, error: null };
 }

--- a/src/services/credentials.ts
+++ b/src/services/credentials.ts
@@ -105,7 +105,9 @@ function parseTokens(fileContents: string): WorkosTokens {
   }
 
   const accounts: StoredAccount[] =
-    typeof data.accounts === "string" ? JSON.parse(data.accounts) : data.accounts;
+    typeof data.accounts === "string"
+      ? (JSON.parse(data.accounts) as StoredAccount[])
+      : data.accounts;
 
   if (!Array.isArray(accounts) || accounts.length === 0) {
     throw new Error(

--- a/tests/unit/credentials.test.ts
+++ b/tests/unit/credentials.test.ts
@@ -2,7 +2,6 @@ import { loadCredentials } from "../../src/services/credentials";
 import { requestUrl } from "obsidian";
 import fs from "fs";
 
-// Mock the modules
 jest.mock("obsidian");
 jest.mock("fs", () => ({
   promises: {
@@ -10,7 +9,6 @@ jest.mock("fs", () => ({
   },
 }));
 
-// Mock the logger
 jest.mock("../../src/utils/logger", () => ({
   log: {
     debug: jest.fn(),
@@ -20,198 +18,175 @@ jest.mock("../../src/utils/logger", () => ({
   },
 }));
 
-// Mock PLUGIN_VERSION global constant
 (global as any).PLUGIN_VERSION = "1.0.0-test";
 
-describe("Credentials Service - Token Refresh", () => {
-  const mockAccessToken = "mock-access-token";
-  const mockRefreshToken = "mock-refresh-token";
-  const mockNewAccessToken = "mock-new-access-token";
-  
+const mockAccessToken = "mock-access-token";
+const mockRefreshToken = "mock-refresh-token";
+const mockNewAccessToken = "mock-new-access-token";
+
+interface TokensShape {
+  access_token: string;
+  expires_in: number;
+  refresh_token: string;
+  token_type: string;
+  obtained_at: number;
+  session_id: string;
+  external_id: string;
+}
+
+function buildTokens(overrides: Partial<TokensShape> = {}): TokensShape {
+  return {
+    access_token: mockAccessToken,
+    expires_in: 21600,
+    refresh_token: mockRefreshToken,
+    token_type: "Bearer",
+    obtained_at: Date.now(),
+    session_id: "session-123",
+    external_id: "external-123",
+    ...overrides,
+  };
+}
+
+function storedAccountsFile(
+  tokens: TokensShape | undefined,
+  extra: Record<string, unknown> = {}
+): string {
+  const account: Record<string, unknown> = {
+    userId: "user-1",
+    email: "user@example.com",
+    userInfo: JSON.stringify({ id: "user-1" }),
+    savedAt: Date.now(),
+    ...extra,
+  };
+  if (tokens !== undefined) {
+    account.tokens = JSON.stringify(tokens);
+  }
+  return JSON.stringify({ accounts: JSON.stringify([account]) });
+}
+
+function mockRead(response: string | Error): void {
+  const mock = fs.promises.readFile as jest.Mock;
+  mock.mockReset();
+  if (response instanceof Error) {
+    mock.mockRejectedValueOnce(response);
+  } else {
+    mock.mockResolvedValueOnce(response);
+  }
+}
+
+describe("Credentials Service - stored-accounts.json", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
-  it("should load credentials successfully when token is not expired", async () => {
-    const currentTime = Date.now();
-    const mockTokenData = {
-      workos_tokens: JSON.stringify({
-        access_token: mockAccessToken,
-        expires_in: 21600, // 6 hours
-        refresh_token: mockRefreshToken,
-        token_type: "Bearer",
-        obtained_at: currentTime, // Just obtained
-        session_id: "session-123",
-        external_id: "external-123",
-      }),
-    };
-
-    (fs.promises.readFile as jest.Mock).mockResolvedValueOnce(
-      JSON.stringify(mockTokenData)
-    );
+  it("loads access token when not expired", async () => {
+    mockRead(storedAccountsFile(buildTokens()));
 
     const result = await loadCredentials();
 
     expect(result.accessToken).toBe(mockAccessToken);
     expect(result.error).toBeNull();
     expect(fs.promises.readFile).toHaveBeenCalledTimes(1);
+    expect(requestUrl).not.toHaveBeenCalled();
   });
 
-  it("should refresh token when expired", async () => {
-    const currentTime = Date.now();
-    const expiredTime = currentTime - (6 * 60 * 60 * 1000); // 6 hours ago
-    
-    const mockTokenData = {
-      workos_tokens: JSON.stringify({
-        access_token: mockAccessToken,
-        expires_in: 21600, // 6 hours
-        refresh_token: mockRefreshToken,
-        token_type: "Bearer",
-        obtained_at: expiredTime, // Expired
-        session_id: "session-123",
-        external_id: "external-123",
-      }),
-    };
+  it("accepts already-parsed accounts/tokens objects", async () => {
+    const tokens = buildTokens();
+    mockRead(JSON.stringify({ accounts: [{ tokens }] }));
 
-    const mockRefreshResponse = {
-      access_token: mockNewAccessToken,
-      expires_in: 21600,
-      token_type: "Bearer",
-    };
+    const result = await loadCredentials();
 
-    // Mock filesystem read
-    (fs.promises.readFile as jest.Mock).mockResolvedValueOnce(
-      JSON.stringify(mockTokenData)
-    );
-    
-    // Mock refresh API call
+    expect(result.accessToken).toBe(mockAccessToken);
+    expect(result.error).toBeNull();
+  });
+
+  it("surfaces a helpful error when accounts array is empty", async () => {
+    mockRead(JSON.stringify({ accounts: JSON.stringify([]) }));
+
+    const result = await loadCredentials();
+
+    expect(result.accessToken).toBeNull();
+    expect(result.error).toContain("No accounts found");
+  });
+
+  it("surfaces a helpful error when the first account has no tokens", async () => {
+    mockRead(storedAccountsFile(undefined));
+
+    const result = await loadCredentials();
+
+    expect(result.accessToken).toBeNull();
+    expect(result.error).toContain("Missing 'tokens' field");
+  });
+
+  it("reports missing 'accounts' field", async () => {
+    mockRead(JSON.stringify({}));
+
+    const result = await loadCredentials();
+
+    expect(result.accessToken).toBeNull();
+    expect(result.error).toContain("Missing 'accounts' field");
+  });
+});
+
+describe("Credentials Service - refresh behaviour", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("refreshes an expired token", async () => {
+    const expiredAt = Date.now() - 6 * 60 * 60 * 1000;
+    mockRead(storedAccountsFile(buildTokens({ obtained_at: expiredAt })));
     (requestUrl as jest.Mock).mockResolvedValueOnce({
-      json: mockRefreshResponse,
+      json: { access_token: mockNewAccessToken, expires_in: 21600, token_type: "Bearer" },
     });
 
     const result = await loadCredentials();
 
     expect(result.accessToken).toBe(mockNewAccessToken);
     expect(result.error).toBeNull();
-    expect(fs.promises.readFile).toHaveBeenCalledTimes(1);
-    expect(requestUrl).toHaveBeenCalledTimes(1);
-    
-    // Check that refresh was called with correct parameters
-    const refreshCall = (requestUrl as jest.Mock).mock.calls[0][0];
-    expect(refreshCall.url).toBe("https://api.granola.ai/v1/refresh-access-token");
-    expect(refreshCall.method).toBe("POST");
-    expect(JSON.parse(refreshCall.body)).toEqual({
+    const call = (requestUrl as jest.Mock).mock.calls[0][0];
+    expect(call.url).toBe("https://api.granola.ai/v1/refresh-access-token");
+    expect(JSON.parse(call.body)).toEqual({
       refresh_token: mockRefreshToken,
       provider: "workos",
     });
   });
 
-  it("should refresh token when it will expire soon (within 5 minutes)", async () => {
-    const currentTime = Date.now();
-    const expiresIn = 21600; // 6 hours
-    // Set obtained_at so that token expires in 3 minutes
-    const obtainedAt = currentTime - (expiresIn * 1000) + (3 * 60 * 1000);
-    
-    const mockTokenData = {
-      workos_tokens: JSON.stringify({
-        access_token: mockAccessToken,
-        expires_in: expiresIn,
-        refresh_token: mockRefreshToken,
-        token_type: "Bearer",
-        obtained_at: obtainedAt,
-        session_id: "session-123",
-        external_id: "external-123",
-      }),
-    };
-
-    const mockRefreshResponse = {
-      access_token: mockNewAccessToken,
-      expires_in: 21600,
-      token_type: "Bearer",
-    };
-
-    (fs.promises.readFile as jest.Mock).mockResolvedValueOnce(
-      JSON.stringify(mockTokenData)
-    );
-    
+  it("refreshes when token expires within 5 minutes", async () => {
+    const expiresIn = 21600;
+    const obtainedAt = Date.now() - expiresIn * 1000 + 3 * 60 * 1000;
+    mockRead(storedAccountsFile(buildTokens({ obtained_at: obtainedAt, expires_in: expiresIn })));
     (requestUrl as jest.Mock).mockResolvedValueOnce({
-      json: mockRefreshResponse,
+      json: { access_token: mockNewAccessToken, expires_in: 21600, token_type: "Bearer" },
     });
 
     const result = await loadCredentials();
 
     expect(result.accessToken).toBe(mockNewAccessToken);
     expect(result.error).toBeNull();
-    expect(fs.promises.readFile).toHaveBeenCalledTimes(1);
-    expect(requestUrl).toHaveBeenCalledTimes(1);
   });
 
-  it("should handle refresh token failure gracefully", async () => {
-    const currentTime = Date.now();
-    const expiredTime = currentTime - (6 * 60 * 60 * 1000);
-    
-    const mockTokenData = {
-      workos_tokens: JSON.stringify({
-        access_token: mockAccessToken,
-        expires_in: 21600,
-        refresh_token: mockRefreshToken,
-        token_type: "Bearer",
-        obtained_at: expiredTime,
-        session_id: "session-123",
-        external_id: "external-123",
-      }),
-    };
-
-    // Mock filesystem read
-    (fs.promises.readFile as jest.Mock).mockResolvedValueOnce(
-      JSON.stringify(mockTokenData)
-    );
-    
-    // Mock refresh API call failure
-    (requestUrl as jest.Mock).mockRejectedValueOnce(new Error("Refresh failed"));
+  it("returns a clear error when refresh fails", async () => {
+    const expiredAt = Date.now() - 6 * 60 * 60 * 1000;
+    mockRead(storedAccountsFile(buildTokens({ obtained_at: expiredAt })));
+    (requestUrl as jest.Mock).mockRejectedValueOnce(new Error("network down"));
 
     const result = await loadCredentials();
 
     expect(result.accessToken).toBeNull();
     expect(result.error).toContain("Access token has expired and refresh failed");
-    expect(fs.promises.readFile).toHaveBeenCalledTimes(1);
-    expect(requestUrl).toHaveBeenCalledTimes(1);
   });
 
-  it("should use new access token when refresh succeeds", async () => {
-    const currentTime = Date.now();
-    const expiredTime = currentTime - (6 * 60 * 60 * 1000);
-    const newRefreshToken = "new-refresh-token";
-    
-    const mockTokenData = {
-      workos_tokens: JSON.stringify({
-        access_token: mockAccessToken,
-        expires_in: 21600,
-        refresh_token: mockRefreshToken,
-        token_type: "Bearer",
-        obtained_at: expiredTime,
-        session_id: "session-123",
-        external_id: "external-123",
-      }),
-    };
-
-    const mockRefreshResponse = {
-      access_token: mockNewAccessToken,
-      expires_in: 21600,
-      refresh_token: newRefreshToken,
-      token_type: "Bearer",
-    };
-
-    (fs.promises.readFile as jest.Mock).mockResolvedValueOnce(
-      JSON.stringify(mockTokenData)
-    );
-    
+  it("uses the new refresh_token from the refresh response", async () => {
+    const expiredAt = Date.now() - 6 * 60 * 60 * 1000;
+    mockRead(storedAccountsFile(buildTokens({ obtained_at: expiredAt })));
     (requestUrl as jest.Mock).mockResolvedValueOnce({
-      json: mockRefreshResponse,
+      json: {
+        access_token: mockNewAccessToken,
+        expires_in: 21600,
+        token_type: "Bearer",
+        refresh_token: "new-refresh-token",
+      },
     });
 
     const result = await loadCredentials();
@@ -220,35 +195,11 @@ describe("Credentials Service - Token Refresh", () => {
     expect(result.error).toBeNull();
   });
 
-  it("should handle refresh response without new refresh_token", async () => {
-    const currentTime = Date.now();
-    const expiredTime = currentTime - (6 * 60 * 60 * 1000);
-    
-    const mockTokenData = {
-      workos_tokens: JSON.stringify({
-        access_token: mockAccessToken,
-        expires_in: 21600,
-        refresh_token: mockRefreshToken,
-        token_type: "Bearer",
-        obtained_at: expiredTime,
-        session_id: "session-123",
-        external_id: "external-123",
-      }),
-    };
-
-    const mockRefreshResponse = {
-      access_token: mockNewAccessToken,
-      expires_in: 21600,
-      token_type: "Bearer",
-      // No refresh_token in response
-    };
-
-    (fs.promises.readFile as jest.Mock).mockResolvedValueOnce(
-      JSON.stringify(mockTokenData)
-    );
-    
+  it("falls back to the existing refresh_token if not in response", async () => {
+    const expiredAt = Date.now() - 6 * 60 * 60 * 1000;
+    mockRead(storedAccountsFile(buildTokens({ obtained_at: expiredAt })));
     (requestUrl as jest.Mock).mockResolvedValueOnce({
-      json: mockRefreshResponse,
+      json: { access_token: mockNewAccessToken, expires_in: 21600, token_type: "Bearer" },
     });
 
     const result = await loadCredentials();
@@ -257,86 +208,30 @@ describe("Credentials Service - Token Refresh", () => {
     expect(result.error).toBeNull();
   });
 
-  it("should return refreshed access token", async () => {
-    const currentTime = Date.now();
-    const expiredTime = currentTime - (6 * 60 * 60 * 1000);
-    
-    const mockTokenData = {
-      workos_tokens: JSON.stringify({
-        access_token: mockAccessToken,
-        expires_in: 21600,
-        refresh_token: mockRefreshToken,
-        token_type: "Bearer",
-        obtained_at: expiredTime,
-        session_id: "session-123",
-        external_id: "external-123",
-      }),
-    };
-
-    const mockRefreshResponse = {
-      access_token: mockNewAccessToken,
-      expires_in: 21600,
-      token_type: "Bearer",
-    };
-
-    (fs.promises.readFile as jest.Mock).mockResolvedValueOnce(
-      JSON.stringify(mockTokenData)
-    );
-    
+  it("sends Authorization and Content-Type headers on refresh", async () => {
+    const expiredAt = Date.now() - 6 * 60 * 60 * 1000;
+    mockRead(storedAccountsFile(buildTokens({ obtained_at: expiredAt })));
     (requestUrl as jest.Mock).mockResolvedValueOnce({
-      json: mockRefreshResponse,
-    });
-
-    const result = await loadCredentials();
-    
-    expect(result.accessToken).toBe(mockNewAccessToken);
-    expect(result.error).toBeNull();
-    expect(fs.promises.readFile).toHaveBeenCalledTimes(1);
-    expect(requestUrl).toHaveBeenCalledTimes(1);
-  });
-
-  it("should include authorization header in refresh request", async () => {
-    const currentTime = Date.now();
-    const expiredTime = currentTime - (6 * 60 * 60 * 1000);
-    
-    const mockTokenData = {
-      workos_tokens: JSON.stringify({
-        access_token: mockAccessToken,
-        expires_in: 21600,
-        refresh_token: mockRefreshToken,
-        token_type: "Bearer",
-        obtained_at: expiredTime,
-        session_id: "session-123",
-        external_id: "external-123",
-      }),
-    };
-
-    const mockRefreshResponse = {
-      access_token: mockNewAccessToken,
-      expires_in: 21600,
-      token_type: "Bearer",
-    };
-
-    (fs.promises.readFile as jest.Mock).mockResolvedValueOnce(
-      JSON.stringify(mockTokenData)
-    );
-    
-    (requestUrl as jest.Mock).mockResolvedValueOnce({
-      json: mockRefreshResponse,
+      json: { access_token: mockNewAccessToken, expires_in: 21600, token_type: "Bearer" },
     });
 
     await loadCredentials();
 
-    const refreshCall = (requestUrl as jest.Mock).mock.calls[0][0];
-    expect(refreshCall.headers.Authorization).toBe(`Bearer ${mockAccessToken}`);
-    expect(refreshCall.headers["Content-Type"]).toBe("application/json");
+    const call = (requestUrl as jest.Mock).mock.calls[0][0];
+    expect(call.headers.Authorization).toBe(`Bearer ${mockAccessToken}`);
+    expect(call.headers["Content-Type"]).toBe("application/json");
+  });
+});
+
+describe("Credentials Service - error handling", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
-  it("should handle file not found error", async () => {
-    const error = new Error("File not found") as NodeJS.ErrnoException;
-    error.code = "ENOENT";
-
-    (fs.promises.readFile as jest.Mock).mockRejectedValueOnce(error);
+  it("reports file-not-found", async () => {
+    const err = new Error("ENOENT") as NodeJS.ErrnoException;
+    err.code = "ENOENT";
+    mockRead(err);
 
     const result = await loadCredentials();
 
@@ -345,11 +240,10 @@ describe("Credentials Service - Token Refresh", () => {
     expect(result.error).toContain("Please ensure the Granola app has created the credentials file");
   });
 
-  it("should handle permission denied error", async () => {
-    const error = new Error("Permission denied") as NodeJS.ErrnoException;
-    error.code = "EACCES";
-
-    (fs.promises.readFile as jest.Mock).mockRejectedValueOnce(error);
+  it("reports permission denied", async () => {
+    const err = new Error("Permission denied") as NodeJS.ErrnoException;
+    err.code = "EACCES";
+    mockRead(err);
 
     const result = await loadCredentials();
 
@@ -358,8 +252,8 @@ describe("Credentials Service - Token Refresh", () => {
     expect(result.error).toContain("Please check file permissions");
   });
 
-  it("should handle invalid JSON format", async () => {
-    (fs.promises.readFile as jest.Mock).mockResolvedValueOnce("invalid json");
+  it("reports invalid JSON", async () => {
+    mockRead("not json at all");
 
     const result = await loadCredentials();
 
@@ -367,37 +261,10 @@ describe("Credentials Service - Token Refresh", () => {
     expect(result.error).toContain("Invalid JSON format");
   });
 
-  it("should handle missing workos_tokens field", async () => {
-    const invalidTokenData = {
-      // Missing workos_tokens field
-    };
-
-    (fs.promises.readFile as jest.Mock).mockResolvedValueOnce(
-      JSON.stringify(invalidTokenData)
-    );
-
-    const result = await loadCredentials();
-
-    expect(result.accessToken).toBeNull();
-    expect(result.error).toContain("Missing or invalid 'workos_tokens' field");
-  });
-
-  it("should handle missing access_token in workos_tokens", async () => {
-    const mockTokenData = {
-      workos_tokens: JSON.stringify({
-        // Missing access_token
-        expires_in: 21600,
-        refresh_token: mockRefreshToken,
-        token_type: "Bearer",
-        obtained_at: Date.now(),
-        session_id: "session-123",
-        external_id: "external-123",
-      }),
-    };
-
-    (fs.promises.readFile as jest.Mock).mockResolvedValueOnce(
-      JSON.stringify(mockTokenData)
-    );
+  it("reports missing access_token inside the tokens object", async () => {
+    const tokens = buildTokens();
+    delete (tokens as Partial<TokensShape>).access_token;
+    mockRead(storedAccountsFile(tokens as TokensShape));
 
     const result = await loadCredentials();
 


### PR DESCRIPTION
## Migrate credentials loader to stored-accounts.json
- Granola's May 2026 update moved on-disk auth from `supabase.json` to `stored-accounts.json`. Fresh installs no longer write the legacy file, so the plugin could not find credentials.
- Point the loader at `stored-accounts.json` on macOS, Windows and Linux. The new path mirrors the previous per-platform locations (`Library/Application Support/Granola`, `AppData/Roaming/Granola`, `.config/Granola`).
- Parse the new `accounts[].tokens` shape, where both `accounts` and each `tokens` entry are JSON-stringified. We use the first account.

## Keep refresh logic untouched
- The token object nested inside `tokens` exposes the same fields as the legacy `workos_tokens` value (`access_token`, `refresh_token`, `expires_in`, `obtained_at`, `token_type`, `session_id`, `external_id`).
- `isTokenExpired` and `refreshAccessToken` need no changes; the existing 5-minute buffer and refresh endpoint still apply.

## Other changes
- Rewrite `credentials.test.ts` around the new format with 15 tests covering load, refresh and error paths (file-not-found, permission-denied, invalid JSON, empty accounts array, missing `tokens`, missing `access_token`).
- Tighten error messages so the surfaced path is always `stored-accounts.json`.

## Test plan
- [x] `npx jest` — 469 passed
- [x] `npx tsc --noEmit` — clean
- [x] Manual: sync against a real Granola install on macOS