### PR TITLE
fix: handle encrypted credentials and refresh failure gracefully (#126)

### DIFF
--- a/src/services/credentials.ts
+++ b/src/services/credentials.ts
@@ -29,29 +29,26 @@ interface RefreshTokenResponse {
   token_type: string;
 }
 
-function getTokenFilePath(): string {
+function getGranolaDir(): string {
   if (Platform.isWin) {
-    return path.join(
-      os.homedir(),
-      "AppData",
-      "Roaming",
-      "Granola",
-      "stored-accounts.json"
-    );
+    return path.join(os.homedir(), "AppData", "Roaming", "Granola");
   }
   if (Platform.isLinux) {
-    return path.join(os.homedir(), ".config", "Granola", "stored-accounts.json");
+    return path.join(os.homedir(), ".config", "Granola");
   }
-  return path.join(
-    os.homedir(),
-    "Library",
-    "Application Support",
-    "Granola",
-    "stored-accounts.json"
-  );
+  return path.join(os.homedir(), "Library", "Application Support", "Granola");
+}
+
+function getTokenFilePath(): string {
+  return path.join(getGranolaDir(), "stored-accounts.json");
+}
+
+function getEncryptedTokenFilePath(): string {
+  return path.join(getGranolaDir(), "stored-accounts.json.enc");
 }
 
 const filePath = getTokenFilePath();
+const encryptedFilePath = getEncryptedTokenFilePath();
 
 /**
  * Returns true if the access token has expired or expires within 5 minutes.
@@ -60,6 +57,16 @@ function isTokenExpired(workosTokens: WorkosTokens): boolean {
   const expirationTime = workosTokens.obtained_at + workosTokens.expires_in * 1000;
   const bufferMs = 5 * 60 * 1000;
   return Date.now() >= expirationTime - bufferMs;
+}
+
+/**
+ * Returns true if the access token's hard expiry has already passed.
+ * Distinguished from {@link isTokenExpired} which includes a 5-minute refresh buffer.
+ * Used by the refresh-failure fallback: an "expiring soon" token is still usable.
+ */
+function isTokenHardExpired(workosTokens: WorkosTokens): boolean {
+  const expirationTime = workosTokens.obtained_at + workosTokens.expires_in * 1000;
+  return Date.now() >= expirationTime;
 }
 
 async function refreshAccessToken(workosTokens: WorkosTokens): Promise<WorkosTokens> {
@@ -127,10 +134,53 @@ function parseTokens(fileContents: string): WorkosTokens {
     : account.tokens;
 }
 
+/**
+ * Checks whether the desktop Granola app has migrated to encrypted credentials
+ * (`stored-accounts.json.enc`) while the plaintext file is stale.
+ *
+ * Returns true when the encrypted file exists and is newer than the plaintext
+ * file (or the plaintext file is missing). This is the signal that the user
+ * has updated to a Granola desktop build that no longer writes plaintext
+ * credentials we can read.
+ */
+export async function encryptedCredentialsIsNewerThanPlaintext(): Promise<boolean> {
+  try {
+    const encStat = await fs.promises.stat(encryptedFilePath);
+    try {
+      const plainStat = await fs.promises.stat(filePath);
+      return encStat.mtimeMs > plainStat.mtimeMs;
+    } catch (plainErr) {
+      const code = (plainErr as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") {
+        // Encrypted exists but plaintext does not — treat as newer.
+        return true;
+      }
+      return false;
+    }
+  } catch {
+    // Encrypted file does not exist, or stat failed for another reason.
+    return false;
+  }
+}
+
 export async function loadCredentials(): Promise<{
   accessToken: string | null;
   error: string | null;
 }> {
+  // Check if the desktop app has moved to encrypted storage. We log this even
+  // on the happy path so users can correlate sync issues with the desktop
+  // app update. The plain-file read below remains authoritative — if it
+  // succeeds and the token still works, we use it.
+  const encNewer = await encryptedCredentialsIsNewerThanPlaintext();
+  if (encNewer) {
+    log.warn(
+      "Granola desktop credentials appear to have migrated to an encrypted file (stored-accounts.json.enc) " +
+        "that is newer than the plaintext file this plugin reads. Sync may fail. " +
+        "Consider switching to API key authentication (Granola Business/Enterprise) " +
+        "or see https://github.com/tomelliot/obsidian-granola-sync/issues/126 for status."
+    );
+  }
+
   let fileContents: string;
   try {
     fileContents = await fs.promises.readFile(filePath, "utf-8");
@@ -138,6 +188,17 @@ export async function loadCredentials(): Promise<{
     const code = (error as NodeJS.ErrnoException).code;
     log.error("Credentials file read error:", error);
     if (code === "ENOENT") {
+      if (encNewer) {
+        return {
+          accessToken: null,
+          error:
+            `Credentials file not found at ${filePath}, but an encrypted credentials file ` +
+            `(stored-accounts.json.enc) exists. The Granola desktop app has switched to encrypted ` +
+            `credentials this plugin cannot read. See ` +
+            `https://github.com/tomelliot/obsidian-granola-sync/issues/126 for status; ` +
+            `Business/Enterprise users can configure an API key in plugin settings.`,
+        };
+      }
       return {
         accessToken: null,
         error: `Credentials file not found at ${filePath}. Please ensure the Granola app has created the credentials file.`,
@@ -185,10 +246,28 @@ export async function loadCredentials(): Promise<{
       log.debug("Token refresh completed successfully");
     } catch (refreshError) {
       log.error("Failed to refresh token:", refreshError);
+
+      // Refresh-failure fallback: if the existing access token has not actually
+      // expired yet (only inside the 5-minute pre-expiry buffer), use it.
+      // This is the common case when refresh transiently fails (network blip,
+      // server hiccup) — the existing token is still valid for short calls and
+      // a future sync will refresh again.
+      if (!isTokenHardExpired(workosTokens)) {
+        log.warn(
+          "Falling back to existing access token after refresh failure; token is still within hard-expiry window."
+        );
+        return { accessToken: workosTokens.access_token, error: null };
+      }
+
+      const encNewerNow = encNewer || (await encryptedCredentialsIsNewerThanPlaintext());
+      const hint = encNewerNow
+        ? " The Granola desktop app appears to have switched to encrypted credential storage " +
+          "(see https://github.com/tomelliot/obsidian-granola-sync/issues/126). Business/Enterprise users " +
+          "can switch to API key authentication in plugin settings."
+        : " Please re-authenticate in the Granola app.";
       return {
         accessToken: null,
-        error:
-          "Access token has expired and refresh failed. Please re-authenticate in the Granola app.",
+        error: "Access token has expired and refresh failed." + hint,
       };
     }
   }

--- a/tests/unit/credentials.test.ts
+++ b/tests/unit/credentials.test.ts
@@ -1,4 +1,7 @@
-import { loadCredentials } from "../../src/services/credentials";
+import {
+  loadCredentials,
+  encryptedCredentialsIsNewerThanPlaintext,
+} from "../../src/services/credentials";
 import { requestUrl } from "obsidian";
 import fs from "fs";
 
@@ -6,6 +9,7 @@ jest.mock("obsidian");
 jest.mock("fs", () => ({
   promises: {
     readFile: jest.fn(),
+    stat: jest.fn(),
   },
 }));
 
@@ -74,9 +78,49 @@ function mockRead(response: string | Error): void {
   }
 }
 
+/**
+ * Default stat mock: encrypted file does not exist. Tests that assert on the
+ * encrypted-newer code path should override this with mockStat() below.
+ */
+function defaultStatMock(): void {
+  const mock = fs.promises.stat as jest.Mock;
+  mock.mockReset();
+  mock.mockImplementation(() => {
+    const err = new Error("ENOENT") as NodeJS.ErrnoException;
+    err.code = "ENOENT";
+    return Promise.reject(err);
+  });
+}
+
+/**
+ * Configures the fs.stat mock so the .enc credentials file is reported as
+ * existing with mtime `encMtimeMs`, and (optionally) the plaintext file as
+ * existing with mtime `plainMtimeMs`. Pass `plainMtimeMs: null` to simulate
+ * the plaintext file being missing.
+ */
+function mockStat(opts: {
+  encMtimeMs: number;
+  plainMtimeMs: number | null;
+}): void {
+  const mock = fs.promises.stat as jest.Mock;
+  mock.mockReset();
+  mock.mockImplementation((p: string) => {
+    if (p.endsWith(".enc")) {
+      return Promise.resolve({ mtimeMs: opts.encMtimeMs });
+    }
+    if (opts.plainMtimeMs === null) {
+      const err = new Error("ENOENT") as NodeJS.ErrnoException;
+      err.code = "ENOENT";
+      return Promise.reject(err);
+    }
+    return Promise.resolve({ mtimeMs: opts.plainMtimeMs });
+  });
+}
+
 describe("Credentials Service - stored-accounts.json", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    defaultStatMock();
   });
 
   it("loads access token when not expired", async () => {
@@ -131,6 +175,7 @@ describe("Credentials Service - stored-accounts.json", () => {
 describe("Credentials Service - refresh behaviour", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    defaultStatMock();
   });
 
   it("refreshes an expired token", async () => {
@@ -226,6 +271,7 @@ describe("Credentials Service - refresh behaviour", () => {
 describe("Credentials Service - error handling", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    defaultStatMock();
   });
 
   it("reports file-not-found", async () => {
@@ -270,5 +316,94 @@ describe("Credentials Service - error handling", () => {
 
     expect(result.accessToken).toBeNull();
     expect(result.error).toContain("Missing 'access_token' field");
+  });
+});
+
+describe("Credentials Service - .enc detection band-aid (#126)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns true when .enc file is newer than plaintext", async () => {
+    mockStat({ encMtimeMs: 2000, plainMtimeMs: 1000 });
+    expect(await encryptedCredentialsIsNewerThanPlaintext()).toBe(true);
+  });
+
+  it("returns true when .enc exists but plaintext does not", async () => {
+    mockStat({ encMtimeMs: 1000, plainMtimeMs: null });
+    expect(await encryptedCredentialsIsNewerThanPlaintext()).toBe(true);
+  });
+
+  it("returns false when plaintext is newer", async () => {
+    mockStat({ encMtimeMs: 1000, plainMtimeMs: 2000 });
+    expect(await encryptedCredentialsIsNewerThanPlaintext()).toBe(false);
+  });
+
+  it("returns false when .enc does not exist", async () => {
+    defaultStatMock();
+    expect(await encryptedCredentialsIsNewerThanPlaintext()).toBe(false);
+  });
+
+  it("emits a hint pointing at issue #126 when plaintext is missing and .enc is newer", async () => {
+    mockStat({ encMtimeMs: 1000, plainMtimeMs: null });
+    const err = new Error("ENOENT") as NodeJS.ErrnoException;
+    err.code = "ENOENT";
+    mockRead(err);
+
+    const result = await loadCredentials();
+
+    expect(result.accessToken).toBeNull();
+    expect(result.error).toContain("encrypted credentials file");
+    expect(result.error).toContain("issues/126");
+  });
+
+  it("emits a hint pointing at issue #126 when refresh fails and .enc is newer", async () => {
+    mockStat({ encMtimeMs: 2000, plainMtimeMs: 1000 });
+    // Hard-expired so the fallback below does not kick in
+    const obtainedAt = Date.now() - 24 * 60 * 60 * 1000;
+    mockRead(storedAccountsFile(buildTokens({ obtained_at: obtainedAt })));
+    (requestUrl as jest.Mock).mockRejectedValueOnce(new Error("network down"));
+
+    const result = await loadCredentials();
+
+    expect(result.accessToken).toBeNull();
+    expect(result.error).toContain("refresh failed");
+    expect(result.error).toContain("issues/126");
+  });
+});
+
+describe("Credentials Service - refresh-failure fallback band-aid (#126)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    defaultStatMock();
+  });
+
+  it("falls back to existing access token when refresh fails but token has not hard-expired", async () => {
+    // Token is inside the 5-minute pre-expiry buffer but not actually expired.
+    // expires_in 600s (10 min), obtained_at 7 min ago → 3 min left.
+    const obtainedAt = Date.now() - 7 * 60 * 1000;
+    mockRead(
+      storedAccountsFile(buildTokens({ obtained_at: obtainedAt, expires_in: 600 }))
+    );
+    (requestUrl as jest.Mock).mockRejectedValueOnce(new Error("network down"));
+
+    const result = await loadCredentials();
+
+    expect(result.accessToken).toBe(mockAccessToken);
+    expect(result.error).toBeNull();
+  });
+
+  it("still errors when refresh fails and the token is hard-expired", async () => {
+    // 1 hour past expiry.
+    const obtainedAt = Date.now() - 7 * 60 * 60 * 1000;
+    mockRead(
+      storedAccountsFile(buildTokens({ obtained_at: obtainedAt, expires_in: 21600 }))
+    );
+    (requestUrl as jest.Mock).mockRejectedValueOnce(new Error("network down"));
+
+    const result = await loadCredentials();
+
+    expect(result.accessToken).toBeNull();
+    expect(result.error).toContain("refresh failed");
   });
 });


### PR DESCRIPTION
## Summary

- Free/Personal-plan users on the latest Granola desktop builds hit [#126](https://github.com/tomelliot/obsidian-granola-sync/issues/126) when the app encrypts its credentials (`stored-accounts.json.enc`). The current generic "credentials file not found" error gives no path forward.
- Add two complementary safety nets to `loadCredentials()` so this surfaces actionably.
- Desktop happy path is unchanged — both fixes only activate when something is already broken.

## How it works

**Detect encrypted-newer state**
- New `encryptedCredentialsIsNewerThanPlaintext()` checks if `stored-accounts.json.enc` exists and is newer than (or supersedes) the plaintext file.
- When detected, sync errors include a link to #126 and mention API key authentication as a Business/Enterprise workaround.

**Refresh-failure fallback**
- Distinguish "expires soon (5-min buffer)" from "hard-expired" via new `isTokenHardExpired()`.
- If refresh fails (network blip, server hiccup) but the existing access token hasn't actually expired yet, use it. Previously: any refresh failure poisoned the entire sync.
- Hard-expired tokens still surface the same clear error.

## Test plan

- [x] `npx jest tests/unit/credentials.test.ts` — 23 passed (15 existing + 8 new covering `.enc` mtime comparisons, missing plaintext, expired-vs-hard-expired, network failure paths, and error message content)
- [x] `npm test` — all 477 tests pass
- [x] `npm run lint` — clean
- [x] `npm run build` — production build succeeds
- [x] Reproduced #126 conditions on macOS by `touch`-ing `.enc` newer than plaintext; verified the new error message surfaces with the link

Closes #126