### PR TITLE
feat: add Granola Public API key authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,27 @@ Choose **Always Allow**. That records Obsidian as a trusted reader for this spec
 
 The same flow applies — your OS will ask once whether Obsidian may read Granola's credentials from its secret store (libsecret/kwallet on Linux, Credential Manager on Windows). Approve once and subsequent syncs are silent.
 
+### Alternative: API key authentication
+
+For Granola **Business / Enterprise** users, the plugin also supports authenticating against Granola's official [Public API](https://docs.granola.ai/introduction) with a `grn_*` key, as an opt-in alternative to reading the desktop credentials. Switch via **Settings → Authentication → Authentication method**. Desktop credentials remain the default.
+
+Caveats for API key mode:
+
+- The API returns Granola's **AI summary** (`summary_markdown`), not the ProseMirror enhanced-note body the desktop app syncs. By default, the plugin uses `apiSyncBodyMode = refresh-transcripts-only` to leave existing note bodies alone — only transcripts and frontmatter are updated. Use `force-refresh-all` as a one-shot if you want the API summary as canonical.
+- Private notes are not exposed; that toggle is disabled.
+- "Include shared notes" is controlled by your API key's scopes (Personal vs Public) when you create the key, not by the in-plugin toggle.
+- Existing files synced via desktop are deduplicated against the API by extracting the UUID from each note's `web_url` (no duplicate files when switching modes).
+- Your API key is stored in the plugin's `data.json`. If you sync your vault (Obsidian Sync, iCloud, Dropbox, Git), **the key syncs with it** — revoke and re-create if leaked.
+
+Use **Granola: Dry-run sync** to see exactly what would change in your vault before running a live API-mode sync.
+
 ## Configuration
+
+### Note and transcript settings
 
 1. Configure note syncing:
    - Choose whether to sync notes
-   - Optionally enable "Include Private Notes" to include your raw private notes at the top of each synced note
+   - Optionally enable "Include Private Notes" to include your raw private notes at the top of each synced note (desktop credentials only)
    - Select the destination: a specific folder, daily notes, or daily note folder structure
    - Optionally set a section heading for daily notes
 2. Configure transcript syncing:

--- a/docs/sync-process.md
+++ b/docs/sync-process.md
@@ -30,6 +30,64 @@ flowchart TD
     P --> H
 ```
 
+## Authentication
+
+The plugin supports two authentication methods, selected in **Settings → Authentication**:
+
+| Method | Endpoint | Plan | Source of credentials |
+|--------|----------|------|----------------------|
+| **Desktop credentials** (default) | `api.granola.ai` | Any (incl. free / Personal) | `stored-accounts.json` written by the Granola desktop app |
+| **API key** | `public-api.granola.ai` | Business or Enterprise | `grn_*` key entered in plugin settings, stored in plugin `data.json` |
+
+The auth method is resolved per sync via [`resolveAuth`](../src/services/auth.ts). Both paths produce a bearer token used by the appropriate API client; the rest of the sync pipeline is auth-agnostic.
+
+### Auth selection
+
+```mermaid
+flowchart TD
+  start[sync triggered]
+  resolve[resolveAuth settings]
+  desktop[loadCredentials → access token]
+  apikey[validate grn_ key]
+  fetcher[fetchDocumentsForSync]
+
+  start --> resolve
+  resolve -->|authMethod=desktop| desktop --> fetcher
+  resolve -->|authMethod=api_key| apikey --> fetcher
+```
+
+### API key mode caveats
+
+Switching to API key mode is **not a 1:1 replacement** for desktop sync:
+
+- **Note body comes from `summary_markdown`** (AI summary), not the ProseMirror enhanced-note body the desktop app syncs. The plugin defaults to `apiSyncBodyMode = refresh-transcripts-only` on first API sync to avoid rewriting every note body. `force-refresh-all` is available as a one-shot opt-in (auto-reverts after one sync).
+- **Private notes are not exposed** by the Public API; the corresponding toggle is disabled.
+- **Shared notes scope** is controlled by the API key's scopes (Personal vs Public) when it's created in Granola, not by the in-plugin toggle.
+- **Folder data** comes from `folder_membership` on each Get Note response. Folder renames are detected by diffing a per-`granola_id` snapshot persisted across syncs (`settings._apiFolderSnapshot`), since the API doesn't emit rename events.
+- **Eligibility:** the Public API only returns meetings with a finished AI summary + transcript. Notes you can browse in a shared workspace folder but don't own may not be returned — use desktop credentials for full shared-folder coverage.
+- **Rate limits:** the Public API is N+1 (one list call + one Get Note per note). The plugin throttles to ~4.5 req/s to stay below Granola's documented 5 req/s sustained limit, and gates `Get Note` calls behind the list endpoint's `updated_at` so unchanged notes don't re-fetch.
+
+### Legacy ID bridge
+
+When a vault has files previously synced via desktop credentials (frontmatter `granola_id` is the legacy UUID), API key mode dedups against them by extracting the UUID from each note's `web_url`:
+
+```mermaid
+flowchart LR
+  vaultFile["vault file granola_id uuid"]
+  apiNote["API Get Note web_url contains uuid"]
+  match{uuid matches?}
+  update["update same file"]
+  apiNote --> match
+  vaultFile --> match
+  match -->|yes| update
+```
+
+The bridge is in-memory only — it does not rewrite `granola_id` in frontmatter, so rollback to a previous plugin version stays safe. Files synced first via API mode that we later see in desktop mode will still match by id directly.
+
+### Dry-run
+
+A `Granola: Dry-run sync` command runs the full sync pipeline up to (but not including) `vault.create / vault.modify / vault.rename`. It intercepts writes at the `FileSyncService` boundary and produces a counted report (would-create / would-modify / would-rename / skip-…). Use this before enabling API key mode on a real vault to verify the expected scope of changes.
+
 ## Credentials Loading
 
 The plugin loads credentials by reading directly from the filesystem. This approach provides secure access to credentials stored in the Granola application's data directory without requiring a temporary HTTP server.
@@ -64,12 +122,13 @@ sequenceDiagram
 
 ### Credentials Service Details
 
-- **File Location**: `{OS-specific}/supabase.json`
-  - Windows: `%APPDATA%/Granola/supabase.json`
-  - Linux: `~/.config/Granola/supabase.json`
-  - macOS: `~/Library/Application Support/Granola/supabase.json`
-- **Token Path**: `workos_tokens.access_token` within the JSON structure
-- **Token Refresh**: Automatically refreshes expired tokens using the refresh token
+- **File Location**: `{OS-specific}/stored-accounts.json`
+  - Windows: `%APPDATA%/Granola/stored-accounts.json`
+  - Linux: `~/.config/Granola/stored-accounts.json`
+  - macOS: `~/Library/Application Support/Granola/stored-accounts.json`
+- **Token Path**: `accounts[0].tokens.access_token` within the JSON structure (where `accounts` and `tokens` may be JSON-encoded strings)
+- **Token Refresh**: Automatically refreshes expired tokens using the refresh token. If refresh fails but the existing access token hasn't hard-expired yet (only within the 5-minute pre-expiry buffer), the plugin falls back to using it so transient network blips don't block sync.
+- **Encrypted credentials detection**: If the Granola desktop app has migrated to `stored-accounts.json.enc` and that file is newer than the plaintext file this plugin reads, sync surfaces an actionable error pointing at [issue #126](https://github.com/tomelliot/obsidian-granola-sync/issues/126). Business / Enterprise users can switch to API key authentication as a workaround.
 - **Error Handling**: Provides clear error messages for:
   - File not found (ENOENT)
   - Permission errors (EACCES)

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,8 +13,6 @@ import {
   migrateSettingsToNewFormat,
 } from "./settings";
 import {
-  getAllDocuments,
-  getRecentDocuments,
   fetchGranolaTranscript,
   GranolaDoc,
   TranscriptEntry,
@@ -23,12 +21,24 @@ import {
   buildFolderMap,
   diffFolderMaps,
 } from "./services/folderMapBuilder";
-import {
-  loadCredentials as loadGranolaCredentials,
-} from "./services/credentials";
+import { resolveAuth, AuthResult } from "./services/auth";
 import { presentCredentialsError } from "./services/credentialsErrorPresenter";
 import { setPluginDirectory } from "./services/granolaCredentialsCrypto";
 import { KeychainPermissionModal } from "./ui/keychainPermissionModal";
+import {
+  fetchDocumentsForSync,
+  FetchedDoc,
+} from "./services/documentFetcher";
+import { PublicApiError, listAllFolders } from "./services/publicGranolaApi";
+import { DryRunRecorder } from "./services/dryRun";
+import { DryRunReportModal } from "./services/dryRunModal";
+import {
+  buildApiFolderSnapshot,
+  diffApiFolderSnapshots,
+  mergeApiFolderSnapshots,
+  folderListResponseToSnapshotFolders,
+  shouldRefetchFolders,
+} from "./services/apiFolderSnapshot";
 import {
   formatTranscriptBySpeaker,
   formatTranscriptBody,
@@ -53,6 +63,14 @@ export default class GranolaSync extends Plugin {
   private fileSyncService!: FileSyncService;
   private documentProcessor!: DocumentProcessor;
   private dailyNoteBuilder!: DailyNoteBuilder;
+  /**
+   * Active dry-run recorder for the current sync, if any. The orchestrator
+   * helpers consult this to short-circuit `vault.modify` /
+   * `processFrontMatter` / `saveData(settings)` calls that bypass the
+   * `FileSyncService` interception. Set in {@link sync} and cleared in the
+   * matching `finally`.
+   */
+  private dryRunRecorder: DryRunRecorder | null = null;
   statusBarItemEl: HTMLElement | null = null;
   statusBarTimeoutId: number | null = null;
 
@@ -86,6 +104,14 @@ export default class GranolaSync extends Plugin {
             "Granola sync: No sync options enabled. Please enable either notes or transcripts in settings."
           );
         }
+      },
+    });
+
+    this.addCommand({
+      id: "dry-run-granola",
+      name: "Dry-run sync (no writes)",
+      callback: async () => {
+        await this.runDryRun();
       },
     });
 
@@ -321,7 +347,15 @@ export default class GranolaSync extends Plugin {
           updatedFolders
         );
         if (updatedContent !== content) {
-          await this.app.vault.modify(file, updatedContent);
+          if (this.dryRunRecorder) {
+            this.dryRunRecorder.record({
+              outcome: "would-modify-frontmatter",
+              path: file.path,
+              reason: "folder rename",
+            });
+          } else {
+            await this.app.vault.modify(file, updatedContent);
+          }
           updatedCount++;
         }
       }
@@ -329,7 +363,7 @@ export default class GranolaSync extends Plugin {
 
     if (updatedCount > 0) {
       log.debug(
-        `Updated folders in ${updatedCount} file(s) due to folder renames`
+        `${this.dryRunRecorder ? "Dry-run: would update" : "Updated"} folders in ${updatedCount} file(s) due to folder renames`
       );
     }
   }
@@ -417,38 +451,354 @@ export default class GranolaSync extends Plugin {
       );
 
       if (updatedContent !== content) {
-        await this.app.vault.modify(file, updatedContent);
+        if (this.dryRunRecorder) {
+          this.dryRunRecorder.record({
+            outcome: "would-modify-frontmatter",
+            path: file.path,
+            granolaId,
+            reason: `backfill folders ${JSON.stringify(folders)}`,
+          });
+        } else {
+          await this.app.vault.modify(file, updatedContent);
+        }
         updatedCount++;
-        log.debug(`backfill updated — ${file.path} (granolaId=${granolaId}, folders=${JSON.stringify(folders)})`);
+        log.debug(`backfill ${this.dryRunRecorder ? "would update" : "updated"} — ${file.path} (granolaId=${granolaId}, folders=${JSON.stringify(folders)})`);
       }
     }
 
-    log.debug(`backfillFolderMetadata — scanned=${scannedCount} granola files, updated=${updatedCount}, alreadyHasFolders=${alreadyHasFoldersCount}, noFolderData=${noFolderDataCount}, noFrontmatter=${noFrontmatterCount}`);
+    log.debug(`backfillFolderMetadata — scanned=${scannedCount} granola files, ${this.dryRunRecorder ? "would-update" : "updated"}=${updatedCount}, alreadyHasFolders=${alreadyHasFoldersCount}, noFolderData=${noFolderDataCount}, noFrontmatter=${noFrontmatterCount}`);
+  }
+
+  /**
+   * Refreshes the API-mode folder snapshot and applies any detected renames.
+   *
+   * Runs in API-key mode regardless of whether this sync's window returned
+   * any notes — folder renames need to be detected even on empty incremental
+   * syncs. The work has three parts:
+   *
+   * 1. Merge this sync's per-note `folder_membership` into the persisted
+   *    snapshot.
+   * 2. Once per `FOLDERS_REFETCH_INTERVAL_MS` (or always on `mode: "full"`),
+   *    call `listFolders()` for the full hierarchy and merge it in. Catches
+   *    renames of folders whose notes didn't appear in this sync window.
+   * 3. Diff the previous snapshot against the merged one and dispatch any
+   *    renames to {@link updateRenamedFolders}.
+   *
+   * Failures of `listFolders` are soft — we log and continue so a transient
+   * network blip doesn't block the rest of sync.
+   */
+  private async refreshApiFolderState(
+    apiKey: string,
+    fetched: FetchedDoc[],
+    mode: "standard" | "full"
+  ): Promise<void> {
+    const partial = buildApiFolderSnapshot(
+      fetched
+        .filter((f) => f.folderMembership !== undefined)
+        .map((f) => ({ granolaId: f.doc.id, membership: f.folderMembership }))
+    );
+    const previousSnapshot =
+      this.settings._apiFolderSnapshot ?? { folders: {}, docFolders: {} };
+    let mergedSnapshot = mergeApiFolderSnapshots(previousSnapshot, partial);
+
+    const shouldFetchFullList =
+      mode === "full" ||
+      shouldRefetchFolders(Date.now(), this.settings._apiFoldersLastFetched);
+    if (shouldFetchFullList) {
+      try {
+        const allFolders = await listAllFolders(apiKey);
+        const fullFolders = folderListResponseToSnapshotFolders(allFolders);
+        mergedSnapshot = mergeApiFolderSnapshots(mergedSnapshot, {
+          folders: fullFolders,
+          docFolders: {},
+        });
+        this.settings._apiFoldersLastFetched = Date.now();
+        log.debug(
+          `Periodic listFolders refresh — ${Object.keys(fullFolders).length} folder(s)`
+        );
+      } catch (e) {
+        log.warn(
+          "Periodic listFolders call failed; continuing without full-hierarchy refresh",
+          e
+        );
+      }
+    }
+
+    const renamedPaths = diffApiFolderSnapshots(
+      previousSnapshot,
+      mergedSnapshot
+    );
+    if (renamedPaths.size > 0) {
+      log.debug(
+        `Detected ${renamedPaths.size} folder rename(s) (api_key mode)`
+      );
+      await this.updateRenamedFolders(renamedPaths);
+    }
+    this.settings._apiFolderSnapshot = mergedSnapshot;
+    await this.persistSettingsDuringSync();
+  }
+
+  /**
+   * Wrapper around `saveData(this.settings)` used by sync helpers. Skips the
+   * write entirely in dry-run mode so the user's `data.json` is left
+   * untouched. Live sync persists as before.
+   *
+   * This is intentionally a separate helper (rather than inlining the guard
+   * everywhere) so future settings persistence inside the sync run can't
+   * regress the dry-run contract — there's exactly one path.
+   */
+  private async persistSettingsDuringSync(): Promise<void> {
+    if (this.dryRunRecorder) {
+      log.debug(
+        "Dry-run: skipping saveData(settings) — settings persistence is read-only during dry-run"
+      );
+      return;
+    }
+    await this.saveData(this.settings);
+  }
+
+  /**
+   * Builds a `granolaId → updated_at` map from existing vault files. Used by
+   * the API-key fetcher to skip Get Note calls for notes whose remote
+   * `updated_at` hasn't moved since the last sync.
+   *
+   * Reads from `metadataCache.frontmatter` so this is O(n) over vault notes
+   * with no I/O — it relies on the already-populated cache populated by
+   * `fileSyncService.buildCache()`.
+   */
+  private buildKnownUpdatedAtMap(): Map<string, string | undefined> {
+    const out = new Map<string, string | undefined>();
+    for (const file of this.app.vault.getMarkdownFiles()) {
+      const cache = this.app.metadataCache.getFileCache(file);
+      const granolaId = cache?.frontmatter?.granola_id as string | undefined;
+      if (!granolaId) continue;
+      const updated = cache?.frontmatter?.updated as string | undefined;
+      out.set(granolaId, updated);
+    }
+    return out;
+  }
+
+  /**
+   * Surfaces a user-facing Notice for fetch failures. API-key 401s set the
+   * settings flag so the settings tab can show a "key revoked" badge until
+   * the next successful sync clears it.
+   */
+  /**
+   * Note on dry-run: this helper deliberately does NOT route its
+   * `saveData(...)` calls through {@link persistSettingsDuringSync}. The
+   * `_lastApiAuthError` flag is diagnostic — a 401 detected during a
+   * dry-run is real (the key really was rejected), and surfacing the badge
+   * in settings UI helps the user fix it without needing to run a live sync
+   * first. The only persistence side-effect here is that one boolean.
+   */
+  private async handleFetchError(
+    error: unknown,
+    auth: AuthResult
+  ): Promise<void> {
+    if (error instanceof PublicApiError) {
+      if (error.status === 401) {
+        new Notice(
+          "Granola API key invalid or revoked — open settings to fix.",
+          10000
+        );
+        this.settings._lastApiAuthError = true;
+        await this.saveData(this.settings);
+      } else if (error.status === 429) {
+        new Notice(
+          "Granola sync error: rate limited by the Granola API. Try again in a minute.",
+          10000
+        );
+      } else if (error.status >= 500) {
+        new Notice(
+          "Granola sync error: Granola API server error. Please try again later.",
+          10000
+        );
+      } else {
+        new Notice(
+          `Granola sync error: ${error.message}` +
+            (error.requestId ? ` (request-id ${error.requestId})` : ""),
+          10000
+        );
+      }
+      log.error(
+        `Public API error during fetch — status=${error.status}, requestId=${error.requestId ?? "<none>"}`,
+        error
+      );
+      return;
+    }
+    const errorStatus = (error as { status?: number })?.status;
+    if (errorStatus === 401) {
+      new Notice(
+        auth.method === "api_key"
+          ? "Granola API key invalid or revoked — open settings to fix."
+          : "Granola sync error: Authentication failed. Your access token may have expired. Please reload Granola to update your credentials file.",
+        10000
+      );
+      if (auth.method === "api_key") {
+        this.settings._lastApiAuthError = true;
+        await this.saveData(this.settings);
+      }
+    } else if (errorStatus === 403) {
+      new Notice("Granola sync error: Access forbidden.", 10000);
+    } else if (errorStatus === 404) {
+      new Notice("Granola sync error: API endpoint not found.", 10000);
+    } else if (errorStatus && errorStatus >= 500) {
+      new Notice(
+        "Granola sync error: Granola API server error. Please try again later.",
+        10000
+      );
+    } else {
+      new Notice(
+        "Granola sync error: Failed to fetch documents from Granola API. Please check your internet connection.",
+        10000
+      );
+    }
+    log.error("Error fetching Granola documents:", error);
   }
 
   // Top-level sync function that handles common setup once
-  async sync(options: { mode?: "standard" | "full" } = {}) {
+  async sync(
+    options: { mode?: "standard" | "full"; dryRun?: DryRunRecorder } = {}
+  ) {
     const mode = options.mode ?? "standard";
-    log.debug(`Sync started — mode=${mode}, daysBack=${this.settings.syncDaysBack}`);
-    showStatusBar(this, "Granola sync: Syncing...");
-
-    // Load credentials at the start of each sync
-    const credentialsResult = await loadGranolaCredentials();
-    const { accessToken } = credentialsResult;
-    if (!accessToken || credentialsResult.error) {
-      log.error("Error loading Granola credentials:", credentialsResult.error);
-      presentCredentialsError(
-        {
-          ...credentialsResult,
-          error: credentialsResult.error ?? "No access token loaded.",
-        },
-        {
-          onKeychainDenied: () =>
-            new KeychainPermissionModal(this.app).open(),
-          onOtherError: (message) =>
-            new Notice(`Granola sync error: ${message}`, 10000),
+    log.debug(`Sync started — mode=${mode}, daysBack=${this.settings.syncDaysBack}, dryRun=${options.dryRun ? "yes" : "no"}`);
+    showStatusBar(
+      this,
+      options.dryRun ? "Granola dry-run: Syncing..." : "Granola sync: Syncing..."
+    );
+    // Wire dry-run interception into both the FileSyncService write paths
+    // AND the orchestrator-level write paths (backfill, cross-links,
+    // rename-application, settings persistence) for the duration of this
+    // sync. The orchestrator helpers consult `this.dryRunRecorder` directly.
+    //
+    // In-memory settings snapshot: even though we skip writing settings to
+    // disk during dry-run, individual code paths still mutate `this.settings`
+    // in place (e.g. `this.settings.latestSyncTime = Date.now()`). Without
+    // a snapshot, two back-to-back dry-runs in the same Obsidian session see
+    // different state because the first run advanced the in-memory clock.
+    // We snapshot before the run and restore after, with one documented
+    // exception: `_lastApiAuthError = true` (a 401 surfaced by dry-run is
+    // real and we want the settings UI badge to show until the user fixes
+    // the key — that mutation is allowed through).
+    this.dryRunRecorder = options.dryRun ?? null;
+    this.fileSyncService.setDryRunRecorder(options.dryRun ?? null);
+    this.dailyNoteBuilder.setDryRunRecorder(options.dryRun ?? null);
+    const settingsSnapshot = options.dryRun
+      ? this.snapshotSettings()
+      : null;
+    try {
+      return await this._sync(mode, options.dryRun ?? null);
+    } finally {
+      if (settingsSnapshot) {
+        const lastApiAuthError = this.settings._lastApiAuthError;
+        this.restoreSettingsSnapshot(settingsSnapshot);
+        // Preserve the 401 flag from this dry-run (documented exception)
+        if (lastApiAuthError) {
+          this.settings._lastApiAuthError = lastApiAuthError;
         }
-      );
+      }
+      this.dryRunRecorder = null;
+      this.fileSyncService.setDryRunRecorder(null);
+      this.dailyNoteBuilder.setDryRunRecorder(null);
+    }
+  }
+
+  /**
+   * Runs a dry-run sync and shows the report inline via {@link DryRunReportModal}.
+   *
+   * Single entry point for both the command palette command and the settings
+   * "Dry-run sync" button — keeps the UX consistent and the recorder lifecycle
+   * in one place.
+   */
+  async runDryRun(): Promise<void> {
+    new Notice("Granola dry-run: Starting (no files will be modified).");
+    const recorder = new DryRunRecorder();
+    const startedAt = new Date();
+    try {
+      await this.sync({ dryRun: recorder });
+    } catch (e) {
+      // sync() catches and surfaces its own errors via Notice + log.error,
+      // so we expect to be told via the recorder + Notice rather than via a
+      // thrown error. If something escaped, surface it so the modal still
+      // opens with the partial state captured up to the failure.
+      log.error("Dry-run threw unexpectedly; opening modal with partial state.", e);
+    }
+    const finishedAt = new Date();
+    log.info(recorder.summarize());
+    new DryRunReportModal(this.app, recorder, startedAt, finishedAt).open();
+  }
+
+  /**
+   * Captures the current settings state for restoration after a dry-run.
+   *
+   * Uses `structuredClone` to deep-copy nested fields like `_folderMapCache`
+   * and `_apiFolderSnapshot` so in-place mutations inside the sync don't
+   * surface in the snapshot. Falls back to a JSON round-trip for older
+   * runtimes that lack `structuredClone` (none of Obsidian's supported
+   * platforms, but safer to guard).
+   */
+  private snapshotSettings(): GranolaSyncSettings {
+    if (typeof structuredClone === "function") {
+      return structuredClone(this.settings);
+    }
+    return JSON.parse(JSON.stringify(this.settings)) as GranolaSyncSettings;
+  }
+
+  /**
+   * Restores settings to the snapshot taken at the start of a dry-run.
+   *
+   * Mutates `this.settings` in place (not reassign) so the closure-captured
+   * `getSettings` reference in {@link FileSyncService} keeps pointing at
+   * the same object. Replacing keys, not the object identity.
+   */
+  private restoreSettingsSnapshot(snapshot: GranolaSyncSettings): void {
+    // Delete keys that were added during the dry-run but aren't in the
+    // snapshot, then re-apply snapshot values. This handles the case where
+    // a sync added a new field (e.g. `_apiFoldersLastFetched` on first ever
+    // API sync).
+    for (const k of Object.keys(this.settings) as Array<keyof GranolaSyncSettings>) {
+      if (!(k in snapshot)) {
+        delete this.settings[k];
+      }
+    }
+    Object.assign(this.settings, snapshot);
+  }
+
+  private async _sync(
+    mode: "standard" | "full",
+    dryRun: DryRunRecorder | null
+  ): Promise<void> {
+
+    // Resolve auth (desktop credentials or API key) at the start of each sync.
+    // The desktop path returns the full `credentialsResult` so we can route
+    // keychain-denied / decrypt-error states through the dedicated modal that
+    // ships with the desktop credential decryption work (PR #130).
+    const { auth, error, credentialsResult } = await resolveAuth(this.settings);
+    if (!auth || error) {
+      log.error("Error resolving Granola auth:", error);
+      if (credentialsResult) {
+        // Desktop path failure — `presentCredentialsError` routes
+        // `errorKind === "keychain"` to the modal and everything else to a
+        // Notice. Keeps the UX consistent with the desktop-only sync flow.
+        presentCredentialsError(
+          {
+            ...credentialsResult,
+            error: credentialsResult.error ?? "No access token loaded.",
+          },
+          {
+            onKeychainDenied: () =>
+              new KeychainPermissionModal(this.app).open(),
+            onOtherError: (message) =>
+              new Notice(`Granola sync error: ${message}`, 10000),
+          }
+        );
+      } else {
+        // API key path failure (no credentials file involved) — simple Notice.
+        new Notice(
+          `Granola sync error: ${error || "No credentials available."}`,
+          10000
+        );
+      }
       hideStatusBar(this);
       return;
     }
@@ -456,51 +806,55 @@ export default class GranolaSync extends Plugin {
     // Build the Granola ID cache before syncing
     await this.fileSyncService.buildCache();
 
-    // Fetch documents
-    let documents: GranolaDoc[] = [];
-    const includeShared = this.settings.includeSharedNotes;
+    // Build the list-level updated_at gate for API-key mode. This lets the
+    // fetcher skip Get Note calls for notes whose remote timestamp hasn't
+    // moved since the last sync — the dominant cost saver on large vaults.
+    let knownUpdatedAtByGranolaId: Map<string, string | undefined> | undefined;
+    if (auth.method === "api_key") {
+      knownUpdatedAtByGranolaId = this.buildKnownUpdatedAtMap();
+    }
+
+    // Fetch documents via the appropriate API for this auth method
+    let fetched: FetchedDoc[];
     try {
-      if (mode === "full") {
-        documents = await getAllDocuments(accessToken, 100, includeShared);
-      } else {
-        documents = await getRecentDocuments(
-          accessToken,
-          this.settings.syncDaysBack,
-          100,
-          includeShared
-        );
-      }
+      fetched = await fetchDocumentsForSync(auth, this.settings, {
+        mode,
+        includeTranscripts: this.settings.syncTranscripts,
+        knownUpdatedAtByGranolaId,
+        latestSyncTime: this.settings.latestSyncTime,
+      });
     } catch (error: unknown) {
-      const errorStatus = (error as { status?: number })?.status;
-      if (errorStatus === 401) {
-        new Notice(
-          "Granola sync error: Authentication failed. Your access token may have expired. Please reload Granola to update your credentials file.",
-          10000
-        );
-      } else if (errorStatus === 403) {
-        new Notice(
-          "Granola sync error: Access forbidden. Please check your permissions.",
-          10000
-        );
-      } else if (errorStatus === 404) {
-        new Notice(
-          "Granola sync error: API endpoint not found. Please check for updates.",
-          10000
-        );
-      } else if (errorStatus && errorStatus >= 500) {
-        new Notice(
-          "Granola sync error: Granola API server error. Please try again later.",
-          10000
-        );
-      } else {
-        new Notice(
-          "Granola sync error: Failed to fetch documents from Granola API. Please check your internet connection.",
-          10000
-        );
-      }
-      log.error("Error fetching Granola documents:", error);
+      await this.handleFetchError(error, auth);
       hideStatusBar(this);
       return;
+    }
+
+    // Clear any "last sync was 401" flag — we got past the fetch.
+    if (this.settings._lastApiAuthError) {
+      this.settings._lastApiAuthError = false;
+      await this.persistSettingsDuringSync();
+    }
+
+    // For API-key mode we already have folder data inline on each FetchedDoc
+    // and pre-fetched transcripts. The desktop path still uses the legacy
+    // accessToken for the folder-map builder and transcript endpoint.
+    const accessToken = auth.method === "desktop" ? auth.token : "";
+    let documents: GranolaDoc[] = fetched.map((f) => f.doc);
+    const apiFoldersByDocId = new Map<string, string[]>();
+    const apiTranscriptsByDocId = new Map<string, TranscriptEntry[]>();
+    const publicIdByDocId = new Map<string, string>();
+    for (const f of fetched) {
+      if (f.folders) apiFoldersByDocId.set(f.doc.id, f.folders);
+      if (f.apiTranscript) apiTranscriptsByDocId.set(f.doc.id, f.apiTranscript);
+      if (f.publicId) publicIdByDocId.set(f.doc.id, f.publicId);
+    }
+
+    // Record ID bridge alias entries so updateExistingFile and isRemoteNewer
+    // can resolve by either the legacy UUID or the public `not_*` id.
+    for (const [docId, publicId] of publicIdByDocId) {
+      this.fileSyncService.recordPublicIdBridge(publicId, docId, "note");
+      this.fileSyncService.recordPublicIdBridge(publicId, docId, "transcript");
+      this.fileSyncService.recordPublicIdBridge(publicId, docId, "combined");
     }
 
     // Apply title filter
@@ -509,6 +863,13 @@ export default class GranolaSync extends Plugin {
       this.settings.titleFilterMode,
       this.settings.titleFilterKeyword
     );
+
+    // API-mode folder housekeeping runs BEFORE the empty-docs early-return.
+    // An incremental sync window may return zero notes while a folder rename
+    // still needs to be detected via the periodic listFolders() refresh.
+    if (auth.method === "api_key") {
+      await this.refreshApiFolderState(auth.token, fetched, mode);
+    }
 
     if (documents.length === 0) {
       new Notice(
@@ -530,34 +891,42 @@ export default class GranolaSync extends Plugin {
 
     // Build folder map (document → folder paths)
     let docFolders: Record<string, string[]> = {};
-    try {
-      showStatusBar(this, "Granola sync: Fetching folders...");
-      const freshFolderMap = await buildFolderMap(accessToken);
-      const previousFolderMap = this.settings._folderMapCache ?? null;
+    if (auth.method === "desktop") {
+      try {
+        showStatusBar(this, "Granola sync: Fetching folders...");
+        const freshFolderMap = await buildFolderMap(accessToken);
+        const previousFolderMap = this.settings._folderMapCache ?? null;
 
-      // Detect folder renames and update affected notes
-      const diff = diffFolderMaps(previousFolderMap, freshFolderMap);
-      if (diff.renamedPaths.size > 0) {
-        log.debug(`Detected ${diff.renamedPaths.size} folder rename(s)`);
-        await this.updateRenamedFolders(diff.renamedPaths);
+        // Detect folder renames and update affected notes
+        const diff = diffFolderMaps(previousFolderMap, freshFolderMap);
+        if (diff.renamedPaths.size > 0) {
+          log.debug(`Detected ${diff.renamedPaths.size} folder rename(s)`);
+          await this.updateRenamedFolders(diff.renamedPaths);
+        }
+
+        // Persist the fresh folder map
+        this.settings._folderMapCache = freshFolderMap;
+        await this.persistSettingsDuringSync();
+
+        docFolders = freshFolderMap.docFolders;
+        log.debug(`Folder map built — ${Object.keys(freshFolderMap.folders).length} folder(s), ${Object.keys(docFolders).length} document(s) with folder data`);
+
+        // Backfill folders on existing notes that don't have the field yet
+        await this.backfillFolderMetadata(docFolders);
+      } catch (error) {
+        log.error("Failed to build folder map, continuing sync without folder data:", error);
+        // Use previously cached data if available
+        if (this.settings._folderMapCache) {
+          docFolders = this.settings._folderMapCache.docFolders;
+          log.debug("Using cached folder map from previous sync");
+        }
       }
-
-      // Persist the fresh folder map
-      this.settings._folderMapCache = freshFolderMap;
-      await this.saveData(this.settings);
-
-      docFolders = freshFolderMap.docFolders;
-      log.debug(`Folder map built — ${Object.keys(freshFolderMap.folders).length} folder(s), ${Object.keys(docFolders).length} document(s) with folder data`);
-
-      // Backfill folders on existing notes that don't have the field yet
+    } else {
+      // API-key mode: folder snapshot / rename detection already ran via
+      // refreshApiFolderState() above the empty-docs early-return. Here we
+      // only need to thread the per-doc folder paths through to backfill.
+      docFolders = Object.fromEntries(apiFoldersByDocId.entries());
       await this.backfillFolderMetadata(docFolders);
-    } catch (error) {
-      log.error("Failed to build folder map, continuing sync without folder data:", error);
-      // Use previously cached data if available
-      if (this.settings._folderMapCache) {
-        docFolders = this.settings._folderMapCache.docFolders;
-        log.debug("Using cached folder map from previous sync");
-      }
     }
 
     const forceOverwrite = mode === "full";
@@ -565,13 +934,45 @@ export default class GranolaSync extends Plugin {
     if (this.settings.syncTranscripts) {
       const transcriptResult = await this.syncTranscripts(
         documents,
-        accessToken,
-        forceOverwrite
+        auth,
+        forceOverwrite,
+        apiTranscriptsByDocId
       );
       transcriptDataMap = transcriptResult.transcriptDataMap;
     }
     if (this.settings.syncNotes) {
-      await this.syncNotes(documents, forceOverwrite, transcriptDataMap, docFolders);
+      // API-key mode body-write policy:
+      // - `refresh-transcripts-only` (default): preserve note bodies on
+      //   EXISTING files (don't overwrite the desktop-rendered ProseMirror
+      //   body the user already has), but still CREATE missing notes. This
+      //   resolves "orphan" cases where desktop sync wrote a transcript
+      //   before Granola finished the AI summary and the matching note
+      //   never landed.
+      // - `force-refresh-all`: write everything (one-shot, auto-reverts).
+      // - `normal`: write when remote is newer (desktop-equivalent behavior).
+      // - Desktop auth: pass through with `skipExistingBodies = false`.
+      //
+      // Daily-notes mode in `refresh-transcripts-only` is not yet covered by
+      // per-doc orphan-fix; see `syncNotesToDailyNotes` for why.
+      const apiBodyMode =
+        auth.method === "api_key" ? this.settings.apiSyncBodyMode : "normal";
+      const skipExistingBodies = apiBodyMode === "refresh-transcripts-only";
+      await this.syncNotes(
+        documents,
+        forceOverwrite || apiBodyMode === "force-refresh-all",
+        transcriptDataMap,
+        docFolders,
+        { skipExistingBodies }
+      );
+      // force-refresh-all is a one-shot: auto-revert so users don't permanently
+      // run in body-rewriting mode after a single corrective sync.
+      if (apiBodyMode === "force-refresh-all") {
+        log.debug(
+          "Auto-reverting apiSyncBodyMode from force-refresh-all to refresh-transcripts-only after a completed sync"
+        );
+        this.settings.apiSyncBodyMode = "refresh-transcripts-only";
+        await this.persistSettingsDuringSync();
+      }
     }
 
     // Update frontmatter cross-links between notes and transcripts using
@@ -586,24 +987,28 @@ export default class GranolaSync extends Plugin {
     documents: GranolaDoc[],
     forceOverwrite: boolean = false,
     transcriptDataMap: Map<string, TranscriptEntry[]> | null = null,
-    docFolders: Record<string, string[]> = {}
+    docFolders: Record<string, string[]> = {},
+    options: { skipExistingBodies?: boolean } = {}
   ): Promise<void> {
     let syncedCount: number;
-    log.debug(`syncNotes — mode=${this.settings.saveAsIndividualFiles ? "individual" : "daily-notes"}, docs=${documents.length}`);
+    const skipExistingBodies = options.skipExistingBodies ?? false;
+    log.debug(`syncNotes — mode=${this.settings.saveAsIndividualFiles ? "individual" : "daily-notes"}, docs=${documents.length}, skipExistingBodies=${skipExistingBodies}`);
 
     if (!this.settings.saveAsIndividualFiles) {
       syncedCount = await this.syncNotesToDailyNotes(
         documents,
         forceOverwrite,
         transcriptDataMap,
-        docFolders
+        docFolders,
+        { skipExistingBodies }
       );
     } else {
       const result = await this.syncNotesToIndividualFiles(
         documents,
         forceOverwrite,
         transcriptDataMap,
-        docFolders
+        docFolders,
+        { skipExistingBodies }
       );
       syncedCount = result.syncedCount;
 
@@ -627,7 +1032,7 @@ export default class GranolaSync extends Plugin {
     this.settings.latestSyncTime = Date.now();
     // Persist directly: saveSettings() rebuilds services and would clear the
     // FileSyncService cache mid-sync, breaking updateCrossLinks().
-    await this.saveData(this.settings);
+    await this.persistSettingsDuringSync();
 
     log.debug(`Saved ${syncedCount} note(s)`);
   }
@@ -636,8 +1041,38 @@ export default class GranolaSync extends Plugin {
     documents: GranolaDoc[],
     forceOverwrite: boolean = false,
     transcriptDataMap: Map<string, TranscriptEntry[]> | null = null,
-    docFolders: Record<string, string[]> = {}
+    docFolders: Record<string, string[]> = {},
+    options: { skipExistingBodies?: boolean } = {}
   ): Promise<number> {
+    // Daily-notes mode + skipExistingBodies (API-key refresh-transcripts-only):
+    // sections live INSIDE daily-note files and the existing updater replaces
+    // the entire heading-to-next-heading block as a unit. Implementing a
+    // per-doc "only fill missing sections, never overwrite existing ones"
+    // requires refactoring `updateDailyNoteSection` to splice sections rather
+    // than rewrite. Until that's done, the safe fallback is to skip the whole
+    // method — preserving existing daily notes. The cost: orphan notes in
+    // daily-notes mode won't auto-resolve on API sync until this lands. Track
+    // as a follow-up; out of scope for the orphan-fix in PR-current.
+    if (options.skipExistingBodies) {
+      log.warn(
+        "syncNotesToDailyNotes — skipExistingBodies requested but per-doc " +
+          "orphan-fix is not yet implemented for daily-notes mode. Skipping all " +
+          "note writes for this sync. (Transcripts and folder housekeeping still ran.)"
+      );
+      if (this.dryRunRecorder) {
+        for (const doc of documents) {
+          this.dryRunRecorder.record({
+            outcome: "skip-body-write-disabled",
+            path: this.pathResolver.computeNotePath(doc),
+            granolaId: doc.id,
+            type: "note",
+            reason:
+              "apiSyncBodyMode=refresh-transcripts-only (daily-notes mode — per-doc orphan-fix not yet supported)",
+          });
+        }
+      }
+      return 0;
+    }
     const dailyNotesMap = this.dailyNoteBuilder.buildDailyNotesMap(documents, docFolders);
     const sectionHeadingSetting = (
       this.settings.dailyNoteSectionHeading ||
@@ -653,6 +1088,22 @@ export default class GranolaSync extends Plugin {
       const dailyNoteFile = await this.dailyNoteBuilder.getOrCreateDailyNote(
         dateKey
       );
+      if (!dailyNoteFile) {
+        // Dry-run + daily note does not exist on disk yet.
+        // `getOrCreateDailyNote` already recorded a would-create event;
+        // we record the intended write and skip the section-update step
+        // (there's no file to read or modify).
+        if (this.dryRunRecorder) {
+          this.dryRunRecorder.record({
+            outcome: "would-modify",
+            path: `(daily note for ${dateKey})`,
+            reason: `would write ${notesWithDocs.length} note section(s) into new daily note`,
+          });
+        }
+        processedCount += notesWithDocs.length;
+        this.updateSyncStatus("Note", processedCount, documents.length);
+        continue;
+      }
 
       // Extract just the note data for comparison
       const notesForDay = notesWithDocs.map((item) => item.noteData);
@@ -737,7 +1188,8 @@ export default class GranolaSync extends Plugin {
     documents: GranolaDoc[],
     forceOverwrite: boolean = false,
     transcriptDataMap: Map<string, TranscriptEntry[]> | null = null,
-    docFolders: Record<string, string[]> = {}
+    docFolders: Record<string, string[]> = {},
+    options: { skipExistingBodies?: boolean } = {}
   ): Promise<{
     syncedCount: number;
     syncedNotes: Array<{ doc: GranolaDoc; notePath: string }>;
@@ -751,23 +1203,43 @@ export default class GranolaSync extends Plugin {
     const isCombinedMode =
       this.settings.syncTranscripts &&
       this.settings.transcriptHandling === "combined";
+    const skipExistingBodies = options.skipExistingBodies ?? false;
 
     for (const doc of documents) {
       const notePath = this.pathResolver.computeNotePath(doc);
+      const fileType: "note" | "combined" = isCombinedMode ? "combined" : "note";
+      const existingNote = this.fileSyncService.findByGranolaId(doc.id, fileType);
+
+      // refresh-transcripts-only: preserve the body on EXISTING files but
+      // still create missing ones. Resolves orphans without clobbering the
+      // user's desktop-rendered ProseMirror body when present. Subsequent
+      // syncs see the created note as "existing" and preserve it from then
+      // on (user-edit safety).
+      if (skipExistingBodies && existingNote) {
+        log.debug(
+          `Skipping body write for ${doc.id} — file exists at ${existingNote.path} (skipExistingBodies)`
+        );
+        if (this.dryRunRecorder) {
+          this.dryRunRecorder.record({
+            outcome: "skip-body-write-disabled",
+            path: existingNote.path,
+            granolaId: doc.id,
+            type: fileType,
+            reason: "apiSyncBodyMode=refresh-transcripts-only",
+          });
+        }
+        continue;
+      }
 
       // Skip processing if note already exists locally and is up-to-date (unless forceOverwrite is true)
       if (!forceOverwrite) {
-        const existingNote = this.fileSyncService.findByGranolaId(
-          doc.id,
-          isCombinedMode ? "combined" : "note"
-        );
         if (existingNote) {
           // Check if remote is newer than local
           if (
             !this.fileSyncService.isRemoteNewer(
               doc.id,
               getEffectiveUpdatedAt(doc),
-              isCombinedMode ? "combined" : "note"
+              fileType
             )
           ) {
             log.debug(`Skipping doc ${doc.id} — local copy is up-to-date`);
@@ -866,12 +1338,21 @@ export default class GranolaSync extends Plugin {
           const noteFile = this.fileSyncService.findByGranolaId(doc.id, "note");
           if (noteFile) {
             noteLinkPath = noteFile.path;
-            await this.app.fileManager.processFrontMatter(
-              noteFile,
-              (fm: Record<string, unknown>) => {
-                fm.transcript = `[[${transcriptFile.path}]]`;
-              }
-            );
+            if (this.dryRunRecorder) {
+              this.dryRunRecorder.record({
+                outcome: "would-modify-frontmatter",
+                path: noteFile.path,
+                granolaId: doc.id,
+                reason: `cross-link transcript=[[${transcriptFile.path}]]`,
+              });
+            } else {
+              await this.app.fileManager.processFrontMatter(
+                noteFile,
+                (fm: Record<string, unknown>) => {
+                  fm.transcript = `[[${transcriptFile.path}]]`;
+                }
+              );
+            }
           }
         } else {
           // Daily notes mode: link to the daily note heading
@@ -885,29 +1366,45 @@ export default class GranolaSync extends Plugin {
         }
 
         if (noteLinkPath) {
-          await this.app.fileManager.processFrontMatter(
-            transcriptFile,
-            (fm: Record<string, unknown>) => {
-              fm.note = `[[${noteLinkPath}]]`;
-            }
-          );
+          if (this.dryRunRecorder) {
+            this.dryRunRecorder.record({
+              outcome: "would-modify-frontmatter",
+              path: transcriptFile.path,
+              granolaId: doc.id,
+              reason: `cross-link note=[[${noteLinkPath}]]`,
+            });
+          } else {
+            await this.app.fileManager.processFrontMatter(
+              transcriptFile,
+              (fm: Record<string, unknown>) => {
+                fm.note = `[[${noteLinkPath}]]`;
+              }
+            );
+          }
+          // Only count a "pair" when we actually had both sides to link. If
+          // the matching note file didn't exist locally (`noteLinkPath` was
+          // never set), there's nothing to record — and bumping the counter
+          // would produce a misleading "Updated cross-links in N pair(s)"
+          // log line.
+          updatedCount++;
         }
-
-        updatedCount++;
       } catch (e) {
         log.error(`updateCrossLinks: failed for doc ${doc.id}:`, e);
       }
     }
 
     if (updatedCount > 0) {
-      log.debug(`Updated cross-links in ${updatedCount} note/transcript pair(s)`);
+      log.debug(
+        `${this.dryRunRecorder ? "Dry-run: would update" : "Updated"} cross-links in ${updatedCount} note/transcript pair(s)`
+      );
     }
   }
 
   private async syncTranscripts(
     documents: GranolaDoc[],
-    accessToken: string,
-    forceOverwrite: boolean = false
+    auth: AuthResult,
+    forceOverwrite: boolean = false,
+    apiTranscriptsByDocId?: Map<string, TranscriptEntry[]>
   ): Promise<{ transcriptDataMap: Map<string, TranscriptEntry[]> }> {
     const transcriptDataMap = new Map<string, TranscriptEntry[]>();
     const isCombinedMode = this.settings.transcriptHandling === "combined";
@@ -940,10 +1437,13 @@ export default class GranolaSync extends Plugin {
           }
         }
 
-        const transcriptData: TranscriptEntry[] = await fetchGranolaTranscript(
-          accessToken,
-          docId
-        );
+        // In API-key mode, the transcript was already fetched inline with the
+        // note. The desktop path still hits /v1/get-document-transcript.
+        const transcriptData: TranscriptEntry[] =
+          apiTranscriptsByDocId?.get(docId) ??
+          (auth.method === "desktop"
+            ? await fetchGranolaTranscript(auth.token, docId)
+            : []);
         if (transcriptData.length === 0) {
           log.debug(`Skipping transcript for doc ${docId} — API returned empty transcript`);
           continue;
@@ -1000,3 +1500,4 @@ export default class GranolaSync extends Plugin {
     return { transcriptDataMap };
   }
 }
+

--- a/src/services/apiFolderSnapshot.ts
+++ b/src/services/apiFolderSnapshot.ts
@@ -1,0 +1,183 @@
+import type {
+  PublicFolderMembershipEntry,
+  PublicListFoldersResponse,
+  PublicFolder,
+} from "./publicApiSchemas";
+import { resolveFolderPath, type FolderInfo } from "./folderMapBuilder";
+
+/**
+ * Default interval between full `listFolders()` API calls in API-key mode.
+ *
+ * Per-sync folder list calls would catch renames in folders whose notes
+ * didn't appear in the incremental sync window, but the cost adds up
+ * (especially with `mode: "standard"` running on a periodic timer). A daily
+ * cadence catches the rename within 24h with one extra request per day.
+ *
+ * Override at the call site (e.g. tests) by passing a different interval to
+ * {@link shouldRefetchFolders}; the constant is the default.
+ */
+export const FOLDERS_REFETCH_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Persisted snapshot of folder state from Public API syncs.
+ *
+ * Mirrors the shape of `FolderMapData` (the desktop equivalent) so the same
+ * `resolveFolderPath` + diff algorithm can be reused. The difference is the
+ * source of data:
+ *
+ * - Desktop sync gets folder hierarchy from `get-document-lists-metadata` +
+ *   `get-document-list`, which always returns *every* folder + membership.
+ * - Public API only gives us `folder_membership` inline on each Get Note
+ *   response. We only observe folders that have at least one note in the
+ *   current sync window. Use {@link mergeApiFolderSnapshots} to preserve
+ *   previously-seen folders that a partial sync didn't include.
+ *
+ * Storing folder IDs (not just slashed paths) is what makes rename detection
+ * robust against parent renames, sibling collisions, and incremental fetches.
+ */
+export interface ApiFolderSnapshot {
+  /** Stable folder ID → folder metadata. */
+  folders: Record<string, FolderInfo>;
+  /** Granola doc ID → array of folder IDs the doc belongs to. */
+  docFolders: Record<string, string[]>;
+}
+
+export interface SnapshotInput {
+  /** Internal granola_id (UUID extracted from web_url) for this doc. */
+  granolaId: string;
+  membership: PublicFolderMembershipEntry[] | undefined;
+}
+
+/**
+ * Builds a fresh snapshot from a batch of Get Note responses. The caller is
+ * expected to pass *every* doc returned in this sync's window; previously-seen
+ * folders not in this batch are merged in via {@link mergeApiFolderSnapshots}.
+ */
+export function buildApiFolderSnapshot(
+  inputs: SnapshotInput[]
+): ApiFolderSnapshot {
+  const folders: Record<string, FolderInfo> = {};
+  const docFolders: Record<string, string[]> = {};
+
+  for (const { granolaId, membership } of inputs) {
+    const seen = new Set<string>();
+    const ids: string[] = [];
+    if (membership) {
+      for (const entry of membership) {
+        folders[entry.id] = {
+          title: entry.name,
+          parentId: entry.parent_folder_id ?? null,
+        };
+        if (!seen.has(entry.id)) {
+          seen.add(entry.id);
+          ids.push(entry.id);
+        }
+      }
+    }
+    docFolders[granolaId] = ids;
+  }
+
+  return { folders, docFolders };
+}
+
+/**
+ * Merges a fresh (possibly partial) snapshot into a previously-persisted one.
+ *
+ * - `partial.folders` entries override `previous.folders` (folder metadata
+ *   can change; the fresh observation wins).
+ * - `partial.docFolders` entries override `previous.docFolders` only for the
+ *   docs present in `partial`; other docs' previous folder lists are kept.
+ *
+ * The result is suitable for both writing back to settings as the new
+ * snapshot AND for diffing against the previous one — see
+ * {@link diffApiFolderSnapshots}.
+ */
+export function mergeApiFolderSnapshots(
+  previous: ApiFolderSnapshot,
+  partial: ApiFolderSnapshot
+): ApiFolderSnapshot {
+  return {
+    folders: { ...previous.folders, ...partial.folders },
+    docFolders: { ...previous.docFolders, ...partial.docFolders },
+  };
+}
+
+/**
+ * Converts a `listFolders` API response (or just its `folders` array) into
+ * the `folders` half of an {@link ApiFolderSnapshot}. The response carries
+ * no membership info, so `docFolders` is the caller's responsibility (merge
+ * this in alongside a per-note partial snapshot).
+ *
+ * Accepts either the full response object or a flat folder array — the
+ * paginated client returns the flat array via `listAllFolders`.
+ */
+export function folderListResponseToSnapshotFolders(
+  input: PublicListFoldersResponse | PublicFolder[]
+): Record<string, FolderInfo> {
+  const folders = Array.isArray(input) ? input : input.folders;
+  const out: Record<string, FolderInfo> = {};
+  for (const f of folders) {
+    out[f.id] = { title: f.name, parentId: f.parent_folder_id ?? null };
+  }
+  return out;
+}
+
+/**
+ * Returns true when API-mode sync should make an extra `listFolders` call
+ * this run. Used to catch renames of folders whose notes didn't appear in
+ * any recent incremental sync window.
+ *
+ * - First sync (no previous timestamp): returns true.
+ * - Inside the interval: returns false.
+ * - Past the interval: returns true.
+ * - Future-dated timestamp (clock skew / corruption): returns false so we
+ *   don't get stuck refetching every sync.
+ *
+ * Pure function (no Date.now() reads) so callers can pass `now` explicitly
+ * for testability.
+ */
+export function shouldRefetchFolders(
+  now: number,
+  lastFetched: number | undefined,
+  intervalMs: number = FOLDERS_REFETCH_INTERVAL_MS
+): boolean {
+  if (!lastFetched || lastFetched <= 0) return true;
+  if (lastFetched > now) return false;
+  return now - lastFetched >= intervalMs;
+}
+
+/**
+ * Compares two snapshots and returns the set of `oldPath → newPath` renames
+ * (or moves). A folder is considered renamed when its resolved path (parent
+ * chain walked into slashed string) differs between the snapshots.
+ *
+ * Mirrors the desktop {@link import("./folderMapBuilder").diffFolderMaps}
+ * behavior. Pass `previous = null` to indicate first sync — returns an empty
+ * map.
+ *
+ * Caller guarantees: the snapshots must contain only folders observed in
+ * either sync; an unobserved folder cannot be diffed.
+ */
+export function diffApiFolderSnapshots(
+  previous: ApiFolderSnapshot | null,
+  current: ApiFolderSnapshot
+): Map<string, string> {
+  const renames = new Map<string, string>();
+  if (!previous) return renames;
+
+  for (const folderId of Object.keys(current.folders)) {
+    const before = previous.folders[folderId];
+    if (!before) continue;
+    const oldPath = resolveFolderPath(folderId, previous.folders);
+    const newPath = resolveFolderPath(folderId, current.folders);
+    if (oldPath !== newPath && oldPath && newPath) {
+      // First write wins (don't clobber); a single folder id only has one
+      // canonical rename per sync.
+      if (!renames.has(oldPath)) {
+        renames.set(oldPath, newPath);
+      }
+    }
+  }
+
+  return renames;
+}

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,84 @@
+import type { GranolaSyncSettings } from "../settings";
+import { loadCredentials, type CredentialsResult } from "./credentials";
+import { log } from "../utils/logger";
+
+/**
+ * Resolved authentication for a sync run.
+ *
+ * `token` is the bearer token for the appropriate Granola endpoint:
+ * - `desktop`: WorkOS access token for `api.granola.ai`
+ * - `api_key`: `grn_*` key for `public-api.granola.ai`
+ */
+export type AuthResult =
+  | { method: "desktop"; token: string }
+  | { method: "api_key"; token: string };
+
+/**
+ * Return shape for {@link resolveAuth}.
+ *
+ * When desktop auth was attempted (success OR failure), the full
+ * `CredentialsResult` is included so callers can route errors through
+ * `presentCredentialsError` — which knows how to dispatch
+ * `errorKind === "keychain"` to the dedicated modal rather than a generic
+ * Notice. API-key failures don't have a credentials file involved, so
+ * `credentialsResult` is undefined and the caller falls back to a Notice.
+ */
+export interface ResolveAuthResult {
+  auth: AuthResult | null;
+  error: string | null;
+  credentialsResult?: CredentialsResult;
+}
+
+/**
+ * Resolves authentication for a sync run based on plugin settings.
+ *
+ * - When `authMethod === "api_key"`, validates the key shape (non-empty,
+ *   `grn_` prefix). No network call. `credentialsResult` is undefined.
+ * - When `authMethod === "desktop"`, delegates to {@link loadCredentials}
+ *   which reads the Granola app credentials file and (if needed) refreshes
+ *   the access token. The full result (including `errorKind`) is returned
+ *   so the caller can route keychain-denial errors to the dedicated modal.
+ *
+ * Returns `{ auth: null, error }` on failure so callers can surface a Notice
+ * and bail out.
+ */
+export async function resolveAuth(
+  settings: GranolaSyncSettings
+): Promise<ResolveAuthResult> {
+  if (settings.authMethod === "api_key") {
+    const key = settings.apiKey?.trim() ?? "";
+    if (!key) {
+      return {
+        auth: null,
+        error:
+          "Granola API key is required when API key authentication is selected. " +
+          "Add your key in Settings → Authentication, or switch back to Desktop credentials.",
+      };
+    }
+    if (!key.startsWith("grn_")) {
+      return {
+        auth: null,
+        error:
+          "Granola API key has an unexpected format (expected to start with 'grn_'). " +
+          "Double-check the key in Settings → Authentication.",
+      };
+    }
+    log.debug("resolveAuth — using API key authentication");
+    return { auth: { method: "api_key", token: key }, error: null };
+  }
+
+  log.debug("resolveAuth — using desktop credentials");
+  const credentialsResult = await loadCredentials();
+  if (!credentialsResult.accessToken) {
+    return {
+      auth: null,
+      error: credentialsResult.error,
+      credentialsResult,
+    };
+  }
+  return {
+    auth: { method: "desktop", token: credentialsResult.accessToken },
+    error: null,
+    credentialsResult,
+  };
+}

--- a/src/services/dailyNoteBuilder.ts
+++ b/src/services/dailyNoteBuilder.ts
@@ -10,6 +10,7 @@ import { getNoteDate } from "../utils/dateUtils";
 import { DocumentProcessor } from "./documentProcessor";
 import { updateSection } from "../utils/textUtils";
 import { log } from "../utils/logger";
+import type { DryRunRecorder } from "./dryRun";
 
 export interface NoteData {
   title: string;
@@ -36,7 +37,19 @@ export interface NoteLinkData {
  * Handles grouping notes by date, building section content, and updating daily notes.
  */
 export class DailyNoteBuilder {
+  /**
+   * Active dry-run recorder for the current sync. When set,
+   * {@link updateDailyNoteSection} records the intended write instead of
+   * calling `vault.modify`, and {@link getOrCreateDailyNote} records
+   * would-create instead of calling `createDailyNote`.
+   */
+  private dryRunRecorder: DryRunRecorder | null = null;
+
   constructor(private app: App, private documentProcessor: DocumentProcessor) {}
+
+  setDryRunRecorder(recorder: DryRunRecorder | null): void {
+    this.dryRunRecorder = recorder;
+  }
 
   /**
    * Extracts existing Granola IDs and their updated_at timestamps from a daily note section.
@@ -156,14 +169,30 @@ export class DailyNoteBuilder {
   /**
    * Gets or creates a daily note for the given date.
    *
+   * Dry-run behavior: if the daily note does NOT exist and a recorder is
+   * active, this records a `would-create` event and returns null. Callers
+   * MUST handle null by skipping any subsequent `vault.read` /
+   * `updateDailyNoteSection` call (there's nothing to read).
+   *
    * @param dateKey - Date key in YYYY-MM-DD format
-   * @returns The daily note file
+   * @returns The daily note file, or null if dry-run + missing.
    */
-  async getOrCreateDailyNote(dateKey: string): Promise<TFile> {
+  async getOrCreateDailyNote(dateKey: string): Promise<TFile | null> {
     const noteMoment = moment(dateKey, "YYYY-MM-DD");
     let dailyNoteFile = getDailyNote(noteMoment, getAllDailyNotes());
 
     if (!dailyNoteFile) {
+      if (this.dryRunRecorder) {
+        // We don't know the actual file path the daily-notes plugin would
+        // resolve to without invoking it, so use the dateKey as the path
+        // identifier in the report.
+        this.dryRunRecorder.record({
+          outcome: "would-create",
+          path: `(daily note for ${dateKey})`,
+          reason: "createDailyNote",
+        });
+        return null;
+      }
       dailyNoteFile = await createDailyNote(noteMoment);
     }
 
@@ -240,6 +269,31 @@ export class DailyNoteBuilder {
     sectionContent: string,
     forceOverwrite: boolean = false
   ): Promise<void> {
+    if (this.dryRunRecorder) {
+      // In dry-run, simulate the change check that `updateSection` would do:
+      // read existing, compare new section with old. Record `would-modify`
+      // only when something would actually change.
+      try {
+        const existingContent = await this.app.vault.read(dailyNoteFile);
+        const existingSection = this.extractSectionText(
+          existingContent,
+          sectionHeading
+        );
+        const wouldChange =
+          forceOverwrite || existingSection.trim() !== sectionContent.trim();
+        this.dryRunRecorder.record({
+          outcome: wouldChange ? "would-modify" : "skip-unchanged",
+          path: dailyNoteFile.path,
+          reason: `daily note section "${sectionHeading.trim()}"`,
+        });
+      } catch (error) {
+        log.warn(
+          `Dry-run: could not read ${dailyNoteFile.path} to assess daily-note section change`,
+          error
+        );
+      }
+      return;
+    }
     try {
       await updateSection(
         this.app,
@@ -255,6 +309,35 @@ export class DailyNoteBuilder {
       );
       log.error("Error updating daily note section:", error);
     }
+  }
+
+  /**
+   * Extracts the verbatim section text (heading + body up to next same-or-
+   * higher-level heading) for change comparison. Used by the dry-run path of
+   * {@link updateDailyNoteSection}; intentionally lives here rather than in
+   * shared utilities so it's purely a diagnostic helper.
+   */
+  private extractSectionText(content: string, heading: string): string {
+    const lines = content.split("\n");
+    const headingMatch = heading.match(/^(#{1,6})\s/);
+    const headingLevel = headingMatch ? headingMatch[1].length : null;
+    let start = -1;
+    let end = lines.length;
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].trim() === heading.trim()) {
+        start = i;
+        continue;
+      }
+      if (start !== -1 && headingLevel !== null) {
+        const m = lines[i].match(/^(#{1,6})\s/);
+        if (m && m[1].length <= headingLevel) {
+          end = i;
+          break;
+        }
+      }
+    }
+    if (start === -1) return "";
+    return lines.slice(start, end).join("\n");
   }
 
   /**
@@ -446,6 +529,21 @@ export class DailyNoteBuilder {
     for (const [dateKey, newLinksForDay] of linksMap) {
       try {
         const dailyNoteFile = await this.getOrCreateDailyNote(dateKey);
+        if (!dailyNoteFile) {
+          // Dry-run path: getOrCreateDailyNote already recorded a
+          // would-create for the missing daily note. We don't have an
+          // existing file to read or merge with — the live sync would
+          // start the section from scratch with the new links. Record the
+          // intended section write and continue.
+          if (this.dryRunRecorder) {
+            this.dryRunRecorder.record({
+              outcome: "would-modify",
+              path: `(daily note for ${dateKey})`,
+              reason: `would write ${newLinksForDay.length} meeting link(s) into new daily note`,
+            });
+          }
+          continue;
+        }
 
         const fileContent = await this.app.vault.read(dailyNoteFile);
         const existingLinks = this.parseExistingLinks(

--- a/src/services/documentFetcher.ts
+++ b/src/services/documentFetcher.ts
@@ -1,0 +1,235 @@
+import {
+  getAllDocuments,
+  getRecentDocuments,
+  fetchGranolaTranscript,
+} from "./granolaApi";
+import {
+  listAllNotes,
+  getNote,
+  PublicApiError,
+} from "./publicGranolaApi";
+import {
+  adaptPublicNoteToGranolaDoc,
+  adaptPublicNoteSummary,
+  adaptTranscript,
+  extractFoldersFromMembership,
+} from "./granolaDocAdapter";
+import type { AuthResult } from "./auth";
+import type { GranolaSyncSettings } from "../settings";
+import type { GranolaDoc, TranscriptEntry } from "./granolaTypes";
+import type { PublicFolderMembershipEntry } from "./publicApiSchemas";
+import { log } from "../utils/logger";
+
+/**
+ * A document ready for the sync pipeline, plus per-doc context the API-key
+ * path needs to carry around (legacy ID bridge, folders, transcript).
+ *
+ * `desktop` mode populates `doc` only; `apiFolders` / `apiTranscript` /
+ * `_publicId` are empty / undefined.
+ */
+export interface FetchedDoc {
+  doc: GranolaDoc;
+  /** Folder paths derived from the source (Public API or desktop folder map). */
+  folders?: string[];
+  /**
+   * Raw API folder_membership for this note, when in API-key mode. Carries
+   * stable folder IDs needed for {@link import("./apiFolderSnapshot").buildApiFolderSnapshot}
+   * to detect renames robustly. Undefined for desktop mode.
+   */
+  folderMembership?: PublicFolderMembershipEntry[];
+  /** Pre-fetched transcript entries, available in API-key mode. */
+  apiTranscript?: TranscriptEntry[];
+  /** Public API `not_*` id when in API-key mode. */
+  publicId?: string;
+  /** Public API `web_url` when in API-key mode. */
+  webUrl?: string | null;
+}
+
+export type FetcherMode = "standard" | "full";
+
+export interface FetcherOptions {
+  mode: FetcherMode;
+  /**
+   * If true, the API-key path fetches transcripts in the same Get Note call.
+   * Mirrors `settings.syncTranscripts` — separated as a parameter so the
+   * orchestrator can override (e.g. dry-run could pass false).
+   */
+  includeTranscripts?: boolean;
+  /**
+   * Optional `granolaId → last-known-updated_at` map. When provided, the
+   * API-key path uses this to skip `Get Note` calls for unchanged notes —
+   * the "gate Get Note behind list updated_at" optimization.
+   */
+  knownUpdatedAtByGranolaId?: Map<string, string | undefined>;
+  /** Latest successful sync timestamp (ms). Used as `updated_after` in API mode. */
+  latestSyncTime?: number;
+}
+
+/**
+ * Reads documents for a sync run from the appropriate Granola endpoint based on
+ * `auth.method`. Returns a flat list of {@link FetchedDoc}; the rest of the
+ * sync pipeline shouldn't have to know which API the data came from.
+ *
+ * Performance notes (API-key mode):
+ * - Public API is N+1: one list call + one Get Note per note. Rate-limited
+ *   at ~4.5 req/s by {@link publicGranolaApi} to stay under Granola's
+ *   documented 5 req/s sustained limit.
+ * - We pre-gate with the list-level `updated_at`: when the caller supplies
+ *   `knownUpdatedAtByGranolaId`, we skip `getNote` for notes whose remote
+ *   timestamp matches what we already have on disk.
+ */
+export async function fetchDocumentsForSync(
+  auth: AuthResult,
+  settings: GranolaSyncSettings,
+  options: FetcherOptions
+): Promise<FetchedDoc[]> {
+  if (auth.method === "desktop") {
+    return fetchDesktop(auth.token, settings, options);
+  }
+  return fetchApiKey(auth.token, settings, options);
+}
+
+async function fetchDesktop(
+  token: string,
+  settings: GranolaSyncSettings,
+  options: FetcherOptions
+): Promise<FetchedDoc[]> {
+  const includeShared = settings.includeSharedNotes;
+  const docs =
+    options.mode === "full"
+      ? await getAllDocuments(token, 100, includeShared)
+      : await getRecentDocuments(token, settings.syncDaysBack, 100, includeShared);
+  return docs.map((doc) => ({ doc }));
+}
+
+/**
+ * Computes the `updated_after` / `created_after` window for the API list call.
+ *
+ * - `full` mode: no window (paginate everything Granola exposes).
+ * - `standard` mode + recent `latestSyncTime`: use `updated_after = latestSyncTime`.
+ * - `standard` mode without `latestSyncTime`: use `created_after = now() - syncDaysBack`.
+ *
+ * Returning an object with at most one bound keeps the API call simple and
+ * matches Granola's filter semantics (server treats absent params as "no
+ * lower bound").
+ */
+export function computeApiFetchWindow(
+  settings: GranolaSyncSettings,
+  options: FetcherOptions
+): { createdAfter?: string; updatedAfter?: string } {
+  if (options.mode === "full") return {};
+
+  if (options.latestSyncTime && options.latestSyncTime > 0) {
+    return { updatedAfter: new Date(options.latestSyncTime).toISOString() };
+  }
+
+  const daysBack = settings.syncDaysBack;
+  if (!daysBack || daysBack <= 0) return {};
+
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - daysBack);
+  return { createdAfter: cutoff.toISOString() };
+}
+
+async function fetchApiKey(
+  apiKey: string,
+  settings: GranolaSyncSettings,
+  options: FetcherOptions
+): Promise<FetchedDoc[]> {
+  const window = computeApiFetchWindow(settings, options);
+  log.debug(
+    `documentFetcher (api_key) — window=${JSON.stringify(window)}, mode=${options.mode}`
+  );
+
+  const summaries = await listAllNotes(apiKey, window);
+  log.debug(`documentFetcher (api_key) — list returned ${summaries.length} note(s)`);
+
+  const out: FetchedDoc[] = [];
+  const includeTranscripts = options.includeTranscripts ?? settings.syncTranscripts;
+
+  for (const summary of summaries) {
+    const summaryDoc = adaptPublicNoteSummary(summary);
+    const knownUpdated = options.knownUpdatedAtByGranolaId?.get(summaryDoc.id);
+
+    // List-level gate: when we already have this note locally and the API's
+    // updated_at hasn't moved, skip the Get Note call entirely. This is the
+    // dominant cost saver on large vaults (N+1 → N).
+    if (
+      knownUpdated &&
+      summary.updated_at &&
+      timestampsEqual(summary.updated_at, knownUpdated)
+    ) {
+      log.debug(
+        `documentFetcher gate — skipping Get Note for ${summaryDoc.id} (updated_at unchanged)`
+      );
+      continue;
+    }
+
+    try {
+      const full = await getNote(apiKey, summary.id, {
+        includeTranscript: includeTranscripts,
+      });
+      const adapted = adaptPublicNoteToGranolaDoc(full);
+      const folders = extractFoldersFromMembership(full);
+      const apiTranscript = includeTranscripts
+        ? adaptTranscript(adapted.id, full.transcript)
+        : undefined;
+      out.push({
+        doc: adapted,
+        folders,
+        folderMembership: full.folder_membership,
+        apiTranscript,
+        publicId: adapted._publicId,
+        webUrl: adapted._webUrl,
+      });
+    } catch (e) {
+      if (e instanceof PublicApiError && e.status === 404) {
+        log.debug(
+          `documentFetcher (api_key) — 404 for note ${summary.id}; treating as missing`
+        );
+        continue;
+      }
+      // Propagate so the orchestrator surfaces an error to the user (esp 401).
+      throw e;
+    }
+  }
+  return out;
+}
+
+/**
+ * Tolerant timestamp comparison. Two ISO strings represent the same instant
+ * if their parsed dates are equal. We compare by parsed milliseconds so
+ * trailing-zero / timezone-offset differences don't cause a spurious miss.
+ */
+function timestampsEqual(a: string, b: string): boolean {
+  const da = new Date(a).getTime();
+  const db = new Date(b).getTime();
+  if (Number.isNaN(da) || Number.isNaN(db)) return a === b;
+  return da === db;
+}
+
+/**
+ * Convenience: in API-key mode the transcript is fetched in the same call as
+ * the note. This shim lets callers ask for the transcript by docId without
+ * caring whether they're in desktop or API mode.
+ *
+ * @param fetched - The {@link FetchedDoc} produced by {@link fetchDocumentsForSync}.
+ * @param auth - Active auth so we know how to fall back when the API path didn't include the transcript.
+ * @param desktopFetcher - Pulled-in callback so this module doesn't drag in the desktop client when it isn't needed. Defaults to {@link fetchGranolaTranscript}.
+ */
+export async function fetchTranscriptFor(
+  fetched: FetchedDoc,
+  auth: AuthResult,
+  desktopFetcher: (
+    token: string,
+    docId: string
+  ) => Promise<TranscriptEntry[]> = fetchGranolaTranscript
+): Promise<TranscriptEntry[]> {
+  if (fetched.apiTranscript !== undefined) return fetched.apiTranscript;
+  if (auth.method === "desktop") {
+    return desktopFetcher(auth.token, fetched.doc.id);
+  }
+  // API key mode but we didn't request transcripts up front. Caller should
+  // have set includeTranscripts; nothing else we can do here.
+  return [];
+}

--- a/src/services/dryRun.ts
+++ b/src/services/dryRun.ts
@@ -1,0 +1,113 @@
+import { log } from "../utils/logger";
+
+export type DryRunOutcome =
+  | "would-create"
+  | "would-modify"
+  | "would-modify-frontmatter"
+  | "would-rename"
+  | "skip-unchanged"
+  | "skip-not-newer"
+  | "skip-body-write-disabled";
+
+export interface DryRunRecord {
+  outcome: DryRunOutcome;
+  path: string;
+  granolaId?: string;
+  type?: "note" | "transcript" | "combined";
+  /** Human-readable explanation (e.g. "remote newer by 142s"). */
+  reason?: string;
+  /** When the outcome is `would-rename`, the destination path. */
+  toPath?: string;
+}
+
+/**
+ * Records intended file-system writes during a dry-run sync. When attached to
+ * a `FileSyncService` (or accessed via `GranolaSync.dryRunRecorder`), all
+ * `vault.create / vault.modify / vault.rename` calls become record-only and
+ * the sync pipeline produces a report instead of touching disk.
+ *
+ * The recorder is intentionally process-global per sync run; callers should
+ * `new DryRunRecorder()` for each invocation and clear it afterwards so
+ * subsequent live syncs don't accidentally inherit dry-run mode.
+ */
+export class DryRunRecorder {
+  private records: DryRunRecord[] = [];
+
+  record(rec: DryRunRecord): void {
+    this.records.push(rec);
+    log.debug(
+      `dry-run — ${rec.outcome} ${rec.path}` +
+        (rec.toPath ? ` → ${rec.toPath}` : "") +
+        (rec.reason ? ` (${rec.reason})` : "")
+    );
+  }
+
+  all(): readonly DryRunRecord[] {
+    return this.records;
+  }
+
+  /**
+   * Returns a markdown-formatted report suitable for the debug log or a
+   * Notice's "open log" hint.
+   */
+  summarize(): string {
+    const counts: Record<DryRunOutcome, number> = {
+      "would-create": 0,
+      "would-modify": 0,
+      "would-modify-frontmatter": 0,
+      "would-rename": 0,
+      "skip-unchanged": 0,
+      "skip-not-newer": 0,
+      "skip-body-write-disabled": 0,
+    };
+    for (const r of this.records) counts[r.outcome]++;
+
+    const lines: string[] = [];
+    lines.push("Dry-run summary:");
+    lines.push(`  would-create: ${counts["would-create"]}`);
+    lines.push(`  would-modify: ${counts["would-modify"]}`);
+    lines.push(
+      `  would-modify-frontmatter: ${counts["would-modify-frontmatter"]}`
+    );
+    lines.push(`  would-rename: ${counts["would-rename"]}`);
+    lines.push(`  skip-unchanged: ${counts["skip-unchanged"]}`);
+    lines.push(`  skip-not-newer: ${counts["skip-not-newer"]}`);
+    lines.push(
+      `  skip-body-write-disabled: ${counts["skip-body-write-disabled"]}`
+    );
+
+    if (this.records.length > 0) {
+      lines.push("");
+      lines.push("Details:");
+      for (const r of this.records) {
+        lines.push(
+          `  [${r.outcome}] ${r.path}` +
+            (r.toPath ? ` → ${r.toPath}` : "") +
+            (r.granolaId ? ` (granolaId=${r.granolaId})` : "") +
+            (r.reason ? ` — ${r.reason}` : "")
+        );
+      }
+    }
+    return lines.join("\n");
+  }
+
+  shortNotice(): string {
+    const c = this.records.reduce(
+      (acc, r) => {
+        if (r.outcome === "would-create") acc.create++;
+        else if (r.outcome === "would-modify") acc.modify++;
+        else if (r.outcome === "would-modify-frontmatter") acc.fmModify++;
+        else if (r.outcome === "would-rename") acc.rename++;
+        else acc.skip++;
+        return acc;
+      },
+      { create: 0, modify: 0, fmModify: 0, rename: 0, skip: 0 }
+    );
+    return (
+      `Granola dry-run: would create ${c.create}, modify ${c.modify}, ` +
+      `modify-frontmatter ${c.fmModify}, rename ${c.rename}, skip ${c.skip}. ` +
+      `See debug log for per-file detail.`
+    );
+  }
+}
+

--- a/src/services/dryRunModal.ts
+++ b/src/services/dryRunModal.ts
@@ -1,0 +1,162 @@
+import { App, Modal, Notice, Setting } from "obsidian";
+import type { DryRunRecord, DryRunRecorder } from "./dryRun";
+
+/**
+ * Modal that displays a dry-run report inline in Obsidian instead of forcing
+ * the user to dig through the debug log file.
+ *
+ * Layout: a summary block of counts at the top, then a per-record table of
+ * intended writes. A "Copy report to clipboard" button at the bottom dumps
+ * the full markdown report for sharing in a bug report or sync diary.
+ *
+ * Stateless beyond the records snapshot — re-running a dry-run creates a
+ * fresh modal with the new recorder.
+ */
+export class DryRunReportModal extends Modal {
+  private readonly recorder: DryRunRecorder;
+  private readonly startedAt: Date;
+  private readonly finishedAt: Date;
+
+  constructor(
+    app: App,
+    recorder: DryRunRecorder,
+    startedAt: Date,
+    finishedAt: Date
+  ) {
+    super(app);
+    this.recorder = recorder;
+    this.startedAt = startedAt;
+    this.finishedAt = finishedAt;
+  }
+
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+    contentEl.addClass("granola-sync-dry-run-modal");
+
+    contentEl.createEl("h2", { text: "Granola dry-run report" });
+
+    const timingEl = contentEl.createEl("p", {
+      cls: "granola-sync-dry-run-timing",
+    });
+    const elapsedMs = this.finishedAt.getTime() - this.startedAt.getTime();
+    timingEl.setText(
+      `Completed ${this.finishedAt.toLocaleTimeString()} ` +
+        `(took ${(elapsedMs / 1000).toFixed(1)}s). ` +
+        `No files were modified.`
+    );
+
+    this.renderCounts(contentEl);
+    this.renderDetails(contentEl);
+
+    new Setting(contentEl)
+      .addButton((btn) =>
+        btn
+          .setButtonText("Copy report to clipboard")
+          .setCta()
+          .onClick(async () => {
+            try {
+              await navigator.clipboard.writeText(this.recorder.summarize());
+              new Notice("Dry-run report copied to clipboard.");
+            } catch (err) {
+              new Notice(
+                "Failed to copy: " +
+                  (err instanceof Error ? err.message : String(err))
+              );
+            }
+          })
+      )
+      .addButton((btn) => btn.setButtonText("Close").onClick(() => this.close()));
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
+
+  /**
+   * Counts block. Renders zero-buckets too so users have a stable mental
+   * model of "what could change" — empty rows are useful signal (e.g.
+   * `would-modify-frontmatter: 0` confirms the cross-link path didn't run).
+   */
+  private renderCounts(parent: HTMLElement): void {
+    const records = this.recorder.all();
+    const counts = {
+      "would-create": 0,
+      "would-modify": 0,
+      "would-modify-frontmatter": 0,
+      "would-rename": 0,
+      "skip-unchanged": 0,
+      "skip-not-newer": 0,
+      "skip-body-write-disabled": 0,
+    } as Record<DryRunRecord["outcome"], number>;
+    for (const r of records) counts[r.outcome]++;
+
+    const summary = parent.createEl("div", { cls: "granola-sync-dry-run-counts" });
+    summary.createEl("h3", { text: "Summary" });
+    const list = summary.createEl("ul");
+    const friendly: Record<DryRunRecord["outcome"], string> = {
+      "would-create": "Would create",
+      "would-modify": "Would modify",
+      "would-modify-frontmatter": "Would modify frontmatter",
+      "would-rename": "Would rename",
+      "skip-unchanged": "Skip (unchanged)",
+      "skip-not-newer": "Skip (remote not newer)",
+      "skip-body-write-disabled": "Skip (body writes disabled)",
+    };
+    for (const outcome of Object.keys(counts) as Array<DryRunRecord["outcome"]>) {
+      const li = list.createEl("li");
+      li.createEl("strong", { text: `${counts[outcome]}` });
+      li.appendText(` ${friendly[outcome]}`);
+    }
+  }
+
+  /**
+   * Per-record detail table. Shows each intended change with its path,
+   * granolaId, and reason. Long lists scroll inside the modal so wide
+   * vaults don't blow out the dialog.
+   */
+  private renderDetails(parent: HTMLElement): void {
+    const records = this.recorder.all();
+    parent.createEl("h3", { text: `Details (${records.length} record(s))` });
+
+    if (records.length === 0) {
+      parent.createEl("p", {
+        text: "No changes would be made. (Sync is up-to-date or returned no documents.)",
+      });
+      return;
+    }
+
+    const scrollEl = parent.createEl("div", {
+      cls: "granola-sync-dry-run-details",
+    });
+    const table = scrollEl.createEl("table");
+    const thead = table.createEl("thead");
+    const headRow = thead.createEl("tr");
+    for (const h of ["Outcome", "Path", "Reason"]) {
+      headRow.createEl("th", { text: h });
+    }
+    const tbody = table.createEl("tbody");
+    for (const r of records) {
+      const tr = tbody.createEl("tr");
+      tr.createEl("td", {
+        text: r.outcome,
+        cls: "granola-sync-dry-run-outcome",
+      });
+
+      const pathCell = tr.createEl("td", { cls: "granola-sync-dry-run-path" });
+      const pathText = r.toPath ? `${r.path} → ${r.toPath}` : r.path;
+      pathCell.appendText(pathText);
+      if (r.granolaId) {
+        const idEl = pathCell.createEl("div", {
+          cls: "granola-sync-dry-run-granola-id",
+        });
+        idEl.setText(`granolaId=${r.granolaId}`);
+      }
+
+      tr.createEl("td", {
+        text: r.reason ?? "",
+        cls: "granola-sync-dry-run-reason",
+      });
+    }
+  }
+}

--- a/src/services/fileSyncService.ts
+++ b/src/services/fileSyncService.ts
@@ -5,6 +5,7 @@ import { PathResolver } from "./pathResolver";
 import { GranolaSyncSettings } from "../settings";
 import { getNoteDate, formatDateForFilename } from "../utils/dateUtils";
 import { log } from "../utils/logger";
+import type { DryRunRecorder } from "./dryRun";
 
 /**
  * Service for handling file synchronization operations including
@@ -12,6 +13,21 @@ import { log } from "../utils/logger";
  */
 export class FileSyncService {
   private granolaIdCache: Map<string, TFile> = new Map();
+  /**
+   * Secondary index from `granola_public_id` (the `not_*` ID written by API-key
+   * mode) to the primary `${granolaId}-${type}` cache key. Lets sync look up
+   * existing files by either id without forcing a frontmatter rewrite.
+   */
+  private publicIdIndex: Map<string, string> = new Map();
+  /**
+   * When set, all writes are intercepted and recorded instead of executed.
+   * Used for the `Granola: Dry-run sync` command and as a pre-PR gate.
+   */
+  private dryRunRecorder: DryRunRecorder | null = null;
+
+  setDryRunRecorder(recorder: DryRunRecorder | null): void {
+    this.dryRunRecorder = recorder;
+  }
 
   constructor(
     private app: App,
@@ -27,6 +43,7 @@ export class FileSyncService {
    */
   async buildCache(): Promise<void> {
     this.granolaIdCache.clear();
+    this.publicIdIndex.clear();
     const files = this.app.vault.getMarkdownFiles();
 
     for (const file of files) {
@@ -37,6 +54,17 @@ export class FileSyncService {
           const type = (cache.frontmatter.type as string | undefined) || "note"; // Default for backward compatibility
           const cacheKey = `${granolaId}-${type}`;
           this.granolaIdCache.set(cacheKey, file);
+
+          // Secondary index: granola_public_id (`not_*`) → primary cache key.
+          // Lets API-key sync find existing desktop-synced files when the API
+          // returns the legacy UUID via web_url AND the public id was previously
+          // recorded in frontmatter (after a prior API-mode write).
+          const publicId = cache.frontmatter.granola_public_id as
+            | string
+            | undefined;
+          if (publicId) {
+            this.publicIdIndex.set(`${publicId}-${type}`, cacheKey);
+          }
         }
       } catch (e) {
         log.error(`Error reading frontmatter for ${file.path}:`, e);
@@ -56,7 +84,36 @@ export class FileSyncService {
     type: "note" | "transcript" | "combined" = "note"
   ): TFile | null {
     const cacheKey = `${granolaId}-${type}`;
-    return this.granolaIdCache.get(cacheKey) || null;
+    const direct = this.granolaIdCache.get(cacheKey);
+    if (direct) return direct;
+
+    // ID bridge: caller may have supplied a public (`not_*`) id, but the file
+    // on disk stores the legacy UUID in `granola_id`. Use the secondary index
+    // to resolve to the primary cache entry.
+    const bridged = this.publicIdIndex.get(cacheKey);
+    if (bridged) {
+      return this.granolaIdCache.get(bridged) ?? null;
+    }
+    return null;
+  }
+
+  /**
+   * Records a `granola_public_id` mapping in the in-memory index. Used by
+   * API-key sync to bridge the legacy UUID and `not_*` id without rewriting
+   * frontmatter on every match. Call after a successful save or when a file's
+   * frontmatter is augmented with `granola_public_id`.
+   *
+   * @param publicId - The `not_*` id from Granola's Public API.
+   * @param granolaId - The legacy UUID stored in `granola_id` frontmatter.
+   * @param type - File type (note / transcript / combined).
+   */
+  recordPublicIdBridge(
+    publicId: string,
+    granolaId: string,
+    type: "note" | "transcript" | "combined" = "note"
+  ): void {
+    if (!publicId || !granolaId) return;
+    this.publicIdIndex.set(`${publicId}-${type}`, `${granolaId}-${type}`);
   }
 
   /**
@@ -132,6 +189,18 @@ export class FileSyncService {
         return true;
       }
 
+      // <60s staleness buffer: treat the remote as up-to-date when the delta
+      // is positive but smaller than a minute. This is what prevents toggling
+      // auth modes — where one path includes the panel timestamp and the
+      // other doesn't — from rewriting every file with a near-equal value.
+      const diffMs = remoteDate.getTime() - localDate.getTime();
+      if (diffMs > 0 && diffMs < 60_000) {
+        log.debug(
+          `isRemoteNewer — within <60s buffer (${diffMs}ms), treating local as up-to-date for ${granolaId} (${type})`
+        );
+        return false;
+      }
+
       return remoteDate > localDate;
     } catch (e) {
       log.error(`Error comparing timestamps for ${granolaId}:`, e);
@@ -168,6 +237,16 @@ export class FileSyncService {
     try {
       const folderExists = this.app.vault.getAbstractFileByPath(folderPath);
       if (!folderExists) {
+        if (this.dryRunRecorder) {
+          // Folder creation is implicit support for the downstream file
+          // create; we don't surface a separate `would-create-folder`
+          // outcome (would be noisy and per-day spammy). The user infers
+          // it from the `would-create` records on files inside.
+          log.debug(
+            `Dry-run: would create folder ${folderPath} (skipping vault.createFolder)`
+          );
+          return true;
+        }
         await this.app.vault.createFolder(folderPath);
       }
       return true;
@@ -246,6 +325,15 @@ export class FileSyncService {
     granolaId: string,
     type: "note" | "transcript" | "combined"
   ): Promise<boolean> {
+    if (this.dryRunRecorder) {
+      this.dryRunRecorder.record({
+        outcome: "would-create",
+        path: normalizedPath,
+        granolaId,
+        type,
+      });
+      return true;
+    }
     const newFile = await this.app.vault.create(normalizedPath, content);
     this.updateCache(granolaId, newFile, type);
     log.debug(`Created ${type} file: ${normalizedPath} (granolaId=${granolaId})`);
@@ -269,7 +357,34 @@ export class FileSyncService {
     if (!forceOverwrite && existingContent === content) {
       this.updateCache(granolaId, existingFile, type);
       log.debug(`Skipped ${type} file — content unchanged: ${existingFile.path} (granolaId=${granolaId})`);
+      if (this.dryRunRecorder) {
+        this.dryRunRecorder.record({
+          outcome: "skip-unchanged",
+          path: existingFile.path,
+          granolaId,
+          type,
+        });
+      }
       return false;
+    }
+
+    if (this.dryRunRecorder) {
+      this.dryRunRecorder.record({
+        outcome: "would-modify",
+        path: existingFile.path,
+        granolaId,
+        type,
+      });
+      if (existingFile.path !== normalizedPath) {
+        this.dryRunRecorder.record({
+          outcome: "would-rename",
+          path: existingFile.path,
+          toPath: normalizedPath,
+          granolaId,
+          type,
+        });
+      }
+      return true;
     }
 
     await this.app.vault.modify(existingFile, content);
@@ -648,6 +763,24 @@ export class FileSyncService {
       ) ?? [];
 
     if (imageAttachments.length === 0) {
+      return content;
+    }
+
+    if (this.dryRunRecorder) {
+      // Dry-run protection: image attachments hit network (`requestUrl`)
+      // and write to disk via `vault.createBinary`. Both are side-effects
+      // we promised not to make. Record an intent line per attachment for
+      // visibility and return the content unchanged — the note dry-run
+      // record already represents the intended write of the note body
+      // (without embed lines, which is acceptable for the report).
+      for (const attachment of imageAttachments) {
+        this.dryRunRecorder.record({
+          outcome: "would-create",
+          path: `(attachment ${attachment.id ?? "?"} for ${doc.id})`,
+          granolaId: doc.id,
+          reason: "image attachment (download + binary write skipped in dry-run)",
+        });
+      }
       return content;
     }
 

--- a/src/services/granolaDocAdapter.ts
+++ b/src/services/granolaDocAdapter.ts
@@ -1,0 +1,201 @@
+import type { GranolaDoc, TranscriptEntry } from "./granolaTypes";
+import type {
+  PublicNote,
+  PublicNoteSummary,
+  PublicTranscriptEntry,
+  PublicFolderMembershipEntry,
+} from "./publicApiSchemas";
+import { log } from "../utils/logger";
+
+/**
+ * Adapter: maps Granola Public API shapes (`public-api.granola.ai`) into the
+ * internal `GranolaDoc` / `TranscriptEntry` shapes the rest of the plugin
+ * already speaks.
+ *
+ * Design notes:
+ *
+ * - `summary_markdown` becomes `last_viewed_panel.content` as a markdown
+ *   string. Downstream code in `documentProcessor` already accepts string
+ *   content (used by the desktop API for HTML).
+ * - `folder_membership` is normalized to flat `"A/B/C"` slashed paths and
+ *   exposed via {@link extractFoldersFromMembership} for the sync pipeline.
+ *   Paths are sorted to keep frontmatter writes deterministic (no spurious
+ *   diffs).
+ * - We never write the `not_*` id into `granola_id`; the `web_url` UUID is
+ *   the canonical identity, preserved by extracting it via
+ *   {@link extractLegacyIdFromWebUrl}.
+ *
+ * The adapter is pure (no I/O), so tests can drive it directly from
+ * fixture JSON.
+ */
+
+/**
+ * Extracts the legacy UUID from a Public API `web_url`. The desktop API
+ * returns this same UUID as `doc.id` and stores it in vault frontmatter as
+ * `granola_id`, so this is the "bridge" that lets API-mode sync update
+ * existing files in place.
+ *
+ * Returns null when the URL is missing or doesn't match the expected shape.
+ */
+export function extractLegacyIdFromWebUrl(
+  webUrl: string | null | undefined
+): string | null {
+  if (!webUrl) return null;
+  const m = webUrl.match(
+    /\/d\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i
+  );
+  return m ? m[1] : null;
+}
+
+/**
+ * Builds a `parent_id → child` map and walks it to produce slashed paths.
+ * If a parent reference is missing or cyclical, the offending node becomes
+ * a root.
+ */
+export function membershipToFolderPaths(
+  membership: PublicFolderMembershipEntry[] | undefined
+): string[] {
+  if (!membership || membership.length === 0) return [];
+
+  const byId = new Map<string, PublicFolderMembershipEntry>();
+  for (const entry of membership) byId.set(entry.id, entry);
+
+  const paths: string[] = [];
+  for (const entry of membership) {
+    const parts: string[] = [];
+    let cursor: PublicFolderMembershipEntry | undefined = entry;
+    const seen = new Set<string>();
+    while (cursor && !seen.has(cursor.id)) {
+      seen.add(cursor.id);
+      parts.unshift(cursor.name);
+      if (!cursor.parent_folder_id) break;
+      cursor = byId.get(cursor.parent_folder_id);
+    }
+    paths.push(parts.join("/"));
+  }
+
+  // Dedupe + sort so the frontmatter is byte-stable across syncs.
+  return Array.from(new Set(paths)).sort();
+}
+
+/**
+ * Returns the slashed folder paths for a `PublicNote`. Empty array when the
+ * note has no folder membership.
+ */
+export function extractFoldersFromMembership(note: PublicNote): string[] {
+  return membershipToFolderPaths(note.folder_membership);
+}
+
+/**
+ * Maps a public transcript source value to the internal `source` field used
+ * by {@link formatTranscriptBody}, which treats `"microphone"` as "You" and
+ * everything else as "Guest".
+ */
+function mapPublicSpeakerSource(source: string | undefined): string {
+  if (source === "me" || source === "microphone") return "microphone";
+  return source ?? "guest";
+}
+
+/**
+ * Maps the Public API transcript array to internal `TranscriptEntry[]`.
+ * Discards entries with empty text. Fills in best-effort defaults for the
+ * fields internal formatters require (`is_final`, `document_id`, etc.).
+ */
+export function adaptTranscript(
+  documentId: string,
+  publicTranscript: PublicTranscriptEntry[] | undefined
+): TranscriptEntry[] {
+  if (!publicTranscript) return [];
+  const out: TranscriptEntry[] = [];
+  let droppedEmpty = 0;
+  for (let i = 0; i < publicTranscript.length; i++) {
+    const entry = publicTranscript[i];
+    if (!entry.text || entry.text.trim().length === 0) {
+      droppedEmpty++;
+      continue;
+    }
+    out.push({
+      id: entry.id ?? `${documentId}-${i}`,
+      document_id: documentId,
+      start_timestamp: entry.start_time ?? "",
+      end_timestamp: entry.end_time ?? "",
+      text: entry.text,
+      source: mapPublicSpeakerSource(entry.speaker?.source),
+      is_final: true,
+    });
+  }
+  if (droppedEmpty > 0) {
+    log.debug(
+      `adaptTranscript — dropped ${droppedEmpty} empty/whitespace-only transcript entry/entries for doc ${documentId}`
+    );
+  }
+  return out;
+}
+
+/**
+ * Maps a full {@link PublicNote} to the internal {@link GranolaDoc} shape.
+ *
+ * The `GranolaDoc.id` is intentionally the legacy UUID extracted from
+ * `web_url` when available. This preserves dedup with vault files synced via
+ * desktop auth (their `granola_id` is the UUID). When no UUID can be
+ * extracted (legacy / unusual notes), we fall back to the `not_*` id — sync
+ * will treat that as a new file, which is the safe default.
+ *
+ * The original `not_*` id is preserved on the returned object as
+ * `_publicId` (a non-API extension field) so the sync pipeline can record
+ * it on frontmatter and the cache.
+ */
+export function adaptPublicNoteToGranolaDoc(
+  note: PublicNote
+): GranolaDoc & { _publicId: string; _webUrl: string | null } {
+  const legacyId = extractLegacyIdFromWebUrl(note.web_url ?? null);
+
+  const attendees = note.attendees?.map((a) => ({
+    name: a.name,
+    email: a.email,
+  }));
+
+  // Public API gives us a markdown summary, not ProseMirror. Pass it through
+  // as a string — documentProcessor.buildNoteBody already handles strings
+  // (used by the desktop API for HTML).
+  const body = note.summary_markdown ?? note.summary_text ?? null;
+
+  return {
+    id: legacyId ?? note.id,
+    title: note.title ?? null,
+    created_at: note.created_at ?? undefined,
+    updated_at: note.updated_at ?? undefined,
+    people: attendees ? { attendees } : undefined,
+    last_viewed_panel: body
+      ? {
+          content: body,
+          updated_at: note.updated_at ?? null,
+        }
+      : null,
+    _publicId: note.id,
+    _webUrl: note.web_url ?? null,
+  };
+}
+
+/**
+ * Lightweight adaptation from list-endpoint results (no body, no folders).
+ * Used when sync only needs metadata for the `isRemoteNewer` gate before
+ * deciding whether to fetch the full note.
+ *
+ * Note: the Public API list endpoint does NOT include `web_url`, so this
+ * function always falls back to the `not_*` id for `GranolaDoc.id`. The
+ * legacy-UUID bridge runs later via {@link adaptPublicNoteToGranolaDoc} on
+ * the Get Note response, which does carry `web_url`.
+ */
+export function adaptPublicNoteSummary(
+  summary: PublicNoteSummary
+): GranolaDoc & { _publicId: string; _webUrl: string | null } {
+  return {
+    id: summary.id,
+    title: summary.title ?? null,
+    created_at: summary.created_at ?? undefined,
+    updated_at: summary.updated_at ?? undefined,
+    _publicId: summary.id,
+    _webUrl: null,
+  };
+}

--- a/src/services/publicApiSchemas.ts
+++ b/src/services/publicApiSchemas.ts
@@ -1,0 +1,142 @@
+import * as v from "valibot";
+
+/**
+ * Valibot schemas for Granola's Public API (public-api.granola.ai).
+ *
+ * These intentionally accept a superset of fields the plugin uses (via
+ * `v.looseObject`) so future API additions don't break sync. The plugin
+ * still asserts on the fields it depends on.
+ *
+ * Source: https://docs.granola.ai/api-reference/list-notes
+ *         https://docs.granola.ai/api-reference/get-note
+ *         https://docs.granola.ai/api-reference/list-folders
+ */
+
+const OwnerSchema = v.looseObject({
+  id: v.optional(v.string()),
+  name: v.optional(v.string()),
+  email: v.optional(v.string()),
+});
+
+const AttendeeSchema = v.looseObject({
+  name: v.optional(v.string()),
+  email: v.optional(v.string()),
+});
+
+/**
+ * Public folder membership entry. Field names confirmed against live API:
+ * - `id` (e.g. `fol_EcATHi5XhKY6nr`)
+ * - `name` (the folder title)
+ * - `parent_folder_id` (nullable)
+ * - `object: "folder"` discriminator (Granola includes this on most objects)
+ */
+const FolderMembershipEntrySchema = v.looseObject({
+  id: v.string(),
+  name: v.string(),
+  parent_folder_id: v.nullish(v.string()),
+  object: v.optional(v.string()),
+});
+
+/**
+ * Public transcript entry shape. Field names confirmed against live API:
+ * `start_time` / `end_time` (ISO datetimes), `speaker.source` values include
+ * `"microphone"` (user's own audio) and `"speaker"` (other parties via the
+ * device speakers). Diarization label is optional. The adapter normalizes
+ * this into the internal `TranscriptEntry` shape used by the formatter.
+ */
+const PublicTranscriptEntrySchema = v.looseObject({
+  id: v.optional(v.string()),
+  start_time: v.optional(v.string()),
+  end_time: v.optional(v.string()),
+  text: v.string(),
+  speaker: v.optional(
+    v.looseObject({
+      source: v.optional(v.string()),
+      diarization_label: v.optional(v.string()),
+    })
+  ),
+});
+
+/**
+ * Note summary as returned by `GET /v1/notes` (list endpoint). The list
+ * endpoint omits `summary_markdown`, `transcript`, `folder_membership`, and
+ * `web_url` — those require a follow-up `GET /v1/notes/{id}` call. The spec
+ * marks `id`, `object`, `title`, `owner`, `created_at`, `updated_at` as
+ * required; we use `looseObject` so future server additions don't break us.
+ */
+export const PublicNoteSummarySchema = v.looseObject({
+  id: v.string(),
+  object: v.optional(v.string()),
+  title: v.nullish(v.string()),
+  created_at: v.nullish(v.string()),
+  updated_at: v.nullish(v.string()),
+  owner: v.nullish(OwnerSchema),
+});
+
+/**
+ * `GET /v1/notes` response. Spec uses camelCase `hasMore` and bare `cursor`
+ * (not `next_cursor`). Locking these names exactly — pagination depends on
+ * them.
+ */
+export const PublicListNotesResponseSchema = v.looseObject({
+  notes: v.array(PublicNoteSummarySchema),
+  cursor: v.nullish(v.string()),
+  hasMore: v.optional(v.boolean()),
+});
+
+/**
+ * Full note as returned by `GET /v1/notes/{id}`. `transcript` is only present
+ * when `?include=transcript` is requested. `summary_markdown` is the canonical
+ * note body for API-key auth.
+ */
+export const PublicNoteSchema = v.looseObject({
+  id: v.string(),
+  title: v.nullish(v.string()),
+  created_at: v.nullish(v.string()),
+  updated_at: v.nullish(v.string()),
+  web_url: v.nullish(v.string()),
+  owner: v.nullish(OwnerSchema),
+  attendees: v.optional(v.array(AttendeeSchema)),
+  summary_markdown: v.nullish(v.string()),
+  summary_text: v.nullish(v.string()),
+  folder_membership: v.optional(v.array(FolderMembershipEntrySchema)),
+  transcript: v.optional(v.array(PublicTranscriptEntrySchema)),
+});
+
+/**
+ * Folder shape from `GET /v1/folders`. Spec field name is `parent_folder_id`
+ * (not `parent_id`), matching the folder_membership shape on Get Note.
+ */
+const PublicFolderSchema = v.looseObject({
+  id: v.string(),
+  object: v.optional(v.string()),
+  name: v.string(),
+  parent_folder_id: v.nullish(v.string()),
+});
+
+/**
+ * `GET /v1/folders` response. Same pagination contract as list-notes:
+ * camelCase `hasMore`, bare `cursor`.
+ */
+export const PublicListFoldersResponseSchema = v.looseObject({
+  folders: v.array(PublicFolderSchema),
+  cursor: v.nullish(v.string()),
+  hasMore: v.optional(v.boolean()),
+});
+
+// Type exports for use by the adapter and client.
+export type PublicNoteSummary = v.InferOutput<typeof PublicNoteSummarySchema>;
+export type PublicNote = v.InferOutput<typeof PublicNoteSchema>;
+export type PublicTranscriptEntry = v.InferOutput<
+  typeof PublicTranscriptEntrySchema
+>;
+export type PublicFolderMembershipEntry = v.InferOutput<
+  typeof FolderMembershipEntrySchema
+>;
+export type PublicFolder = v.InferOutput<typeof PublicFolderSchema>;
+export type PublicListNotesResponse = v.InferOutput<
+  typeof PublicListNotesResponseSchema
+>;
+export type PublicListFoldersResponse = v.InferOutput<
+  typeof PublicListFoldersResponseSchema
+>;

--- a/src/services/publicGranolaApi.ts
+++ b/src/services/publicGranolaApi.ts
@@ -1,0 +1,301 @@
+import { requestUrl, RequestUrlParam } from "obsidian";
+import * as v from "valibot";
+import {
+  PublicListNotesResponseSchema,
+  PublicNoteSchema,
+  PublicListFoldersResponseSchema,
+  PublicNote,
+  PublicNoteSummary,
+  PublicListNotesResponse,
+  PublicListFoldersResponse,
+} from "./publicApiSchemas";
+import { log } from "../utils/logger";
+
+/**
+ * Client for Granola's Public API (`public-api.granola.ai`).
+ *
+ * Differences from the internal `granolaApi.ts` client:
+ * - Uses Bearer token (the `grn_*` API key) instead of WorkOS access token.
+ * - GET endpoints with cursor pagination instead of POST + offset.
+ * - Conservative rate limiting (5 req/s sustained per Granola docs).
+ * - Surfaces HTTP status to callers so the sync orchestrator can react to
+ *   401 / 429 distinctly from generic failures.
+ */
+
+const BASE_URL = "https://public-api.granola.ai";
+/**
+ * Granola's documented sustained rate limit is 5 req/s. We space requests
+ * 220ms apart (~4.5 req/s) to leave headroom for clock skew and avoid 429s.
+ * Tuneable for tests via {@link setMinRequestSpacingMs}.
+ */
+let MIN_REQUEST_SPACING_MS = 220;
+
+/**
+ * Test hook: override the request spacing. Set to 0 in tests so suites stay
+ * fast; production callers should leave the default.
+ */
+export function setMinRequestSpacingMs(ms: number): void {
+  MIN_REQUEST_SPACING_MS = ms;
+}
+
+/**
+ * Thrown when the API returns an error status. Carries the HTTP status and
+ * (when present) Granola's `granola-request-id` header so logs / bug reports
+ * can be cross-referenced with Granola support.
+ */
+export class PublicApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly requestId?: string
+  ) {
+    super(message);
+    this.name = "PublicApiError";
+  }
+}
+
+interface RequestOpts {
+  /** Defaults to GET. */
+  method?: "GET" | "POST";
+  query?: Record<string, string | number | undefined>;
+  body?: unknown;
+}
+
+let lastRequestAt = 0;
+
+/**
+ * Sleeps so the next request is at least {@link MIN_REQUEST_SPACING_MS} after
+ * the previous one. Single-threaded — Obsidian plugin code runs on the
+ * renderer's main thread, so this is sufficient throttling.
+ */
+async function throttleNextRequest(): Promise<void> {
+  if (MIN_REQUEST_SPACING_MS <= 0) return;
+  const now = Date.now();
+  const wait = lastRequestAt + MIN_REQUEST_SPACING_MS - now;
+  if (wait > 0) {
+    await new Promise((resolve) => window.setTimeout(resolve, wait));
+  }
+  lastRequestAt = Date.now();
+}
+
+function buildUrl(
+  path: string,
+  query: Record<string, string | number | undefined> | undefined
+): string {
+  const url = new URL(path, BASE_URL);
+  if (query) {
+    for (const [k, v] of Object.entries(query)) {
+      if (v === undefined) continue;
+      url.searchParams.set(k, String(v));
+    }
+  }
+  return url.toString();
+}
+
+async function requestPublicApi(
+  apiKey: string,
+  path: string,
+  opts: RequestOpts = {}
+): Promise<{ json: unknown; status: number; requestId?: string }> {
+  await throttleNextRequest();
+
+  const url = buildUrl(path, opts.query);
+  const params: RequestUrlParam = {
+    url,
+    method: opts.method ?? "GET",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      Accept: "application/json",
+      "User-Agent": `GranolaObsidianPlugin/${PLUGIN_VERSION}`,
+    },
+    // requestUrl throws by default on non-2xx; we want to inspect status.
+    throw: false,
+  };
+  if (opts.body !== undefined) {
+    params.body = JSON.stringify(opts.body);
+    if (!params.headers) params.headers = {};
+    params.headers["Content-Type"] = "application/json";
+  }
+
+  log.debug(`publicGranolaApi → ${params.method} ${path}`);
+  const response = await requestUrl(params);
+  const requestId =
+    response.headers?.["granola-request-id"] ??
+    response.headers?.["x-request-id"];
+
+  if (response.status >= 400) {
+    log.error(
+      `publicGranolaApi ${params.method} ${path} → ${response.status}` +
+        (requestId ? ` (request-id ${requestId})` : "")
+    );
+    throw new PublicApiError(
+      `Granola public API ${path} returned HTTP ${response.status}`,
+      response.status,
+      requestId
+    );
+  }
+
+  return { json: response.json, status: response.status, requestId };
+}
+
+function safeParseOrThrow<TSchema extends v.GenericSchema>(
+  schema: TSchema,
+  data: unknown,
+  context: string
+): v.InferOutput<TSchema> {
+  const result = v.safeParse(schema, data);
+  if (!result.success) {
+    log.error(`publicGranolaApi schema validation failed for ${context}`);
+    log.error(JSON.stringify(result.issues, null, 2));
+    throw new Error(
+      `Invalid response from Granola public API (${context})`
+    );
+  }
+  return result.output;
+}
+
+export interface ListNotesParams {
+  /** ISO 8601 timestamp. Only notes created at or after are returned. */
+  createdAfter?: string;
+  /** ISO 8601 timestamp. Only notes updated at or after are returned. */
+  updatedAfter?: string;
+  cursor?: string;
+  /** Public API max is 30 per page. */
+  pageSize?: number;
+}
+
+/**
+ * Fetches a single page of notes. Caller is responsible for following the
+ * cursor — use {@link listAllNotes} for the common case.
+ */
+export async function listNotes(
+  apiKey: string,
+  params: ListNotesParams = {}
+): Promise<PublicListNotesResponse> {
+  const { json } = await requestPublicApi(apiKey, "/v1/notes", {
+    query: {
+      created_after: params.createdAfter,
+      updated_after: params.updatedAfter,
+      cursor: params.cursor,
+      page_size: params.pageSize ?? 30,
+    },
+  });
+  return safeParseOrThrow(
+    PublicListNotesResponseSchema,
+    json,
+    "PublicListNotesResponseSchema"
+  );
+}
+
+/**
+ * Iterates pages of notes until exhausted. Stops at `maxNotes` (default 5000)
+ * so a pathological response can't loop forever.
+ */
+export async function listAllNotes(
+  apiKey: string,
+  params: ListNotesParams = {},
+  maxNotes = 5000
+): Promise<PublicNoteSummary[]> {
+  const all: PublicNoteSummary[] = [];
+  let cursor: string | undefined = params.cursor;
+  let pages = 0;
+
+  while (all.length < maxNotes) {
+    const page = await listNotes(apiKey, {
+      ...params,
+      cursor,
+    });
+    all.push(...page.notes);
+    pages++;
+    log.debug(
+      `publicGranolaApi listAllNotes — page ${pages}, ${page.notes.length} note(s), total ${all.length}`
+    );
+    if (!page.hasMore || !page.cursor) {
+      break;
+    }
+    cursor = page.cursor;
+  }
+
+  if (all.length >= maxNotes) {
+    log.warn(
+      `publicGranolaApi listAllNotes — hit maxNotes cap (${maxNotes}); some notes may be missing`
+    );
+  }
+  return all;
+}
+
+/**
+ * Fetches a single note. Pass `includeTranscript: true` to attach the
+ * transcript array.
+ */
+export async function getNote(
+  apiKey: string,
+  noteId: string,
+  opts: { includeTranscript?: boolean } = {}
+): Promise<PublicNote> {
+  const query: Record<string, string | undefined> = {};
+  if (opts.includeTranscript) {
+    query.include = "transcript";
+  }
+  const { json } = await requestPublicApi(apiKey, `/v1/notes/${noteId}`, {
+    query,
+  });
+  return safeParseOrThrow(PublicNoteSchema, json, "PublicNoteSchema");
+}
+
+export interface ListFoldersParams {
+  cursor?: string;
+  /** Public API max is 30 per page. */
+  pageSize?: number;
+}
+
+export async function listFolders(
+  apiKey: string,
+  params: ListFoldersParams = {}
+): Promise<PublicListFoldersResponse> {
+  const { json } = await requestPublicApi(apiKey, "/v1/folders", {
+    query: {
+      cursor: params.cursor,
+      page_size: params.pageSize ?? 30,
+    },
+  });
+  return safeParseOrThrow(
+    PublicListFoldersResponseSchema,
+    json,
+    "PublicListFoldersResponseSchema"
+  );
+}
+
+/**
+ * Iterates pages of folders until exhausted. Defaults to a generous cap so a
+ * pathological response can't loop forever. Used by API-mode sync's periodic
+ * folder hierarchy refresh (see `apiFolderSnapshot.ts`).
+ */
+export async function listAllFolders(
+  apiKey: string,
+  maxFolders = 1000
+): Promise<PublicListFoldersResponse["folders"]> {
+  const all: PublicListFoldersResponse["folders"] = [];
+  let cursor: string | undefined;
+  let pages = 0;
+
+  while (all.length < maxFolders) {
+    const page = await listFolders(apiKey, { cursor });
+    all.push(...page.folders);
+    pages++;
+    log.debug(
+      `publicGranolaApi listAllFolders — page ${pages}, ${page.folders.length} folder(s), total ${all.length}`
+    );
+    if (!page.hasMore || !page.cursor) {
+      break;
+    }
+    cursor = page.cursor;
+  }
+
+  if (all.length >= maxFolders) {
+    log.warn(
+      `publicGranolaApi listAllFolders — hit maxFolders cap (${maxFolders}); some folders may be missing`
+    );
+  }
+  return all;
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -91,6 +91,53 @@ export interface AutomaticSyncSettings {
   latestSyncTime: number;
 }
 
+/**
+ * Authentication configuration.
+ *
+ * - `desktop` (default): read WorkOS tokens from the Granola desktop app's
+ *   `stored-accounts.json` and call the internal `api.granola.ai` endpoints.
+ * - `api_key`: use a `grn_*` Public API key against `public-api.granola.ai`.
+ *   Requires Granola Business or Enterprise.
+ */
+export type AuthMethod = "desktop" | "api_key";
+
+/**
+ * Note body behavior when `authMethod === "api_key"`.
+ *
+ * The Public API returns the AI-generated `summary_markdown` rather than the
+ * ProseMirror body the desktop app syncs. This setting controls how aggressive
+ * the first API-mode sync is about overwriting existing note bodies.
+ *
+ * - `refresh-transcripts-only` (default): never rewrite the note body; still
+ *   update transcripts and safe frontmatter. Prevents mass-write churn when a
+ *   user first toggles API auth.
+ * - `normal`: rewrite bodies whenever the remote is newer (mirrors desktop
+ *   behavior).
+ * - `force-refresh-all`: rewrite every body once; auto-reverts to
+ *   `refresh-transcripts-only` after a successful sync.
+ */
+export type ApiSyncBodyMode =
+  | "refresh-transcripts-only"
+  | "normal"
+  | "force-refresh-all";
+
+export interface AuthSettings {
+  authMethod: AuthMethod;
+  /**
+   * Granola Public API key (`grn_*`). Stored in plugin `data.json`; users
+   * should be aware this syncs anywhere the vault syncs (Obsidian Sync,
+   * iCloud, Dropbox, Git, …).
+   */
+  apiKey?: string;
+  apiSyncBodyMode: ApiSyncBodyMode;
+  /**
+   * Set by sync when the most recent API request returned HTTP 401, so the
+   * settings UI can surface a "key revoked/invalid" affordance. Cleared on
+   * the next successful sync.
+   */
+  _lastApiAuthError?: boolean;
+}
+
 type LegacySyncDestination =
   | "granola_folder"
   | "daily_notes"
@@ -112,10 +159,22 @@ export interface LegacySettings {
 export type GranolaSyncSettings = NoteSettings &
   TranscriptSettings &
   AutomaticSyncSettings &
-  FilterSettings & {
+  FilterSettings &
+  AuthSettings & {
     enableDebugLogging: boolean;
-    // Persisted folder map for detecting renames across syncs
+    // Persisted folder map for detecting renames across syncs (desktop mode)
     _folderMapCache?: FolderMapData;
+    // Per-granolaId last-known folder snapshot, used in API-key mode to
+    // detect folder renames (the Public API doesn't emit rename events; we
+    // diff snapshots between syncs). Carries stable folder IDs and a
+    // doc→folder-ids index so parent renames + incremental syncs work.
+    _apiFolderSnapshot?: import("./services/apiFolderSnapshot").ApiFolderSnapshot;
+    /**
+     * Last time API-mode sync called `listFolders()` to refresh the full
+     * folder hierarchy. ms since epoch. Used by
+     * `shouldRefetchFolders` to gate the daily extra request.
+     */
+    _apiFoldersLastFetched?: number;
     // Legacy settings preserved for potential rollback
     _legacySettings?: LegacySettings;
   };
@@ -147,6 +206,9 @@ export const DEFAULT_SETTINGS: GranolaSyncSettings = {
   customTranscriptBaseFolder: "Granola/Transcripts",
   transcriptSubfolderPattern: "none",
   transcriptFilenamePattern: "{title}-transcript",
+  // AuthSettings
+  authMethod: "desktop",
+  apiSyncBodyMode: "refresh-transcripts-only",
   // Debug / diagnostics
   enableDebugLogging: false,
 };
@@ -249,6 +311,8 @@ export class GranolaSyncSettingTab extends PluginSettingTab {
 
     containerEl.empty();
 
+    this.renderAuthSection(containerEl);
+
     // General settings (no heading per Obsidian conventions)
     new Setting(containerEl)
       .setName("Periodic sync enabled")
@@ -321,20 +385,33 @@ export class GranolaSyncSettingTab extends PluginSettingTab {
     if (this.plugin.settings.syncNotes) {
       new Setting(containerEl).setName("Notes").setHeading();
 
-      new Setting(containerEl)
-        .setName("Include private notes")
-        .setDesc(
+      const isApiKeyMode = this.plugin.settings.authMethod === "api_key";
+
+      const privateNotesSetting = new Setting(containerEl).setName(
+        "Include private notes"
+      );
+      if (isApiKeyMode) {
+        privateNotesSetting.setDesc(
+          "Not available in API key mode — Granola's public API does not expose private notes. Switch to desktop credentials to use this setting."
+        );
+      } else {
+        privateNotesSetting.setDesc(
           // eslint-disable-next-line obsidianmd/ui/sentence-case -- '## Private Notes' / '## Enhanced Notes' are literal heading labels written into the output
           "Include your raw private notes at the top of each synced note. Private notes appear in a '## Private Notes' section above the '## Enhanced Notes' section."
-        )
-        .addToggle((toggle) =>
+        );
+      }
+      privateNotesSetting.addToggle((toggle) => {
           toggle
-            .setValue(this.plugin.settings.includePrivateNotes)
+            .setValue(
+              isApiKeyMode ? false : this.plugin.settings.includePrivateNotes
+            )
+            .setDisabled(isApiKeyMode)
             .onChange(async (value) => {
+              if (isApiKeyMode) return;
               this.plugin.settings.includePrivateNotes = value;
               await this.plugin.saveSettings();
-            })
-        );
+            });
+        });
 
       new Setting(containerEl)
         .setName("Save notes as")
@@ -643,6 +720,17 @@ export class GranolaSyncSettingTab extends PluginSettingTab {
             })
         );
 
+      new Setting(containerEl)
+        .setName("Dry-run sync")
+        .setDesc(
+          "Simulates a sync without modifying any files. Opens a report showing exactly what would be created, modified, or skipped. Use before enabling API key authentication or after large changes to verify behavior."
+        )
+        .addButton((button) =>
+          button.setButtonText("Dry-run sync").onClick(async () => {
+            await this.plugin.runDryRun();
+          })
+        );
+
       // Filtering
       new Setting(containerEl).setName("Filtering").setHeading();
 
@@ -669,12 +757,16 @@ export class GranolaSyncSettingTab extends PluginSettingTab {
       new Setting(containerEl)
         .setName("Include shared notes")
         .setDesc(
-          "Include notes that have been shared with you by others. When disabled, only notes you own will be synced."
+          this.plugin.settings.authMethod === "api_key"
+            ? "In API key mode this is controlled by your key's scopes (Personal vs Public). Create the key with the scopes you need in Granola — this toggle has no effect."
+            : "Include notes that have been shared with you by others. When disabled, only notes you own will be synced."
         )
         .addToggle((toggle) =>
           toggle
             .setValue(this.plugin.settings.includeSharedNotes)
+            .setDisabled(this.plugin.settings.authMethod === "api_key")
             .onChange(async (value) => {
+              if (this.plugin.settings.authMethod === "api_key") return;
               this.plugin.settings.includeSharedNotes = value;
               await this.plugin.saveSettings();
             })
@@ -769,7 +861,127 @@ export class GranolaSyncSettingTab extends PluginSettingTab {
         );
     }
 
-    // Support Section
+    this.renderSupportSection(containerEl);
+  }
+
+  /**
+   * Renders the Authentication section at the top of the settings tab.
+   *
+   * The desktop credential path remains the default for backwards
+   * compatibility with existing installs. API key authentication is the
+   * supported path for Granola Business / Enterprise users.
+   */
+  private renderAuthSection(containerEl: HTMLElement): void {
+    new Setting(containerEl).setName("Authentication").setHeading();
+
+    new Setting(containerEl)
+      .setName("Authentication method")
+      .setDesc(
+        "How the plugin authenticates with Granola. " +
+        "'Desktop credentials' reads tokens from your Granola desktop app (free and Personal plans). " +
+        "'API key' uses Granola's official Public API (requires Business or Enterprise)."
+      )
+      .addDropdown((dropdown) =>
+        dropdown
+          .addOption("desktop", "Desktop credentials (default)")
+          .addOption("api_key", "API key")
+          .setValue(this.plugin.settings.authMethod)
+          .onChange(async (value) => {
+            this.plugin.settings.authMethod = value as "desktop" | "api_key";
+            await this.plugin.saveSettings();
+            this.display();
+          })
+      );
+
+    if (this.plugin.settings.authMethod === "api_key") {
+      const keyDesc = activeDocument.createDocumentFragment();
+      keyDesc.append(
+        "Paste your Granola Public API key (starts with 'grn_'). "
+      );
+      const docsLink = activeDocument.createElement("a");
+      docsLink.href = "https://docs.granola.ai/introduction";
+      docsLink.textContent = "Granola API docs";
+      docsLink.target = "_blank";
+      docsLink.rel = "noopener";
+      keyDesc.append(docsLink, ".");
+      keyDesc.append(activeDocument.createElement("br"));
+      keyDesc.append(
+        "Stored in this plugin's data.json. If you sync your Obsidian vault " +
+        "(Obsidian Sync, iCloud, Dropbox, Git), the key syncs with it — " +
+        "revoke and re-create immediately if leaked."
+      );
+
+      new Setting(containerEl)
+        .setName("Granola API key")
+        .setDesc(keyDesc)
+        .addText((text) => {
+          text.inputEl.type = "password";
+          text.inputEl.autocomplete = "off";
+          text.inputEl.spellcheck = false;
+          text
+            // eslint-disable-next-line obsidianmd/ui/sentence-case -- 'grn_' is the literal API key prefix
+            .setPlaceholder("grn_...")
+            .setValue(this.plugin.settings.apiKey ?? "")
+            .onChange(async (value) => {
+              this.plugin.settings.apiKey = value.trim();
+              // User edited the key — clear any stale auth-error flag so the
+              // warning badge disappears until the next sync proves otherwise.
+              if (this.plugin.settings._lastApiAuthError) {
+                this.plugin.settings._lastApiAuthError = false;
+              }
+              await this.plugin.saveSettings();
+            });
+        });
+
+      if (this.plugin.settings._lastApiAuthError) {
+        new Setting(containerEl)
+          .setName("⚠ Last sync returned 401")
+          .setDesc(
+            "The most recent sync failed with an authentication error. Your API key may be " +
+            "invalid, revoked, or missing the required scopes. Re-create it in Granola and paste " +
+            "the new key above."
+          );
+      }
+
+      new Setting(containerEl)
+        .setName("API note body behavior")
+        .setDesc(
+          "The Public API returns Granola's AI summary instead of the ProseMirror " +
+          "body the desktop app syncs. Choose how aggressive sync should be about " +
+          "overwriting existing note bodies. 'Refresh transcripts only' is the safe " +
+          "default — it preserves existing note bodies and only updates transcripts."
+        )
+        .addDropdown((dropdown) =>
+          dropdown
+            .addOption(
+              "refresh-transcripts-only",
+              "Refresh transcripts only (default, safest)"
+            )
+            .addOption("normal", "Normal (rewrite when remote is newer)")
+            .addOption(
+              "force-refresh-all",
+              "Force refresh all (one-shot)"
+            )
+            .setValue(this.plugin.settings.apiSyncBodyMode)
+            .onChange(async (value) => {
+              this.plugin.settings.apiSyncBodyMode = value as
+                | "refresh-transcripts-only"
+                | "normal"
+                | "force-refresh-all";
+              await this.plugin.saveSettings();
+            })
+        );
+
+      new Setting(containerEl).setDesc(
+        "Note: API mode only includes meetings Granola has finished summarizing " +
+        "(AI summary + transcript). Recently-ended meetings may take longer to appear " +
+        "here than with desktop sync. Notes you can browse in a shared workspace folder " +
+        "but don't own may not be returned — use desktop credentials for full shared-folder coverage."
+      );
+    }
+  }
+
+  private renderSupportSection(containerEl: HTMLElement): void {
     new Setting(containerEl).setName("Support").setHeading();
 
     new Setting(containerEl)

--- a/styles.css
+++ b/styles.css
@@ -17,3 +17,61 @@
   width: auto;
   display: block;
 }
+
+/* Dry-run report modal styles. Kept here (vs inline) so the
+   obsidianmd/no-static-styles-assignment rule passes and so users can
+   override via CSS snippets if they want a different presentation. */
+.granola-sync-dry-run-modal .granola-sync-dry-run-timing {
+  color: var(--text-muted);
+  font-size: 0.9em;
+}
+
+.granola-sync-dry-run-modal .granola-sync-dry-run-counts ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+.granola-sync-dry-run-modal .granola-sync-dry-run-counts li {
+  padding: 0.15em 0;
+}
+
+.granola-sync-dry-run-modal .granola-sync-dry-run-details {
+  max-height: 400px;
+  overflow-y: auto;
+  border: 1px solid var(--background-modifier-border);
+  padding: 0.5em;
+}
+
+.granola-sync-dry-run-modal .granola-sync-dry-run-details table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85em;
+}
+
+.granola-sync-dry-run-modal .granola-sync-dry-run-details th {
+  text-align: left;
+  padding: 0.25em 0.5em;
+  border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.granola-sync-dry-run-modal .granola-sync-dry-run-details td {
+  padding: 0.25em 0.5em;
+}
+
+.granola-sync-dry-run-modal .granola-sync-dry-run-outcome {
+  white-space: nowrap;
+  font-family: var(--font-monospace);
+}
+
+.granola-sync-dry-run-modal .granola-sync-dry-run-path {
+  word-break: break-all;
+}
+
+.granola-sync-dry-run-modal .granola-sync-dry-run-granola-id {
+  color: var(--text-muted);
+  font-size: 0.9em;
+}
+
+.granola-sync-dry-run-modal .granola-sync-dry-run-reason {
+  color: var(--text-muted);
+}

--- a/tests/fixtures/public-api/get-note-with-transcript.json
+++ b/tests/fixtures/public-api/get-note-with-transcript.json
@@ -1,0 +1,52 @@
+{
+  "id": "not_AAAAAAAAAAAAAA",
+  "title": "Quarterly Strategy Sync",
+  "created_at": "2026-05-21T15:00:00.000Z",
+  "updated_at": "2026-05-21T15:42:13.000Z",
+  "web_url": "https://notes.granola.ai/d/00000000-0000-0000-0000-000000000001",
+  "owner": {
+    "id": "usr_abc",
+    "name": "Alice Example",
+    "email": "alice@example.com"
+  },
+  "attendees": [
+    {
+      "name": "Alice Example",
+      "email": "alice@example.com"
+    },
+    {
+      "name": "Bob Example",
+      "email": "bob@example.com"
+    }
+  ],
+  "summary_markdown": "## Quarterly Strategy Sync\n\n- Reviewed Q3 roadmap\n",
+  "summary_text": "Quarterly Strategy Sync. Reviewed Q3 roadmap.",
+  "folder_membership": [
+    {
+      "object": "folder",
+      "id": "fol_aaaaaaaaaaaaaa",
+      "name": "Strategy",
+      "parent_folder_id": null
+    }
+  ],
+  "transcript": [
+    {
+      "id": "trn_1",
+      "start_time": "2026-05-21T15:00:05.000Z",
+      "end_time": "2026-05-21T15:00:09.000Z",
+      "text": "Hello, welcome to the example meeting.",
+      "speaker": {
+        "source": "speaker"
+      }
+    },
+    {
+      "id": "trn_2",
+      "start_time": "2026-05-21T15:00:10.000Z",
+      "end_time": "2026-05-21T15:00:15.000Z",
+      "text": "Sounds good, I have the agenda open.",
+      "speaker": {
+        "source": "microphone"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/public-api/get-note.json
+++ b/tests/fixtures/public-api/get-note.json
@@ -1,0 +1,38 @@
+{
+  "id": "not_AAAAAAAAAAAAAA",
+  "title": "Quarterly Strategy Sync",
+  "created_at": "2026-05-21T15:00:00.000Z",
+  "updated_at": "2026-05-21T15:42:13.000Z",
+  "web_url": "https://notes.granola.ai/d/00000000-0000-0000-0000-000000000001",
+  "owner": {
+    "id": "usr_abc",
+    "name": "Alice Example",
+    "email": "alice@example.com"
+  },
+  "attendees": [
+    {
+      "name": "Alice Example",
+      "email": "alice@example.com"
+    },
+    {
+      "name": "Bob Example",
+      "email": "bob@example.com"
+    }
+  ],
+  "summary_markdown": "## Quarterly Strategy Sync\n\n- Reviewed Q3 roadmap\n- Aligned on staffing for the new initiative\n- Action: schedule follow-up with engineering leads\n",
+  "summary_text": "Quarterly Strategy Sync\n\nReviewed Q3 roadmap. Aligned on staffing for the new initiative. Action: schedule follow-up with engineering leads.",
+  "folder_membership": [
+    {
+      "object": "folder",
+      "id": "fol_aaaaaaaaaaaaaa",
+      "name": "Strategy",
+      "parent_folder_id": null
+    },
+    {
+      "object": "folder",
+      "id": "fol_bbbbbbbbbbbbbb",
+      "name": "Subteam",
+      "parent_folder_id": "fol_aaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/tests/fixtures/public-api/list-notes-last-page.json
+++ b/tests/fixtures/public-api/list-notes-last-page.json
@@ -1,0 +1,14 @@
+{
+  "notes": [
+    {
+      "id": "not_BBBBBBBBBBBBBB",
+      "object": "note",
+      "title": "Quarterly Strategy",
+      "owner": { "name": "Alice Example", "email": "alice@example.com" },
+      "created_at": "2026-03-10T15:00:00.000Z",
+      "updated_at": "2026-03-10T15:55:30.000Z"
+    }
+  ],
+  "cursor": null,
+  "hasMore": false
+}

--- a/tests/fixtures/public-api/list-notes-page.json
+++ b/tests/fixtures/public-api/list-notes-page.json
@@ -1,0 +1,30 @@
+{
+  "notes": [
+    {
+      "id": "not_AAAAAAAAAAAAAA",
+      "object": "note",
+      "title": "Quarterly Strategy Sync",
+      "owner": { "name": "Alice Example", "email": "alice@example.com" },
+      "created_at": "2026-05-21T15:00:00.000Z",
+      "updated_at": "2026-05-21T15:42:13.000Z"
+    },
+    {
+      "id": "not_CCCCCCCCCCCCCC",
+      "object": "note",
+      "title": "Project Alpha",
+      "owner": { "name": "Alice Example", "email": "alice@example.com" },
+      "created_at": "2026-02-25T17:00:00.000Z",
+      "updated_at": "2026-02-25T18:05:42.000Z"
+    },
+    {
+      "id": "not_DDDDDDDDDDDDDD",
+      "object": "note",
+      "title": "Charlie / Alice",
+      "owner": { "name": "Alice Example", "email": "alice@example.com" },
+      "created_at": "2026-05-21T20:00:00.000Z",
+      "updated_at": "2026-05-21T20:32:01.000Z"
+    }
+  ],
+  "cursor": "eyJjcmVhdGVkX2F0IjoiMjAyNi0wMi0yNVQxNzowMDowMC4wMDBaIn0=",
+  "hasMore": true
+}

--- a/tests/unit/adapterParity.test.ts
+++ b/tests/unit/adapterParity.test.ts
@@ -1,0 +1,141 @@
+import {
+  adaptPublicNoteToGranolaDoc,
+  adaptTranscript,
+} from "../../src/services/granolaDocAdapter";
+import { formatTranscriptBody } from "../../src/services/transcriptFormatter";
+import type { GranolaDoc, TranscriptEntry } from "../../src/services/granolaApi";
+import type { PublicNote } from "../../src/services/publicApiSchemas";
+
+jest.mock("../../src/utils/logger", () => ({
+  log: {
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+/**
+ * Adapter byte-identical parity tests.
+ *
+ * Goal: prove that the *stable* parts of a synced file (transcript body,
+ * canonical id, attendees) come out identically whether the source data is a
+ * desktop `GranolaDoc` or a Public API `PublicNote` for the same meeting.
+ *
+ * Allowed differences: note body content may legitimately differ
+ * (ProseMirror vs `summary_markdown`); this test does not assert equality
+ * there. It does assert the transcript section is byte-for-byte equal,
+ * because the formatter operates on the same internal `TranscriptEntry[]`
+ * shape in both modes.
+ */
+
+describe("Adapter parity — desktop GranolaDoc vs Public API note", () => {
+  const meetingUuid = "00000000-0000-0000-0000-000000000001";
+
+  // Desktop side: what /v2/get-documents returned for the meeting.
+  const desktopDoc: GranolaDoc = {
+    id: meetingUuid,
+    title: "Quarterly Strategy",
+    created_at: "2026-05-21T15:00:00.000Z",
+    updated_at: "2026-05-21T15:42:13.000Z",
+    last_viewed_panel: {
+      content: { type: "doc", content: [] },
+      updated_at: "2026-05-21T15:42:13.000Z",
+    },
+    people: {
+      attendees: [
+        { name: "Alice Example", email: "alice@example.com" },
+        { name: "Bob Example", email: "bob@example.com" },
+      ],
+    },
+  };
+
+  // Public API side: what /v1/notes/{not_id}?include=transcript returned.
+  const publicNote: PublicNote = {
+    id: "not_AAAAAAAAAAAAAA",
+    title: "Quarterly Strategy",
+    created_at: "2026-05-21T15:00:00.000Z",
+    updated_at: "2026-05-21T15:42:13.000Z",
+    web_url: `https://notes.granola.ai/d/${meetingUuid}`,
+    owner: { name: "Alice Example", email: "alice@example.com" },
+    attendees: [
+      { name: "Alice Example", email: "alice@example.com" },
+      { name: "Bob Example", email: "bob@example.com" },
+    ],
+    summary_markdown: "## Notes\n\n- ai summary content",
+    summary_text: "Plain text summary",
+    transcript: [
+      {
+        id: "trn_1",
+        start_time: "2026-05-21T15:00:05.000Z",
+        end_time: "2026-05-21T15:00:09.000Z",
+        text: "Good morning everyone.",
+        speaker: { source: "speaker" },
+      },
+      {
+        id: "trn_2",
+        start_time: "2026-05-21T15:00:10.000Z",
+        end_time: "2026-05-21T15:00:15.000Z",
+        text: "I have the agenda pulled up.",
+        speaker: { source: "microphone" },
+      },
+    ],
+  };
+
+  it("produces the same canonical granola_id from both sources", () => {
+    const adapted = adaptPublicNoteToGranolaDoc(publicNote);
+    expect(adapted.id).toBe(desktopDoc.id);
+  });
+
+  it("produces the same attendees in the same order", () => {
+    const adapted = adaptPublicNoteToGranolaDoc(publicNote);
+    expect(adapted.people?.attendees).toEqual(desktopDoc.people?.attendees);
+  });
+
+  it("produces the same created_at / updated_at strings", () => {
+    const adapted = adaptPublicNoteToGranolaDoc(publicNote);
+    expect(adapted.created_at).toBe(desktopDoc.created_at);
+    expect(adapted.updated_at).toBe(desktopDoc.updated_at);
+  });
+
+  it("produces a transcript body byte-identical to one built from the equivalent desktop entries", () => {
+    // Simulate the same meeting reaching us via the desktop transcript endpoint.
+    const desktopTranscript: TranscriptEntry[] = [
+      {
+        id: "trn_1",
+        document_id: meetingUuid,
+        start_timestamp: "2026-05-21T15:00:05.000Z",
+        end_timestamp: "2026-05-21T15:00:09.000Z",
+        text: "Good morning everyone.",
+        source: "speaker",
+        is_final: true,
+      },
+      {
+        id: "trn_2",
+        document_id: meetingUuid,
+        start_timestamp: "2026-05-21T15:00:10.000Z",
+        end_timestamp: "2026-05-21T15:00:15.000Z",
+        text: "I have the agenda pulled up.",
+        source: "microphone",
+        is_final: true,
+      },
+    ];
+    const adaptedTranscript = adaptTranscript(meetingUuid, publicNote.transcript);
+
+    expect(adaptedTranscript).toEqual(desktopTranscript);
+    expect(formatTranscriptBody(adaptedTranscript)).toBe(
+      formatTranscriptBody(desktopTranscript)
+    );
+  });
+
+  it("falls back to the not_ id only when the web_url UUID is missing — confirms the bridge", () => {
+    const adapted = adaptPublicNoteToGranolaDoc(publicNote);
+    const withoutUrl = adaptPublicNoteToGranolaDoc({
+      ...publicNote,
+      web_url: null,
+    });
+
+    expect(adapted.id).toBe(meetingUuid);
+    expect(withoutUrl.id).toBe(publicNote.id);
+  });
+});

--- a/tests/unit/apiFolderSnapshot.test.ts
+++ b/tests/unit/apiFolderSnapshot.test.ts
@@ -1,0 +1,480 @@
+/**
+ * Tests for the API-mode folder snapshot + diff.
+ *
+ * Goal: get the same fidelity as the desktop `diffFolderMaps` (in
+ * folderMapBuilder.ts). The Public API gives us stable folder IDs per
+ * `folder_membership`; we should persist them in the snapshot instead of
+ * just slashed path strings, so diffs survive parent renames and incremental
+ * syncs.
+ *
+ * Each `describe` below documents one behavior we want — TDD-first. Behaviors
+ * the current heuristic in `main.ts::computeFolderRenames` fails are
+ * specifically called out.
+ */
+
+import type {
+  PublicFolderMembershipEntry,
+  PublicListFoldersResponse,
+} from "../../src/services/publicApiSchemas";
+import {
+  buildApiFolderSnapshot,
+  diffApiFolderSnapshots,
+  mergeApiFolderSnapshots,
+  folderListResponseToSnapshotFolders,
+  shouldRefetchFolders,
+  FOLDERS_REFETCH_INTERVAL_MS,
+  type ApiFolderSnapshot,
+} from "../../src/services/apiFolderSnapshot";
+
+// `resolveFolderPath` (used internally by diffApiFolderSnapshots) calls
+// log.error when it detects a folder cycle. The cycle test below exercises
+// that branch deliberately; we mock the logger so the test output stays
+// quiet without altering production behavior.
+jest.mock("../../src/utils/logger", () => ({
+  log: {
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+function membership(
+  ...entries: Array<[id: string, name: string, parentId?: string | null]>
+): PublicFolderMembershipEntry[] {
+  return entries.map(([id, name, parent_folder_id]) => ({
+    id,
+    name,
+    parent_folder_id: parent_folder_id ?? null,
+  }));
+}
+
+describe("buildApiFolderSnapshot", () => {
+  it("collects folder metadata across multiple notes by folder_id", () => {
+    const snap = buildApiFolderSnapshot([
+      {
+        granolaId: "uuid-1",
+        membership: membership(
+          ["fld-strategy", "Strategy", null],
+          ["fld-hopo", "Subteam", "fld-strategy"]
+        ),
+      },
+      {
+        granolaId: "uuid-2",
+        membership: membership(["fld-strategy", "Strategy", null]),
+      },
+    ]);
+
+    expect(snap.folders["fld-strategy"]).toEqual({
+      title: "Strategy",
+      parentId: null,
+    });
+    expect(snap.folders["fld-hopo"]).toEqual({
+      title: "Subteam",
+      parentId: "fld-strategy",
+    });
+    // doc → folder ID associations
+    expect(snap.docFolders["uuid-1"]).toEqual(["fld-strategy", "fld-hopo"]);
+    expect(snap.docFolders["uuid-2"]).toEqual(["fld-strategy"]);
+  });
+
+  it("treats notes with no folders as an empty list (not absent)", () => {
+    const snap = buildApiFolderSnapshot([
+      { granolaId: "uuid-1", membership: [] },
+    ]);
+    expect(snap.docFolders["uuid-1"]).toEqual([]);
+  });
+
+  it("dedupes folder IDs within a note", () => {
+    const snap = buildApiFolderSnapshot([
+      {
+        granolaId: "uuid-1",
+        membership: membership(
+          ["fld-a", "A", null],
+          ["fld-a", "A", null]
+        ),
+      },
+    ]);
+    expect(snap.docFolders["uuid-1"]).toEqual(["fld-a"]);
+  });
+});
+
+describe("diffApiFolderSnapshots — leaf rename", () => {
+  it("emits oldPath → newPath when a leaf folder is renamed", () => {
+    const previous: ApiFolderSnapshot = {
+      folders: {
+        "fld-strategy": { title: "Strategy", parentId: null },
+        "fld-hopo": { title: "Subteam", parentId: "fld-strategy" },
+      },
+      docFolders: { "uuid-1": ["fld-strategy", "fld-hopo"] },
+    };
+    const current: ApiFolderSnapshot = {
+      folders: {
+        "fld-strategy": { title: "Strategy", parentId: null },
+        // Subteam renamed to "Strategy 2026"
+        "fld-hopo": { title: "Strategy 2026", parentId: "fld-strategy" },
+      },
+      docFolders: { "uuid-1": ["fld-strategy", "fld-hopo"] },
+    };
+
+    const renames = diffApiFolderSnapshots(previous, current);
+    expect(renames.get("Strategy/Subteam")).toBe("Strategy/Strategy 2026");
+    expect(renames.size).toBe(1);
+  });
+});
+
+describe("diffApiFolderSnapshots — parent rename (CURRENT HEURISTIC MISSES THIS)", () => {
+  /**
+   * The most important case. When a parent folder is renamed, every
+   * descendant's resolved path changes too. The desktop differ handles this
+   * by walking parents; the current API heuristic in main.ts only compares
+   * leaf names, so it would miss `Strategy/Subteam → Planning/Subteam` when
+   * "Strategy" is renamed to "Planning".
+   */
+  it("propagates a parent rename to all descendants", () => {
+    const previous: ApiFolderSnapshot = {
+      folders: {
+        "fld-strategy": { title: "Strategy", parentId: null },
+        "fld-hopo": { title: "Subteam", parentId: "fld-strategy" },
+        "fld-q1": { title: "Q1", parentId: "fld-hopo" },
+      },
+      docFolders: { "uuid-1": ["fld-q1"] },
+    };
+    const current: ApiFolderSnapshot = {
+      folders: {
+        // Renamed Strategy → Planning
+        "fld-strategy": { title: "Planning", parentId: null },
+        "fld-hopo": { title: "Subteam", parentId: "fld-strategy" },
+        "fld-q1": { title: "Q1", parentId: "fld-hopo" },
+      },
+      docFolders: { "uuid-1": ["fld-q1"] },
+    };
+
+    const renames = diffApiFolderSnapshots(previous, current);
+    expect(renames.get("Strategy")).toBe("Planning");
+    expect(renames.get("Strategy/Subteam")).toBe("Planning/Subteam");
+    expect(renames.get("Strategy/Subteam/Q1")).toBe("Planning/Subteam/Q1");
+  });
+});
+
+describe("diffApiFolderSnapshots — move (reparent without leaf rename)", () => {
+  it("emits the path change when a folder is reparented", () => {
+    const previous: ApiFolderSnapshot = {
+      folders: {
+        "fld-strategy": { title: "Strategy", parentId: null },
+        "fld-archive": { title: "Archive", parentId: null },
+        "fld-hopo": { title: "Subteam", parentId: "fld-strategy" },
+      },
+      docFolders: { "uuid-1": ["fld-hopo"] },
+    };
+    const current: ApiFolderSnapshot = {
+      folders: {
+        "fld-strategy": { title: "Strategy", parentId: null },
+        "fld-archive": { title: "Archive", parentId: null },
+        // Subteam moved under Archive
+        "fld-hopo": { title: "Subteam", parentId: "fld-archive" },
+      },
+      docFolders: { "uuid-1": ["fld-hopo"] },
+    };
+
+    const renames = diffApiFolderSnapshots(previous, current);
+    expect(renames.get("Strategy/Subteam")).toBe("Archive/Subteam");
+  });
+});
+
+describe("diffApiFolderSnapshots — sibling folders with same name", () => {
+  /**
+   * Two folders both named "Standup" but in different parents. Renaming one
+   * must not falsely match the other. The current heuristic groups by
+   * leaf-name only, which could conflate.
+   */
+  it("does not conflate siblings with the same leaf name", () => {
+    const previous: ApiFolderSnapshot = {
+      folders: {
+        "fld-team-a": { title: "Team A", parentId: null },
+        "fld-team-b": { title: "Team B", parentId: null },
+        "fld-standup-a": { title: "Standup", parentId: "fld-team-a" },
+        "fld-standup-b": { title: "Standup", parentId: "fld-team-b" },
+      },
+      docFolders: { "uuid-1": ["fld-standup-a"], "uuid-2": ["fld-standup-b"] },
+    };
+    const current: ApiFolderSnapshot = {
+      folders: {
+        "fld-team-a": { title: "Team A", parentId: null },
+        "fld-team-b": { title: "Team B", parentId: null },
+        // Only the Team A standup gets renamed.
+        "fld-standup-a": { title: "Daily Sync", parentId: "fld-team-a" },
+        "fld-standup-b": { title: "Standup", parentId: "fld-team-b" },
+      },
+      docFolders: { "uuid-1": ["fld-standup-a"], "uuid-2": ["fld-standup-b"] },
+    };
+
+    const renames = diffApiFolderSnapshots(previous, current);
+    expect(renames.get("Team A/Standup")).toBe("Team A/Daily Sync");
+    expect(renames.has("Team B/Standup")).toBe(false);
+  });
+});
+
+describe("diffApiFolderSnapshots — non-renames must not trigger", () => {
+  it("returns empty when a doc gains a folder", () => {
+    const previous: ApiFolderSnapshot = {
+      folders: { "fld-a": { title: "A", parentId: null } },
+      docFolders: { "uuid-1": [] },
+    };
+    const current: ApiFolderSnapshot = {
+      folders: { "fld-a": { title: "A", parentId: null } },
+      docFolders: { "uuid-1": ["fld-a"] },
+    };
+    expect(diffApiFolderSnapshots(previous, current).size).toBe(0);
+  });
+
+  it("returns empty when a doc moves between unrelated folders", () => {
+    const previous: ApiFolderSnapshot = {
+      folders: {
+        "fld-a": { title: "A", parentId: null },
+        "fld-b": { title: "B", parentId: null },
+      },
+      docFolders: { "uuid-1": ["fld-a"] },
+    };
+    const current: ApiFolderSnapshot = {
+      folders: {
+        "fld-a": { title: "A", parentId: null },
+        "fld-b": { title: "B", parentId: null },
+      },
+      docFolders: { "uuid-1": ["fld-b"] },
+    };
+    expect(diffApiFolderSnapshots(previous, current).size).toBe(0);
+  });
+
+  it("returns empty when a new folder appears", () => {
+    const previous: ApiFolderSnapshot = {
+      folders: {},
+      docFolders: {},
+    };
+    const current: ApiFolderSnapshot = {
+      folders: { "fld-a": { title: "A", parentId: null } },
+      docFolders: { "uuid-1": ["fld-a"] },
+    };
+    expect(diffApiFolderSnapshots(previous, current).size).toBe(0);
+  });
+
+  it("returns empty when a folder disappears (we can't tell rename vs delete without a new id)", () => {
+    const previous: ApiFolderSnapshot = {
+      folders: { "fld-a": { title: "A", parentId: null } },
+      docFolders: { "uuid-1": ["fld-a"] },
+    };
+    const current: ApiFolderSnapshot = {
+      folders: {},
+      docFolders: { "uuid-1": [] },
+    };
+    expect(diffApiFolderSnapshots(previous, current).size).toBe(0);
+  });
+
+  it("returns empty when previous is null/empty (first sync)", () => {
+    expect(
+      diffApiFolderSnapshots(null, {
+        folders: { "fld-a": { title: "A", parentId: null } },
+        docFolders: { "uuid-1": ["fld-a"] },
+      }).size
+    ).toBe(0);
+  });
+});
+
+describe("diffApiFolderSnapshots — defensive", () => {
+  it("does not loop on cycles", () => {
+    const previous: ApiFolderSnapshot = {
+      folders: {
+        "fld-a": { title: "A", parentId: "fld-b" },
+        "fld-b": { title: "B", parentId: "fld-a" },
+      },
+      docFolders: { "uuid-1": ["fld-a"] },
+    };
+    const current: ApiFolderSnapshot = {
+      folders: {
+        "fld-a": { title: "A renamed", parentId: "fld-b" },
+        "fld-b": { title: "B", parentId: "fld-a" },
+      },
+      docFolders: { "uuid-1": ["fld-a"] },
+    };
+
+    const renames = diffApiFolderSnapshots(previous, current);
+    // It just needs to terminate and emit *something* for the renamed folder.
+    expect([...renames.keys()].length).toBeGreaterThan(0);
+  });
+});
+
+describe("mergeApiFolderSnapshots — incremental sync preservation", () => {
+  /**
+   * Incremental syncs only fetch a window of notes. The fresh API call only
+   * reports `folder_membership` for the notes in that window. If we replace
+   * the snapshot wholesale, we lose folder info for the 200 other notes in
+   * the vault. The merge keeps previous entries the partial didn't override.
+   */
+  it("preserves previous folder entries the partial did not include", () => {
+    const previous: ApiFolderSnapshot = {
+      folders: {
+        "fld-a": { title: "A", parentId: null },
+        "fld-b": { title: "B", parentId: null },
+      },
+      docFolders: { "uuid-1": ["fld-a"], "uuid-2": ["fld-b"] },
+    };
+    const partial: ApiFolderSnapshot = {
+      folders: {
+        // fresh sync only saw a different folder + reconfirmed fld-a's name
+        "fld-a": { title: "A renamed", parentId: null },
+        "fld-c": { title: "C", parentId: null },
+      },
+      docFolders: { "uuid-1": ["fld-a"], "uuid-3": ["fld-c"] },
+    };
+
+    const merged = mergeApiFolderSnapshots(previous, partial);
+    // partial overrides where present
+    expect(merged.folders["fld-a"].title).toBe("A renamed");
+    expect(merged.folders["fld-c"].title).toBe("C");
+    // previous preserved where partial didn't touch
+    expect(merged.folders["fld-b"].title).toBe("B");
+    // doc associations: partial overrides per-doc, previous fills in untouched docs
+    expect(merged.docFolders["uuid-1"]).toEqual(["fld-a"]);
+    expect(merged.docFolders["uuid-2"]).toEqual(["fld-b"]);
+    expect(merged.docFolders["uuid-3"]).toEqual(["fld-c"]);
+  });
+
+  it("merging an empty partial returns the previous snapshot unchanged", () => {
+    const previous: ApiFolderSnapshot = {
+      folders: { "fld-a": { title: "A", parentId: null } },
+      docFolders: { "uuid-1": ["fld-a"] },
+    };
+    const merged = mergeApiFolderSnapshots(previous, {
+      folders: {},
+      docFolders: {},
+    });
+    expect(merged).toEqual(previous);
+  });
+});
+
+describe("folderListResponseToSnapshotFolders", () => {
+  it("converts the list-folders response into a folders map keyed by id", () => {
+    const response: PublicListFoldersResponse = {
+      folders: [
+        { id: "fol-strategy", object: "folder", name: "Strategy", parent_folder_id: null },
+        { id: "fol-hopo", object: "folder", name: "Subteam", parent_folder_id: "fol-strategy" },
+      ],
+      cursor: null,
+      hasMore: false,
+    };
+    expect(folderListResponseToSnapshotFolders(response)).toEqual({
+      "fol-strategy": { title: "Strategy", parentId: null },
+      "fol-hopo": { title: "Subteam", parentId: "fol-strategy" },
+    });
+  });
+
+  it("returns empty when the response has no folders", () => {
+    expect(
+      folderListResponseToSnapshotFolders({
+        folders: [],
+        cursor: null,
+        hasMore: false,
+      })
+    ).toEqual({});
+  });
+});
+
+describe("shouldRefetchFolders — daily cadence", () => {
+  /**
+   * The behavior we want: an extra listFolders() call only once per
+   * FOLDERS_REFETCH_INTERVAL_MS (default 24h). This avoids the per-sync
+   * cost (one full folder list per sync) while still catching renames of
+   * folders whose notes didn't appear in any recent incremental window
+   * within ~24h.
+   */
+  it("returns true on the very first sync (no previous timestamp)", () => {
+    expect(shouldRefetchFolders(Date.now(), undefined)).toBe(true);
+    expect(shouldRefetchFolders(Date.now(), 0)).toBe(true);
+  });
+
+  it("returns false when the last fetch was inside the interval", () => {
+    const now = Date.UTC(2026, 4, 22, 12, 0, 0);
+    const recent = now - 60 * 60 * 1000; // 1h ago
+    expect(shouldRefetchFolders(now, recent)).toBe(false);
+  });
+
+  it("returns true when the last fetch was past the interval", () => {
+    const now = Date.UTC(2026, 4, 22, 12, 0, 0);
+    const stale = now - (FOLDERS_REFETCH_INTERVAL_MS + 60_000);
+    expect(shouldRefetchFolders(now, stale)).toBe(true);
+  });
+
+  it("treats a future-dated last-fetched timestamp as fresh (clock-skew defense)", () => {
+    // If something corrupted lastFetched into the future, we should not
+    // panic-refetch on every sync; just wait until clock time catches up.
+    const now = Date.UTC(2026, 4, 22, 12, 0, 0);
+    expect(shouldRefetchFolders(now, now + 60_000)).toBe(false);
+  });
+});
+
+describe("integration: listFolders catches a rename that didn't appear in a sync window", () => {
+  /**
+   * Concrete scenario this enables:
+   * - Previous sync persisted folder "Strategy" (fld-strategy).
+   * - User renames Strategy → Planning in Granola.
+   * - No notes in Strategy were touched in the next sync window, so
+   *   no `folder_membership` from Get Note reflects the rename.
+   * - The periodic listFolders call DOES see the new name; merging it in
+   *   then diffing against the previous snapshot produces the rename.
+   */
+  it("emits a rename for a folder no note in the current sync touched", () => {
+    const previous: ApiFolderSnapshot = {
+      folders: {
+        "fld-strategy": { title: "Strategy", parentId: null },
+        "fld-hopo": { title: "Subteam", parentId: "fld-strategy" },
+      },
+      docFolders: { "uuid-1": ["fld-strategy", "fld-hopo"] },
+    };
+
+    // Simulated: zero notes in the incremental window touched Strategy,
+    // so the per-note membership snapshot is empty. But listFolders returned
+    // the freshly renamed hierarchy.
+    const perNotePartial = buildApiFolderSnapshot([]);
+    const freshFoldersOnly: ApiFolderSnapshot = {
+      folders: folderListResponseToSnapshotFolders({
+        folders: [
+          { id: "fld-strategy", object: "folder", name: "Planning", parent_folder_id: null },
+          { id: "fld-hopo", object: "folder", name: "Subteam", parent_folder_id: "fld-strategy" },
+        ],
+        cursor: null,
+        hasMore: false,
+      }),
+      docFolders: {}, // listFolders does not return memberships
+    };
+
+    const merged = mergeApiFolderSnapshots(
+      mergeApiFolderSnapshots(previous, perNotePartial),
+      freshFoldersOnly
+    );
+    const renames = diffApiFolderSnapshots(previous, merged);
+
+    expect(renames.get("Strategy")).toBe("Planning");
+    expect(renames.get("Strategy/Subteam")).toBe("Planning/Subteam");
+  });
+});
+
+describe("diffApiFolderSnapshots — determinism", () => {
+  it("produces the same output for identical inputs", () => {
+    const snap: ApiFolderSnapshot = {
+      folders: {
+        "fld-1": { title: "Zeta", parentId: null },
+        "fld-2": { title: "Alpha", parentId: null },
+      },
+      docFolders: { "uuid-1": ["fld-1", "fld-2"] },
+    };
+    const a = diffApiFolderSnapshots(snap, {
+      ...snap,
+      folders: { ...snap.folders, "fld-1": { title: "Zeta renamed", parentId: null } },
+    });
+    const b = diffApiFolderSnapshots(snap, {
+      ...snap,
+      folders: { ...snap.folders, "fld-1": { title: "Zeta renamed", parentId: null } },
+    });
+    expect([...a.entries()]).toEqual([...b.entries()]);
+  });
+});

--- a/tests/unit/apiSync.integration.test.ts
+++ b/tests/unit/apiSync.integration.test.ts
@@ -1,0 +1,710 @@
+/**
+ * Integration-shaped tests for API-key mode sync.
+ *
+ * Scope: exercises the real `GranolaSync.sync()` orchestration to verify the
+ * periodic `listFolders()` refresh wires up correctly. Mocks the document
+ * fetcher (so we can hand-feed canned FetchedDoc[] without hitting the
+ * network) and the public API client (to assert listFolders call counts and
+ * propagate folder renames). The folder-snapshot module is real — these
+ * tests would catch wiring mistakes between sync, the fetcher, and the
+ * snapshot/diff code.
+ *
+ * If you're looking for the pure algorithm tests, see
+ * `apiFolderSnapshot.test.ts`.
+ */
+
+import GranolaSync from "../../src/main";
+import { DEFAULT_SETTINGS } from "../../src/settings";
+import { FileSyncService } from "../../src/services/fileSyncService";
+import { DocumentProcessor } from "../../src/services/documentProcessor";
+import { DailyNoteBuilder } from "../../src/services/dailyNoteBuilder";
+import { PathResolver } from "../../src/services/pathResolver";
+import { fetchDocumentsForSync } from "../../src/services/documentFetcher";
+import { listAllFolders } from "../../src/services/publicGranolaApi";
+import { DryRunRecorder } from "../../src/services/dryRun";
+import { FOLDERS_REFETCH_INTERVAL_MS } from "../../src/services/apiFolderSnapshot";
+import { showStatusBar, hideStatusBar, showStatusBarTemporary } from "../../src/utils/statusBar";
+import { Notice, App, TFile } from "obsidian";
+
+jest.mock("../../src/services/fileSyncService");
+jest.mock("../../src/services/documentProcessor");
+jest.mock("../../src/services/dailyNoteBuilder");
+jest.mock("../../src/services/pathResolver");
+jest.mock("../../src/services/documentFetcher", () => ({
+  fetchDocumentsForSync: jest.fn(),
+}));
+jest.mock("../../src/services/publicGranolaApi", () => ({
+  listAllFolders: jest.fn(),
+  PublicApiError: class PublicApiError extends Error {
+    constructor(message: string, public status: number, public requestId?: string) {
+      super(message);
+      this.name = "PublicApiError";
+    }
+  },
+}));
+jest.mock("../../src/services/credentials", () => ({
+  loadCredentials: jest.fn(),
+  encryptedCredentialsIsNewerThanPlaintext: jest.fn().mockResolvedValue(false),
+}));
+jest.mock("../../src/utils/statusBar");
+
+jest.mock("../../src/utils/logger", () => ({
+  log: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+  configureLogger: jest.fn(),
+}));
+
+const mockFetchDocumentsForSync = fetchDocumentsForSync as jest.MockedFunction<
+  typeof fetchDocumentsForSync
+>;
+const mockListAllFolders = listAllFolders as jest.MockedFunction<
+  typeof listAllFolders
+>;
+
+function makeFetchedDoc(opts: {
+  granolaId: string;
+  publicId: string;
+  membership?: Array<{ id: string; name: string; parent?: string | null }>;
+}) {
+  const membership = opts.membership?.map((m) => ({
+    id: m.id,
+    name: m.name,
+    parent_folder_id: m.parent ?? null,
+  }));
+  // Mirror what the real fetcher does — derive slashed folder paths from
+  // membership via the adapter. Tests that pass membership expect folders to
+  // be populated too.
+  const byId = new Map(membership?.map((m) => [m.id, m]) ?? []);
+  const folders = membership
+    ? Array.from(
+        new Set(
+          membership.map((entry) => {
+            const parts: string[] = [];
+            let cursor: typeof entry | undefined = entry;
+            const seen = new Set<string>();
+            while (cursor && !seen.has(cursor.id)) {
+              seen.add(cursor.id);
+              parts.unshift(cursor.name);
+              if (!cursor.parent_folder_id) break;
+              cursor = byId.get(cursor.parent_folder_id);
+            }
+            return parts.join("/");
+          })
+        )
+      ).sort()
+    : [];
+  return {
+    doc: {
+      id: opts.granolaId,
+      title: "Test",
+      created_at: "2026-05-21T15:00:00.000Z",
+      updated_at: "2026-05-21T15:42:13.000Z",
+    },
+    folders,
+    folderMembership: membership,
+    apiTranscript: undefined,
+    publicId: opts.publicId,
+    webUrl: null,
+  };
+}
+
+describe("API-key sync — listFolders periodic refresh integration", () => {
+  let plugin: GranolaSync;
+  let mockApp: jest.Mocked<App>;
+  let mockFileSyncService: jest.Mocked<FileSyncService>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockApp = {
+      vault: {
+        getMarkdownFiles: jest.fn().mockReturnValue([]),
+        read: jest.fn(),
+        modify: jest.fn(),
+      },
+      metadataCache: {
+        getFileCache: jest.fn(),
+      },
+      workspace: { iterateAllLeaves: jest.fn() },
+      fileManager: { processFrontMatter: jest.fn() },
+    } as any;
+
+    mockFileSyncService = {
+      buildCache: jest.fn().mockResolvedValue(undefined),
+      findByGranolaId: jest.fn().mockReturnValue(null),
+      isRemoteNewer: jest.fn().mockReturnValue(true),
+      saveNoteToDisk: jest.fn().mockResolvedValue({ saved: false, path: null }),
+      saveTranscriptToDisk: jest
+        .fn()
+        .mockResolvedValue({ saved: false, path: null }),
+      saveCombinedNoteToDisk: jest
+        .fn()
+        .mockResolvedValue({ saved: false, path: null }),
+      setDryRunRecorder: jest.fn(),
+      recordPublicIdBridge: jest.fn(),
+    } as any;
+
+    (FileSyncService as any).mockImplementation(() => mockFileSyncService);
+    (DocumentProcessor as any).mockImplementation(() => ({} as any));
+    (DailyNoteBuilder as any).mockImplementation(
+      () => ({ setDryRunRecorder: jest.fn() } as any)
+    );
+    (PathResolver as any).mockImplementation(() => ({
+      computeNotePath: jest.fn().mockReturnValue("Notes/Test.md"),
+    } as any));
+
+    plugin = new GranolaSync(mockApp, { id: "test", name: "test" } as any);
+    plugin.settings = {
+      ...DEFAULT_SETTINGS,
+      authMethod: "api_key",
+      apiKey: "grn_test",
+      // Default test posture: notes off so we don't have to mock all the
+      // downstream pipeline. Tests that need notes write enable it explicitly.
+      syncNotes: false,
+      syncTranscripts: false,
+    };
+    plugin.registerInterval = jest.fn();
+    plugin.saveData = jest.fn().mockResolvedValue(undefined);
+    (plugin as any).initializeServices();
+
+    (Notice as jest.Mock).mockImplementation(() => ({}));
+    (showStatusBar as jest.Mock).mockImplementation(() => {});
+    (hideStatusBar as jest.Mock).mockImplementation(() => {});
+    (showStatusBarTemporary as jest.Mock).mockImplementation(() => {});
+
+    // Default: no docs returned, no folders. Each test overrides as needed.
+    mockFetchDocumentsForSync.mockResolvedValue([]);
+    mockListAllFolders.mockResolvedValue([]);
+  });
+
+  it("calls listFolders on the very first api_key sync (no _apiFoldersLastFetched)", async () => {
+    await plugin.sync();
+    expect(mockListAllFolders).toHaveBeenCalledTimes(1);
+    expect(mockListAllFolders).toHaveBeenCalledWith("grn_test");
+  });
+
+  it("does NOT call listFolders when the timer is fresh (<24h)", async () => {
+    plugin.settings._apiFoldersLastFetched = Date.now() - 60 * 60 * 1000; // 1h ago
+    await plugin.sync();
+    expect(mockListAllFolders).not.toHaveBeenCalled();
+  });
+
+  it("calls listFolders when the timer is stale (>24h)", async () => {
+    plugin.settings._apiFoldersLastFetched =
+      Date.now() - (FOLDERS_REFETCH_INTERVAL_MS + 5 * 60 * 1000);
+    await plugin.sync();
+    expect(mockListAllFolders).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls listFolders on full sync regardless of timer freshness", async () => {
+    plugin.settings._apiFoldersLastFetched = Date.now() - 60 * 1000; // 60s ago — fresh
+    await plugin.sync({ mode: "full" });
+    expect(mockListAllFolders).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT call listFolders in desktop mode", async () => {
+    plugin.settings.authMethod = "desktop";
+    const { loadCredentials } = await import("../../src/services/credentials");
+    (loadCredentials as jest.Mock).mockResolvedValue({
+      accessToken: "desktop-token",
+      error: null,
+    });
+    // Desktop folder map builder lives in a separate module — we don't mock
+    // it here. Since we have zero docs, the desktop folder-map branch will
+    // run but no notes are affected. We only care that listFolders (public
+    // API) is never called.
+    await plugin.sync();
+    expect(mockListAllFolders).not.toHaveBeenCalled();
+  });
+
+  it("updates _apiFoldersLastFetched after a successful call", async () => {
+    const before = Date.now();
+    await plugin.sync();
+    const fetched = plugin.settings._apiFoldersLastFetched ?? 0;
+    expect(fetched).toBeGreaterThanOrEqual(before);
+    expect(fetched).toBeLessThanOrEqual(Date.now());
+  });
+
+  it("does NOT update _apiFoldersLastFetched when listFolders throws (gives next sync a chance to retry)", async () => {
+    mockListAllFolders.mockRejectedValue(new Error("network down"));
+    await plugin.sync();
+    expect(plugin.settings._apiFoldersLastFetched).toBeUndefined();
+  });
+
+  it("continues sync gracefully when listFolders throws", async () => {
+    // Hand sync a non-empty document set so it runs through to completion
+    // rather than bailing on the "no documents found" branch.
+    mockFetchDocumentsForSync.mockResolvedValue([
+      makeFetchedDoc({
+        granolaId: "uuid-1",
+        publicId: "not_X",
+        membership: [{ id: "fld-a", name: "A", parent: null }],
+      }),
+    ]);
+    mockListAllFolders.mockRejectedValue(new Error("network down"));
+
+    await expect(plugin.sync()).resolves.toBeUndefined();
+    expect(showStatusBarTemporary).toHaveBeenCalledWith(
+      plugin,
+      "Granola sync: Complete"
+    );
+  });
+
+  it("detects and applies a rename found only via listFolders (no note in the window touched the folder)", async () => {
+    // Previous snapshot: Strategy + a child note.
+    plugin.settings._apiFolderSnapshot = {
+      folders: {
+        "fld-strategy": { title: "Strategy", parentId: null },
+        "fld-hopo": { title: "Subteam", parentId: "fld-strategy" },
+      },
+      docFolders: { "uuid-1": ["fld-strategy", "fld-hopo"] },
+    };
+
+    // This sync's docs returned NO membership covering Strategy — we'll
+    // synthesize zero docs.
+    mockFetchDocumentsForSync.mockResolvedValue([]);
+
+    // listFolders sees the rename.
+    mockListAllFolders.mockResolvedValue([
+      { id: "fld-strategy", object: "folder", name: "Planning", parent_folder_id: null },
+      { id: "fld-hopo", object: "folder", name: "Subteam", parent_folder_id: "fld-strategy" },
+    ]);
+
+    // Spy on the (private) rename application — going through metadataCache
+    // is overkill here, so we directly observe the updateRenamedFolders
+    // call. Cast via any to access private method.
+    const renameSpy = jest
+      .spyOn(plugin as any, "updateRenamedFolders")
+      .mockResolvedValue(undefined);
+
+    await plugin.sync();
+
+    expect(renameSpy).toHaveBeenCalledTimes(1);
+    const renames: Map<string, string> = renameSpy.mock.calls[0][0];
+    expect(renames.get("Strategy")).toBe("Planning");
+    expect(renames.get("Strategy/Subteam")).toBe("Planning/Subteam");
+  });
+
+  it("persists the merged snapshot (including listFolders results) back to settings", async () => {
+    plugin.settings._apiFolderSnapshot = {
+      folders: { "fld-existing": { title: "Existing", parentId: null } },
+      docFolders: { "uuid-old": ["fld-existing"] },
+    };
+    mockListAllFolders.mockResolvedValue([
+      { id: "fld-existing", object: "folder", name: "Existing", parent_folder_id: null },
+      { id: "fld-new", object: "folder", name: "New", parent_folder_id: null },
+    ]);
+
+    await plugin.sync();
+
+    const merged = plugin.settings._apiFolderSnapshot!;
+    expect(merged.folders["fld-existing"]).toBeDefined();
+    expect(merged.folders["fld-new"]).toEqual({
+      title: "New",
+      parentId: null,
+    });
+    // Previous docFolders entry must survive (not be wiped by partial sync)
+    expect(merged.docFolders["uuid-old"]).toEqual(["fld-existing"]);
+  });
+
+  describe("refresh-transcripts-only — fills missing notes, preserves existing", () => {
+    /**
+     * The user's Subteam orphan case: transcript exists in vault (from a
+     * desktop sync that won the race against AI summary generation) but no
+     * matching note file. `refresh-transcripts-only` mode should
+     * automatically create the missing note (using the API summary as the
+     * body, since there's nothing to preserve) without overwriting any
+     * notes that DO exist.
+     *
+     * On subsequent syncs after the orphan is filled, the now-existing
+     * note is preserved — covering the "user might edit it locally,
+     * don't clobber" concern.
+     */
+
+    beforeEach(() => {
+      plugin.settings.syncNotes = true;
+      plugin.settings.syncTranscripts = false;
+      plugin.settings.saveAsIndividualFiles = true;
+      plugin.settings.apiSyncBodyMode = "refresh-transcripts-only";
+    });
+
+    it("creates a note when the file is missing locally (orphan-fix)", async () => {
+      const missingId = "uuid-missing";
+      const existingId = "uuid-existing";
+      const existingFile = new TFile("Notes/Existing.md", "md");
+
+      mockFileSyncService.findByGranolaId.mockImplementation(
+        (id: string) => (id === existingId ? existingFile : null)
+      );
+
+      mockFetchDocumentsForSync.mockResolvedValue([
+        makeFetchedDoc({ granolaId: missingId, publicId: "not_missing" }),
+        makeFetchedDoc({ granolaId: existingId, publicId: "not_existing" }),
+      ]);
+
+      const recorder = new DryRunRecorder();
+      await plugin.sync({ dryRun: recorder });
+
+      const skips = recorder
+        .all()
+        .filter((r) => r.outcome === "skip-body-write-disabled");
+      // Only the existing file gets skipped — the missing one falls through
+      // to the normal create path.
+      expect(skips).toHaveLength(1);
+      expect(skips[0].granolaId).toBe(existingId);
+
+      // Save was called for the missing doc (creating the orphan-fix note).
+      // The existing one was NOT saved.
+      const savedIds = (mockFileSyncService.saveNoteToDisk as jest.Mock).mock
+        .calls.map((call) => call[0].id);
+      expect(savedIds).toEqual([missingId]);
+    });
+
+    it("skips body writes for all docs when every match already exists locally", async () => {
+      const file1 = new TFile("Notes/A.md", "md");
+      const file2 = new TFile("Notes/B.md", "md");
+      mockFileSyncService.findByGranolaId.mockImplementation((id: string) =>
+        id === "a" ? file1 : id === "b" ? file2 : null
+      );
+      mockFetchDocumentsForSync.mockResolvedValue([
+        makeFetchedDoc({ granolaId: "a", publicId: "not_a" }),
+        makeFetchedDoc({ granolaId: "b", publicId: "not_b" }),
+      ]);
+
+      const recorder = new DryRunRecorder();
+      await plugin.sync({ dryRun: recorder });
+
+      expect(mockFileSyncService.saveNoteToDisk).not.toHaveBeenCalled();
+      const skips = recorder
+        .all()
+        .filter((r) => r.outcome === "skip-body-write-disabled");
+      expect(skips.map((r) => r.granolaId).sort()).toEqual(["a", "b"]);
+    });
+
+    it("daily-notes mode in refresh-transcripts-only stays all-or-nothing (documented gap)", async () => {
+      // We deliberately do NOT implement the per-doc orphan-fix for daily
+      // notes mode in this iteration — the section-based update semantics
+      // are more invasive to change safely. Lock the existing behavior so
+      // we don't silently regress when this gets revisited.
+      plugin.settings.saveAsIndividualFiles = false;
+      mockFetchDocumentsForSync.mockResolvedValue([
+        makeFetchedDoc({ granolaId: "uuid-1", publicId: "not_X" }),
+      ]);
+
+      const recorder = new DryRunRecorder();
+      await plugin.sync({ dryRun: recorder });
+
+      // No saves at all (current behavior — daily-notes skip stays
+      // all-or-nothing in this mode).
+      expect(mockFileSyncService.saveNoteToDisk).not.toHaveBeenCalled();
+      expect(mockFileSyncService.saveCombinedNoteToDisk).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("dry-run contract — no live writes via orchestrator side-channels", () => {
+    /**
+     * Regression for a real bug surfaced during my own dry-run testing
+     * (2026-05-22): three orchestrator helpers (`backfillFolderMetadata`,
+     * `updateCrossLinks`, `updateRenamedFolders`) bypassed the
+     * `FileSyncService`-level dry-run interception and wrote to disk during
+     * a command labeled "no writes." These tests lock the contract that
+     * those side-channels record-and-skip in dry-run mode.
+     */
+
+    function vaultFile(path: string, frontmatter: Record<string, unknown>) {
+      return {
+        file: new TFile(path, "md"),
+        frontmatter,
+      };
+    }
+
+    function setVaultFiles(
+      entries: Array<{ file: TFile; frontmatter: Record<string, unknown> }>
+    ) {
+      mockApp.vault.getMarkdownFiles.mockReturnValue(entries.map((e) => e.file));
+      mockApp.metadataCache.getFileCache.mockImplementation((file: TFile) => {
+        const match = entries.find((e) => e.file.path === file.path);
+        return match ? ({ frontmatter: match.frontmatter } as any) : null;
+      });
+    }
+
+    it("does not call vault.modify from backfillFolderMetadata in dry-run", async () => {
+      // One vault note matches a fetched doc and is missing folders frontmatter
+      const granolaId = "uuid-1";
+      setVaultFiles([
+        vaultFile("Notes/Existing.md", { granola_id: granolaId }),
+      ]);
+      mockApp.vault.read = jest.fn().mockResolvedValue("---\ngranola_id: uuid-1\n---\nbody");
+
+      mockFetchDocumentsForSync.mockResolvedValue([
+        makeFetchedDoc({
+          granolaId,
+          publicId: "not_X",
+          membership: [{ id: "fol_a", name: "Strategy", parent: null }],
+        }),
+      ]);
+
+      const recorder = new DryRunRecorder();
+      await plugin.sync({ dryRun: recorder });
+
+      expect(mockApp.vault.modify).not.toHaveBeenCalled();
+      const fmRecords = recorder
+        .all()
+        .filter((r) => r.outcome === "would-modify-frontmatter");
+      // The backfill helper records this as a "would-modify-frontmatter"
+      // (folders backfill). Cross-link path is gated separately.
+      expect(fmRecords.some((r) => r.reason?.includes("backfill"))).toBe(true);
+    });
+
+    it("does not produce phantom cross-link 'updates' when the matching note file is missing", async () => {
+      // Regression for misleading log diagnosed during a real dry-run on
+      // 2026-05-22: when an existing transcript file has no matching note
+      // file in the vault, updateCrossLinks would log "Updated cross-links
+      // in 1 pair" despite no record being created and no write being
+      // performed. The counter now only increments on a real link.
+      plugin.settings.syncNotes = true;
+      plugin.settings.syncTranscripts = true;
+      plugin.settings.saveAsIndividualFiles = true;
+      plugin.settings.transcriptHandling = "custom-location";
+
+      const granolaId = "uuid-1";
+      const transcriptFile = new TFile("Transcripts/orphan-transcript.md", "md");
+      // Transcript present, NOTE MISSING.
+      mockFileSyncService.findByGranolaId.mockImplementation(
+        (id: string, type: "note" | "transcript" | "combined") => {
+          if (id !== granolaId) return null;
+          if (type === "transcript") return transcriptFile;
+          return null; // no matching note file
+        }
+      );
+      mockFetchDocumentsForSync.mockResolvedValue([
+        makeFetchedDoc({ granolaId, publicId: "not_X" }),
+      ]);
+
+      const recorder = new DryRunRecorder();
+      await plugin.sync({ dryRun: recorder });
+
+      // No cross-link record should have been emitted — there was no pair.
+      const crossLinkRecords = recorder
+        .all()
+        .filter(
+          (r) =>
+            r.outcome === "would-modify-frontmatter" &&
+            r.reason?.startsWith("cross-link")
+        );
+      expect(crossLinkRecords).toEqual([]);
+      // And no live write either.
+      expect(mockApp.fileManager.processFrontMatter).not.toHaveBeenCalled();
+    });
+
+    it("does not call processFrontMatter from updateCrossLinks in dry-run", async () => {
+      // Enable note + transcript sync so updateCrossLinks would run.
+      plugin.settings.syncNotes = true;
+      plugin.settings.syncTranscripts = true;
+      plugin.settings.saveAsIndividualFiles = true;
+      plugin.settings.transcriptHandling = "custom-location";
+
+      const granolaId = "uuid-1";
+      const noteFile = new TFile("Notes/Note.md", "md");
+      const transcriptFile = new TFile("Transcripts/Note-transcript.md", "md");
+
+      // FileSyncService.findByGranolaId returns the right files per type
+      mockFileSyncService.findByGranolaId.mockImplementation(
+        (id: string, type: "note" | "transcript" | "combined") => {
+          if (id !== granolaId) return null;
+          if (type === "note") return noteFile;
+          if (type === "transcript") return transcriptFile;
+          return null;
+        }
+      );
+
+      mockFetchDocumentsForSync.mockResolvedValue([
+        makeFetchedDoc({ granolaId, publicId: "not_X" }),
+      ]);
+
+      const recorder = new DryRunRecorder();
+      await plugin.sync({ dryRun: recorder });
+
+      expect(mockApp.fileManager.processFrontMatter).not.toHaveBeenCalled();
+      const crossLinkRecords = recorder
+        .all()
+        .filter(
+          (r) =>
+            r.outcome === "would-modify-frontmatter" &&
+            r.reason?.startsWith("cross-link")
+        );
+      expect(crossLinkRecords.length).toBeGreaterThan(0);
+    });
+
+    it("does not call saveData during the sync run in dry-run mode", async () => {
+      // Force the snapshot-write path to execute by providing a fetched doc
+      // with membership and a stale folders-last-fetched (so listFolders runs).
+      mockFetchDocumentsForSync.mockResolvedValue([
+        makeFetchedDoc({
+          granolaId: "uuid-1",
+          publicId: "not_X",
+          membership: [{ id: "fol_a", name: "A", parent: null }],
+        }),
+      ]);
+      mockListAllFolders.mockResolvedValue([]);
+
+      const saveDataSpy = jest.spyOn(plugin, "saveData");
+
+      const recorder = new DryRunRecorder();
+      await plugin.sync({ dryRun: recorder });
+
+      // The only allowed saveData during sync is the 401 path (diagnostic
+      // setting). No 401 occurred here.
+      expect(saveDataSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not mutate in-memory settings during dry-run (settings snapshot restored)", async () => {
+      // Regression for a real bug surfaced on 2026-05-22: a dry-run set
+      // `this.settings.latestSyncTime = Date.now()` in memory, so a second
+      // back-to-back dry-run in the same Obsidian session saw the advanced
+      // clock and returned 0 notes (window started after the first run's
+      // completion). The fix: snapshot settings on dry-run start, restore on
+      // finish. This test locks the contract.
+      const before = {
+        latestSyncTime: 1779000000000,
+        apiFoldersLastFetched: 1779000000000,
+        apiSyncBodyMode: "refresh-transcripts-only" as const,
+        apiFolderSnapshot: {
+          folders: { "fol_a": { title: "A", parentId: null } },
+          docFolders: { "uuid-1": ["fol_a"] },
+        },
+      };
+      plugin.settings.latestSyncTime = before.latestSyncTime;
+      plugin.settings._apiFoldersLastFetched = before.apiFoldersLastFetched;
+      plugin.settings.apiSyncBodyMode = before.apiSyncBodyMode;
+      plugin.settings._apiFolderSnapshot = before.apiFolderSnapshot;
+
+      // Force the listFolders path to run (stale timer) so the snapshot
+      // gets mutated mid-run. Provide a fetched doc so other settings
+      // mutations have a chance to fire.
+      mockFetchDocumentsForSync.mockResolvedValue([
+        makeFetchedDoc({
+          granolaId: "uuid-1",
+          publicId: "not_X",
+          membership: [{ id: "fol_b", name: "B", parent: null }],
+        }),
+      ]);
+      mockListAllFolders.mockResolvedValue([
+        { id: "fol_b", object: "folder", name: "B", parent_folder_id: null },
+      ]);
+
+      const recorder = new DryRunRecorder();
+      await plugin.sync({ dryRun: recorder });
+
+      // Every settings field that the sync code mutates in-memory should
+      // be restored to its pre-dry-run value.
+      expect(plugin.settings.latestSyncTime).toBe(before.latestSyncTime);
+      expect(plugin.settings._apiFoldersLastFetched).toBe(
+        before.apiFoldersLastFetched
+      );
+      expect(plugin.settings.apiSyncBodyMode).toBe(before.apiSyncBodyMode);
+      expect(plugin.settings._apiFolderSnapshot).toEqual(
+        before.apiFolderSnapshot
+      );
+    });
+
+    it("does not advance latestSyncTime between back-to-back dry-runs", async () => {
+      // Concrete repro of the scenario from production: two dry-runs in a
+      // row should both see the SAME `updated_after` window (the original
+      // production timestamp), not a window shifted by the first run.
+      plugin.settings.latestSyncTime = 1779000000000;
+
+      mockFetchDocumentsForSync.mockResolvedValue([]);
+
+      const recorder1 = new DryRunRecorder();
+      await plugin.sync({ dryRun: recorder1 });
+      const fetcherCallArgsFirst =
+        mockFetchDocumentsForSync.mock.calls[0]?.[2];
+
+      mockFetchDocumentsForSync.mockClear();
+
+      const recorder2 = new DryRunRecorder();
+      await plugin.sync({ dryRun: recorder2 });
+      const fetcherCallArgsSecond =
+        mockFetchDocumentsForSync.mock.calls[0]?.[2];
+
+      expect(fetcherCallArgsFirst?.latestSyncTime).toBe(1779000000000);
+      expect(fetcherCallArgsSecond?.latestSyncTime).toBe(1779000000000);
+      expect(plugin.settings.latestSyncTime).toBe(1779000000000);
+    });
+
+    it("preserves the 401 _lastApiAuthError flag even after dry-run snapshot restore", async () => {
+      // 401 detected by dry-run is real; the badge in settings should
+      // surface so the user knows to fix the key. This is the one
+      // documented exception to the "no settings mutation" contract.
+      plugin.settings._lastApiAuthError = false;
+
+      const PublicApiError = (require("../../src/services/publicGranolaApi") as any)
+        .PublicApiError;
+      mockFetchDocumentsForSync.mockRejectedValueOnce(
+        new PublicApiError("Unauthorized", 401, "req_test")
+      );
+
+      const recorder = new DryRunRecorder();
+      await plugin.sync({ dryRun: recorder });
+
+      expect(plugin.settings._lastApiAuthError).toBe(true);
+    });
+
+    it("still calls saveData on 401 (diagnostic _lastApiAuthError flag) even in dry-run", async () => {
+      // PublicApiError with status 401 should set _lastApiAuthError so the
+      // settings badge appears regardless of whether we were in dry-run.
+      const PublicApiError = (require("../../src/services/publicGranolaApi") as any)
+        .PublicApiError;
+      const err = new PublicApiError("Unauthorized", 401, "req_test");
+      mockFetchDocumentsForSync.mockRejectedValueOnce(err);
+
+      const saveDataSpy = jest.spyOn(plugin, "saveData");
+      const recorder = new DryRunRecorder();
+
+      await plugin.sync({ dryRun: recorder });
+
+      expect(saveDataSpy).toHaveBeenCalled();
+      expect(plugin.settings._lastApiAuthError).toBe(true);
+    });
+  });
+
+  it("merges per-note membership and listFolders results into a single snapshot", async () => {
+    // No previous snapshot.
+    plugin.settings._apiFolderSnapshot = undefined;
+    plugin.settings._apiFoldersLastFetched = undefined;
+
+    // Per-note membership: one doc in Strategy/Subteam.
+    mockFetchDocumentsForSync.mockResolvedValue([
+      makeFetchedDoc({
+        granolaId: "uuid-1",
+        publicId: "not_X",
+        membership: [
+          { id: "fld-strategy", name: "Strategy", parent: null },
+          { id: "fld-hopo", name: "Subteam", parent: "fld-strategy" },
+        ],
+      }),
+    ]);
+
+    // listFolders adds one more folder.
+    mockListAllFolders.mockResolvedValue([
+      { id: "fld-strategy", object: "folder", name: "Strategy", parent_folder_id: null },
+      { id: "fld-hopo", object: "folder", name: "Subteam", parent_folder_id: "fld-strategy" },
+      { id: "fld-archive", object: "folder", name: "Archive", parent_folder_id: null },
+    ]);
+
+    await plugin.sync();
+
+    const merged = plugin.settings._apiFolderSnapshot!;
+    expect(Object.keys(merged.folders).sort()).toEqual([
+      "fld-archive",
+      "fld-hopo",
+      "fld-strategy",
+    ]);
+    expect(merged.docFolders["uuid-1"]).toEqual(["fld-strategy", "fld-hopo"]);
+  });
+});

--- a/tests/unit/auth.test.ts
+++ b/tests/unit/auth.test.ts
@@ -1,0 +1,141 @@
+import { resolveAuth } from "../../src/services/auth";
+import { loadCredentials } from "../../src/services/credentials";
+import { DEFAULT_SETTINGS, GranolaSyncSettings } from "../../src/settings";
+
+jest.mock("../../src/services/credentials");
+jest.mock("../../src/utils/logger", () => ({
+  log: {
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+const mockLoadCredentials = loadCredentials as jest.MockedFunction<
+  typeof loadCredentials
+>;
+
+function settings(overrides: Partial<GranolaSyncSettings> = {}): GranolaSyncSettings {
+  return { ...DEFAULT_SETTINGS, ...overrides };
+}
+
+describe("resolveAuth", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("authMethod=api_key", () => {
+    it("returns api_key auth when key looks valid", async () => {
+      const result = await resolveAuth(
+        settings({ authMethod: "api_key", apiKey: "grn_abc123" })
+      );
+
+      expect(result.auth).toEqual({ method: "api_key", token: "grn_abc123" });
+      expect(result.error).toBeNull();
+      expect(mockLoadCredentials).not.toHaveBeenCalled();
+    });
+
+    it("trims whitespace from the API key", async () => {
+      const result = await resolveAuth(
+        settings({ authMethod: "api_key", apiKey: "  grn_abc123  " })
+      );
+
+      expect(result.auth).toEqual({ method: "api_key", token: "grn_abc123" });
+    });
+
+    it("errors when the key is missing", async () => {
+      const result = await resolveAuth(
+        settings({ authMethod: "api_key", apiKey: "" })
+      );
+
+      expect(result.auth).toBeNull();
+      expect(result.error).toContain("API key is required");
+    });
+
+    it("errors when the key is whitespace-only", async () => {
+      const result = await resolveAuth(
+        settings({ authMethod: "api_key", apiKey: "   " })
+      );
+
+      expect(result.auth).toBeNull();
+      expect(result.error).toContain("API key is required");
+    });
+
+    it("errors when the key has the wrong prefix", async () => {
+      const result = await resolveAuth(
+        settings({ authMethod: "api_key", apiKey: "sk_abc123" })
+      );
+
+      expect(result.auth).toBeNull();
+      expect(result.error).toContain("unexpected format");
+    });
+  });
+
+  describe("authMethod=desktop", () => {
+    it("delegates to loadCredentials and returns desktop auth on success", async () => {
+      mockLoadCredentials.mockResolvedValueOnce({
+        accessToken: "workos-token",
+        error: null,
+      });
+
+      const result = await resolveAuth(settings({ authMethod: "desktop" }));
+
+      expect(result.auth).toEqual({ method: "desktop", token: "workos-token" });
+      expect(result.error).toBeNull();
+      expect(mockLoadCredentials).toHaveBeenCalledTimes(1);
+    });
+
+    it("propagates the error from loadCredentials", async () => {
+      mockLoadCredentials.mockResolvedValueOnce({
+        accessToken: null,
+        error: "Credentials file not found",
+      });
+
+      const result = await resolveAuth(settings({ authMethod: "desktop" }));
+
+      expect(result.auth).toBeNull();
+      expect(result.error).toBe("Credentials file not found");
+    });
+
+    it("passes through the full credentialsResult so callers can route keychain errors", async () => {
+      // The desktop-credentials work (PR #130) added `errorKind` to the
+      // credentials result so a keychain-denied state can be routed to the
+      // dedicated modal in main.ts. resolveAuth must surface that result
+      // even on failure.
+      mockLoadCredentials.mockResolvedValueOnce({
+        accessToken: null,
+        error: "Keychain access denied",
+        errorKind: "keychain",
+      } as any);
+
+      const result = await resolveAuth(settings({ authMethod: "desktop" }));
+
+      expect(result.auth).toBeNull();
+      expect(result.credentialsResult).toEqual(
+        expect.objectContaining({ errorKind: "keychain" })
+      );
+    });
+
+    it("also passes credentialsResult on the success path (lets caller inspect provenance)", async () => {
+      mockLoadCredentials.mockResolvedValueOnce({
+        accessToken: "workos-token",
+        error: null,
+      });
+
+      const result = await resolveAuth(settings({ authMethod: "desktop" }));
+
+      expect(result.credentialsResult).toEqual(
+        expect.objectContaining({ accessToken: "workos-token", error: null })
+      );
+    });
+
+    it("does not include credentialsResult when authMethod is api_key", async () => {
+      const result = await resolveAuth(
+        settings({ authMethod: "api_key", apiKey: "grn_abc" })
+      );
+      expect(result.credentialsResult).toBeUndefined();
+      expect(mockLoadCredentials).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/dailyNoteBuilder.test.ts
+++ b/tests/unit/dailyNoteBuilder.test.ts
@@ -49,6 +49,164 @@ describe("DailyNoteBuilder", () => {
     jest.clearAllMocks();
   });
 
+  describe("dry-run interception", () => {
+    /**
+     * Regression for a real leak surfaced on 2026-05-22: a dry-run wrote
+     * `## Meetings` sections to two real daily notes because
+     * `addLinksToDailyNotes` and `getOrCreateDailyNote` had no dry-run
+     * guards. The recorder is now plumbed through DailyNoteBuilder and
+     * these tests lock the contract.
+     */
+
+    let recorder: { record: jest.Mock; all: () => unknown[] };
+    let mockVault: { read: jest.Mock; modify: jest.Mock };
+
+    beforeEach(() => {
+      const records: any[] = [];
+      recorder = {
+        record: jest.fn((rec) => records.push(rec)),
+        all: () => records,
+      };
+      mockVault = {
+        read: jest.fn().mockResolvedValue(""),
+        modify: jest.fn(),
+      };
+      (mockApp as any).vault = mockVault;
+      dailyNoteBuilder.setDryRunRecorder(recorder as any);
+    });
+
+    it("does not call createDailyNote in dry-run for a missing daily note", async () => {
+      (getDailyNote as jest.Mock).mockReturnValue(null);
+      (getAllDailyNotes as jest.Mock).mockReturnValue({});
+
+      const result = await dailyNoteBuilder.getOrCreateDailyNote("2026-05-22");
+
+      expect(createDailyNote).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+      expect(recorder.record).toHaveBeenCalledWith(
+        expect.objectContaining({
+          outcome: "would-create",
+          path: "(daily note for 2026-05-22)",
+        })
+      );
+    });
+
+    it("returns the existing daily note unchanged in dry-run when it exists", async () => {
+      const existing = new TFile("2026-05-22.md", "md");
+      (getDailyNote as jest.Mock).mockReturnValue(existing);
+
+      const result = await dailyNoteBuilder.getOrCreateDailyNote("2026-05-22");
+
+      expect(createDailyNote).not.toHaveBeenCalled();
+      expect(result).toBe(existing);
+      expect(recorder.record).not.toHaveBeenCalled();
+    });
+
+    it("updateDailyNoteSection records would-modify when section would change, no vault.modify", async () => {
+      const existing = new TFile("2026-05-22.md", "md");
+      mockVault.read.mockResolvedValue("# Day\n\n## Meetings\n- 10:00 old\n");
+
+      await dailyNoteBuilder.updateDailyNoteSection(
+        existing,
+        "## Meetings",
+        "## Meetings\n- 10:00 new\n",
+        false
+      );
+
+      expect(updateSection).not.toHaveBeenCalled();
+      expect(mockVault.modify).not.toHaveBeenCalled();
+      expect(recorder.record).toHaveBeenCalledWith(
+        expect.objectContaining({
+          outcome: "would-modify",
+          path: "2026-05-22.md",
+        })
+      );
+    });
+
+    it("updateDailyNoteSection records skip-unchanged when section content is identical", async () => {
+      const existing = new TFile("2026-05-22.md", "md");
+      const section = "## Meetings\n- 10:00 same\n";
+      mockVault.read.mockResolvedValue("# Day\n\n" + section);
+
+      await dailyNoteBuilder.updateDailyNoteSection(
+        existing,
+        "## Meetings",
+        section,
+        false
+      );
+
+      expect(updateSection).not.toHaveBeenCalled();
+      expect(recorder.record).toHaveBeenCalledWith(
+        expect.objectContaining({
+          outcome: "skip-unchanged",
+        })
+      );
+    });
+
+    it("addLinksToDailyNotes records intended writes without calling updateSection", async () => {
+      const existing = new TFile("2026-05-22.md", "md");
+      (getDailyNote as jest.Mock).mockReturnValue(existing);
+      mockVault.read.mockResolvedValue("# Day\n");
+
+      const docs = [
+        {
+          doc: {
+            id: "uuid-1",
+            title: "Meeting",
+            updated_at: "2026-05-22T15:00:00Z",
+          } as GranolaDoc,
+          notePath: "Granola/Meeting.md",
+        },
+      ];
+
+      await dailyNoteBuilder.addLinksToDailyNotes(
+        docs,
+        "## Meetings",
+        false,
+        () => "uuid-1"
+      );
+
+      expect(updateSection).not.toHaveBeenCalled();
+      expect(mockVault.modify).not.toHaveBeenCalled();
+      // Should record at least one would-modify for the section update.
+      const records = recorder.all() as any[];
+      expect(
+        records.some((r) => r.outcome === "would-modify")
+      ).toBe(true);
+    });
+
+    it("addLinksToDailyNotes for a missing daily note records would-create + would-modify, no writes", async () => {
+      (getDailyNote as jest.Mock).mockReturnValue(null);
+      (getAllDailyNotes as jest.Mock).mockReturnValue({});
+
+      const docs = [
+        {
+          doc: {
+            id: "uuid-1",
+            title: "Meeting",
+            updated_at: "2026-05-22T15:00:00Z",
+          } as GranolaDoc,
+          notePath: "Granola/Meeting.md",
+        },
+      ];
+
+      await dailyNoteBuilder.addLinksToDailyNotes(
+        docs,
+        "## Meetings",
+        false,
+        () => "uuid-1"
+      );
+
+      expect(createDailyNote).not.toHaveBeenCalled();
+      expect(updateSection).not.toHaveBeenCalled();
+      expect(mockVault.modify).not.toHaveBeenCalled();
+      const records = recorder.all() as any[];
+      const outcomes = records.map((r) => r.outcome);
+      expect(outcomes).toContain("would-create");
+      expect(outcomes).toContain("would-modify");
+    });
+  });
+
   describe("extractExistingNotes", () => {
     it("should extract Granola IDs and updated_at timestamps from a daily note section", () => {
       const fileContent = [

--- a/tests/unit/documentFetcher.test.ts
+++ b/tests/unit/documentFetcher.test.ts
@@ -1,0 +1,210 @@
+import fs from "fs";
+import path from "path";
+import { requestUrl } from "obsidian";
+import {
+  fetchDocumentsForSync,
+  computeApiFetchWindow,
+} from "../../src/services/documentFetcher";
+import { setMinRequestSpacingMs } from "../../src/services/publicGranolaApi";
+import { DEFAULT_SETTINGS, GranolaSyncSettings } from "../../src/settings";
+
+jest.mock("obsidian");
+jest.mock("../../src/utils/logger", () => ({
+  log: {
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+(global as any).PLUGIN_VERSION = "1.0.0-test";
+
+function loadFixture(name: string): unknown {
+  const p = path.join(__dirname, "..", "fixtures", "public-api", name);
+  return JSON.parse(fs.readFileSync(p, "utf-8"));
+}
+
+const mockRequestUrl = requestUrl as jest.Mock;
+
+function settings(o: Partial<GranolaSyncSettings> = {}): GranolaSyncSettings {
+  return { ...DEFAULT_SETTINGS, ...o };
+}
+
+describe("documentFetcher — computeApiFetchWindow", () => {
+  it("returns empty window for full mode", () => {
+    expect(
+      computeApiFetchWindow(settings({ syncDaysBack: 7 }), {
+        mode: "full",
+        latestSyncTime: 12345,
+      })
+    ).toEqual({});
+  });
+
+  it("uses latestSyncTime as updated_after when set", () => {
+    const t = Date.UTC(2026, 4, 20);
+    const w = computeApiFetchWindow(settings({ syncDaysBack: 7 }), {
+      mode: "standard",
+      latestSyncTime: t,
+    });
+    expect(w.updatedAfter).toBe(new Date(t).toISOString());
+    expect(w.createdAfter).toBeUndefined();
+  });
+
+  it("falls back to created_after = now - syncDaysBack when no latestSyncTime", () => {
+    const w = computeApiFetchWindow(settings({ syncDaysBack: 7 }), {
+      mode: "standard",
+      latestSyncTime: 0,
+    });
+    expect(w.createdAfter).toBeTruthy();
+    const t = new Date(w.createdAfter!).getTime();
+    // ~7 days ago, within a 10s tolerance for test execution time
+    const expected = Date.now() - 7 * 24 * 60 * 60 * 1000;
+    expect(Math.abs(t - expected)).toBeLessThan(10_000);
+  });
+
+  it("returns empty window when syncDaysBack=0 (sync all)", () => {
+    expect(
+      computeApiFetchWindow(settings({ syncDaysBack: 0 }), {
+        mode: "standard",
+      })
+    ).toEqual({});
+  });
+});
+
+describe("documentFetcher — fetchDocumentsForSync (api_key)", () => {
+  beforeAll(() => setMinRequestSpacingMs(0));
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns adapted docs with folders and transcript when includeTranscripts=true", async () => {
+    const listPage = {
+      notes: [
+        {
+          id: "not_AAAAAAAAAAAAAA",
+          title: "Subteam",
+          created_at: "2026-05-21T15:00:00.000Z",
+          updated_at: "2026-05-21T15:42:13.000Z",
+          web_url:
+            "https://notes.granola.ai/d/00000000-0000-0000-0000-000000000001",
+        },
+      ],
+      hasMore: false,
+      cursor: null,
+    };
+    mockRequestUrl
+      .mockResolvedValueOnce({ status: 200, json: listPage, headers: {} })
+      .mockResolvedValueOnce({
+        status: 200,
+        json: loadFixture("get-note-with-transcript.json"),
+        headers: {},
+      });
+
+    const out = await fetchDocumentsForSync(
+      { method: "api_key", token: "grn_test" },
+      settings({ syncTranscripts: true }),
+      { mode: "standard", includeTranscripts: true }
+    );
+
+    expect(out).toHaveLength(1);
+    expect(out[0].doc.id).toBe("00000000-0000-0000-0000-000000000001");
+    expect(out[0].publicId).toBe("not_AAAAAAAAAAAAAA");
+    expect(out[0].folders).toEqual(["Strategy"]);
+    expect(out[0].apiTranscript).toHaveLength(2);
+    // Raw folder_membership is preserved on FetchedDoc so the orchestrator
+    // can build an apiFolderSnapshot keyed by stable folder IDs.
+    expect(out[0].folderMembership).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "fol_aaaaaaaaaaaaaa",
+          name: "Strategy",
+        }),
+      ])
+    );
+  });
+
+  it("gates Get Note behind list-level updated_at (no fetch when unchanged)", async () => {
+    // List endpoint per spec: no `web_url` on summary. The gate keys by
+    // `not_*` id, which the caller is expected to have populated (e.g. from
+    // a previous sync's `_apiNoteIdBridge` entries, or by including both
+    // UUID-keyed AND not-keyed entries in the map).
+    const listPage = {
+      notes: [
+        {
+          id: "not_AAAAAAAAAAAAAA",
+          object: "note",
+          title: "Subteam",
+          owner: { name: "Tristan", email: "t@example.com" },
+          created_at: "2026-05-21T15:00:00.000Z",
+          updated_at: "2026-05-21T15:42:13.000Z",
+        },
+      ],
+      hasMore: false,
+      cursor: null,
+    };
+    mockRequestUrl.mockResolvedValueOnce({
+      status: 200,
+      json: listPage,
+      headers: {},
+    });
+
+    const known = new Map<string, string>([
+      ["not_AAAAAAAAAAAAAA", "2026-05-21T15:42:13.000Z"],
+    ]);
+
+    const out = await fetchDocumentsForSync(
+      { method: "api_key", token: "grn_test" },
+      settings({ syncTranscripts: false }),
+      {
+        mode: "standard",
+        includeTranscripts: false,
+        knownUpdatedAtByGranolaId: known,
+      }
+    );
+
+    // Only the list call was made; Get Note was skipped.
+    expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+    expect(out).toHaveLength(0);
+  });
+
+  it("treats a 404 on Get Note as a missing note (not an error)", async () => {
+    const listPage = {
+      notes: [
+        {
+          id: "not_gone",
+          title: "Gone",
+          web_url: "https://notes.granola.ai/d/00000000-0000-0000-0000-000000000000",
+          updated_at: "2026-05-01T00:00:00.000Z",
+        },
+      ],
+      hasMore: false,
+      cursor: null,
+    };
+    mockRequestUrl
+      .mockResolvedValueOnce({ status: 200, json: listPage, headers: {} })
+      .mockResolvedValueOnce({ status: 404, json: {}, headers: {} });
+
+    const out = await fetchDocumentsForSync(
+      { method: "api_key", token: "grn_test" },
+      settings({ syncTranscripts: false }),
+      { mode: "standard", includeTranscripts: false }
+    );
+
+    expect(out).toEqual([]);
+  });
+
+  it("propagates 401 so the orchestrator can surface a clear error", async () => {
+    mockRequestUrl.mockResolvedValueOnce({
+      status: 401,
+      json: { error: "unauthorized" },
+      headers: { "granola-request-id": "req_xyz" },
+    });
+
+    await expect(
+      fetchDocumentsForSync(
+        { method: "api_key", token: "grn_revoked" },
+        settings(),
+        { mode: "standard" }
+      )
+    ).rejects.toMatchObject({ status: 401 });
+  });
+});

--- a/tests/unit/dryRun.test.ts
+++ b/tests/unit/dryRun.test.ts
@@ -1,0 +1,271 @@
+import { App, TFile } from "obsidian";
+import { FileSyncService } from "../../src/services/fileSyncService";
+import { DryRunRecorder } from "../../src/services/dryRun";
+import { DEFAULT_SETTINGS, GranolaSyncSettings } from "../../src/settings";
+import type { PathResolver } from "../../src/services/pathResolver";
+
+jest.mock("../../src/utils/logger", () => ({
+  log: {
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+describe("DryRunRecorder + FileSyncService integration", () => {
+  let mockApp: jest.Mocked<App>;
+  let svc: FileSyncService;
+  let settings: GranolaSyncSettings;
+  let recorder: DryRunRecorder;
+
+  beforeEach(() => {
+    settings = { ...DEFAULT_SETTINGS, saveAsIndividualFiles: true };
+    mockApp = {
+      vault: {
+        getMarkdownFiles: jest.fn().mockReturnValue([]),
+        getAbstractFileByPath: jest.fn().mockReturnValue(null),
+        createFolder: jest.fn(),
+        create: jest.fn(),
+        read: jest.fn(),
+        modify: jest.fn(),
+        rename: jest.fn(),
+      },
+      metadataCache: { getFileCache: jest.fn() },
+      fileManager: {
+        getAvailablePathForAttachment: jest.fn(),
+        processFrontMatter: jest.fn(),
+      },
+    } as any;
+
+    const pathResolver = {} as PathResolver;
+    svc = new FileSyncService(mockApp, pathResolver, () => settings);
+    recorder = new DryRunRecorder();
+    svc.setDryRunRecorder(recorder);
+  });
+
+  it("records would-create instead of calling vault.create", async () => {
+    const saved = await svc.saveFile("Notes/a.md", "content", "uuid-1", "note");
+
+    expect(saved).toBe(true);
+    expect(mockApp.vault.create).not.toHaveBeenCalled();
+    const records = recorder.all();
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      outcome: "would-create",
+      path: "Notes/a.md",
+      granolaId: "uuid-1",
+      type: "note",
+    });
+  });
+
+  it("records would-modify (and not vault.modify) when an existing file's content differs", async () => {
+    const existing = new TFile("Notes/a.md", "md");
+    mockApp.vault.getMarkdownFiles.mockReturnValue([existing]);
+    mockApp.metadataCache.getFileCache.mockReturnValue({
+      frontmatter: { granola_id: "uuid-1" },
+    } as any);
+    mockApp.vault.read = jest.fn().mockResolvedValue("old content");
+
+    await svc.buildCache();
+    const saved = await svc.saveFile(
+      "Notes/a.md",
+      "new content",
+      "uuid-1",
+      "note"
+    );
+
+    expect(saved).toBe(true);
+    expect(mockApp.vault.modify).not.toHaveBeenCalled();
+    const outcomes = recorder.all().map((r) => r.outcome);
+    expect(outcomes).toContain("would-modify");
+  });
+
+  it("records skip-unchanged when content is identical", async () => {
+    const existing = new TFile("Notes/a.md", "md");
+    mockApp.vault.getMarkdownFiles.mockReturnValue([existing]);
+    mockApp.metadataCache.getFileCache.mockReturnValue({
+      frontmatter: { granola_id: "uuid-1" },
+    } as any);
+    mockApp.vault.read = jest.fn().mockResolvedValue("same content");
+
+    await svc.buildCache();
+    const saved = await svc.saveFile(
+      "Notes/a.md",
+      "same content",
+      "uuid-1",
+      "note"
+    );
+
+    expect(saved).toBe(false);
+    expect(mockApp.vault.modify).not.toHaveBeenCalled();
+    expect(recorder.all().map((r) => r.outcome)).toContain("skip-unchanged");
+  });
+
+  it("records would-rename when the destination path differs from the existing file", async () => {
+    const existing = new TFile("Notes/old.md", "md");
+    mockApp.vault.getMarkdownFiles.mockReturnValue([existing]);
+    mockApp.metadataCache.getFileCache.mockReturnValue({
+      frontmatter: { granola_id: "uuid-1" },
+    } as any);
+    mockApp.vault.read = jest.fn().mockResolvedValue("old content");
+
+    await svc.buildCache();
+    await svc.saveFile("Notes/new.md", "new content", "uuid-1", "note");
+
+    expect(mockApp.vault.rename).not.toHaveBeenCalled();
+    const renameRecord = recorder
+      .all()
+      .find((r) => r.outcome === "would-rename");
+    expect(renameRecord).toMatchObject({
+      outcome: "would-rename",
+      path: "Notes/old.md",
+      toPath: "Notes/new.md",
+    });
+  });
+
+  it("clearing the recorder restores live writes", async () => {
+    svc.setDryRunRecorder(null);
+    await svc.saveFile("Notes/a.md", "content", "uuid-1", "note");
+    expect(mockApp.vault.create).toHaveBeenCalled();
+  });
+});
+
+describe("DryRunRecorder + FileSyncService — ensureFolder", () => {
+  let mockApp: jest.Mocked<App>;
+  let svc: FileSyncService;
+  let settings: GranolaSyncSettings;
+  let recorder: DryRunRecorder;
+
+  beforeEach(() => {
+    settings = { ...DEFAULT_SETTINGS, saveAsIndividualFiles: true };
+    mockApp = {
+      vault: {
+        getMarkdownFiles: jest.fn().mockReturnValue([]),
+        getAbstractFileByPath: jest.fn().mockReturnValue(null),
+        createFolder: jest.fn(),
+        create: jest.fn(),
+        read: jest.fn(),
+        modify: jest.fn(),
+        rename: jest.fn(),
+        createBinary: jest.fn(),
+      },
+      metadataCache: { getFileCache: jest.fn() },
+      fileManager: {
+        getAvailablePathForAttachment: jest.fn(),
+        processFrontMatter: jest.fn(),
+      },
+    } as any;
+
+    const pathResolver = {} as any;
+    svc = new FileSyncService(mockApp, pathResolver, () => settings);
+    recorder = new DryRunRecorder();
+    svc.setDryRunRecorder(recorder);
+  });
+
+  it("does not call vault.createFolder for a missing folder in dry-run", async () => {
+    const ok = await svc.ensureFolder("Granola/2026-05");
+    expect(ok).toBe(true);
+    expect(mockApp.vault.createFolder).not.toHaveBeenCalled();
+  });
+
+  it("still passes through when the folder already exists (live or dry-run)", async () => {
+    mockApp.vault.getAbstractFileByPath = jest
+      .fn()
+      .mockReturnValue({ path: "Granola/2026-05" });
+    const ok = await svc.ensureFolder("Granola/2026-05");
+    expect(ok).toBe(true);
+    expect(mockApp.vault.createFolder).not.toHaveBeenCalled();
+  });
+
+  it("calls vault.createFolder normally when recorder is null (live mode)", async () => {
+    svc.setDryRunRecorder(null);
+    await svc.ensureFolder("Granola/2026-05");
+    expect(mockApp.vault.createFolder).toHaveBeenCalledWith("Granola/2026-05");
+  });
+});
+
+describe("DryRunRecorder + FileSyncService — appendImageEmbedsForAttachments", () => {
+  let mockApp: jest.Mocked<App>;
+  let svc: FileSyncService;
+  let settings: GranolaSyncSettings;
+  let recorder: DryRunRecorder;
+
+  beforeEach(() => {
+    settings = { ...DEFAULT_SETTINGS, saveAsIndividualFiles: true };
+    mockApp = {
+      vault: {
+        getMarkdownFiles: jest.fn().mockReturnValue([]),
+        getAbstractFileByPath: jest.fn().mockReturnValue(null),
+        createBinary: jest.fn(),
+      },
+      metadataCache: { getFileCache: jest.fn() },
+      fileManager: {
+        getAvailablePathForAttachment: jest
+          .fn()
+          .mockReturnValue("attachments/x.png"),
+      },
+    } as any;
+
+    const pathResolver = {} as any;
+    svc = new FileSyncService(mockApp, pathResolver, () => settings);
+    recorder = new DryRunRecorder();
+    svc.setDryRunRecorder(recorder);
+  });
+
+  it("does not hit the network or call createBinary in dry-run, even with image attachments", async () => {
+    const requestUrlMock = (
+      require("obsidian") as { requestUrl: jest.Mock }
+    ).requestUrl;
+    requestUrlMock.mockReset();
+
+    const doc: any = {
+      id: "uuid-1",
+      attachments: [
+        { id: "att-1", url: "https://granola.example/img.png", type: "image" },
+        { id: "att-2", url: "https://granola.example/img2.png", type: "image" },
+      ],
+    };
+    const content = "# Note\nbody";
+
+    const result = await svc.appendImageEmbedsForAttachments(
+      doc,
+      content,
+      "Notes/x.md"
+    );
+
+    expect(requestUrlMock).not.toHaveBeenCalled();
+    expect(mockApp.vault.createBinary).not.toHaveBeenCalled();
+    expect(result).toBe(content); // content unchanged in dry-run
+    const records = recorder.all();
+    expect(records).toHaveLength(2);
+    expect(records.every((r) => r.outcome === "would-create")).toBe(true);
+  });
+
+  it("returns content unchanged when there are no attachments (no record)", async () => {
+    const doc: any = { id: "uuid-1", attachments: [] };
+    const result = await svc.appendImageEmbedsForAttachments(
+      doc,
+      "body",
+      "Notes/x.md"
+    );
+    expect(result).toBe("body");
+    expect(recorder.all()).toHaveLength(0);
+  });
+});
+
+describe("DryRunRecorder.summarize", () => {
+  it("produces a counted summary of records", () => {
+    const r = new DryRunRecorder();
+    r.record({ outcome: "would-create", path: "a.md" });
+    r.record({ outcome: "would-create", path: "b.md" });
+    r.record({ outcome: "would-modify", path: "c.md" });
+    r.record({ outcome: "skip-unchanged", path: "d.md" });
+
+    const summary = r.summarize();
+    expect(summary).toContain("would-create: 2");
+    expect(summary).toContain("would-modify: 1");
+    expect(summary).toContain("skip-unchanged: 1");
+    expect(summary).toContain("a.md");
+  });
+});

--- a/tests/unit/dryRunModal.test.ts
+++ b/tests/unit/dryRunModal.test.ts
@@ -1,0 +1,197 @@
+import { DryRunRecorder } from "../../src/services/dryRun";
+import { DryRunReportModal } from "../../src/services/dryRunModal";
+
+jest.mock("../../src/utils/logger", () => ({
+  log: {
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+// The shared Obsidian mock exports `Setting` as a bare jest.fn() that
+// doesn't support chaining. The modal's footer button setup needs
+// `.addButton(...).addButton(...)`, so override the export to a real
+// chainable class.
+import * as obsidian from "obsidian";
+beforeAll(() => {
+  class FakeSetting {
+    constructor(_el: HTMLElement) {}
+    addButton(cb: (b: any) => any): this {
+      const button = {
+        setButtonText: () => button,
+        setCta: () => button,
+        onClick: () => button,
+      };
+      cb(button);
+      return this;
+    }
+  }
+  (obsidian as any).Setting = FakeSetting;
+});
+
+/**
+ * Smoke tests for the dry-run modal.
+ *
+ * The modal is mostly DOM construction (jsdom can render it but the tests
+ * stay focused on observable behavior: title text, count rows, detail rows,
+ * empty-state). We exercise it directly rather than through full Obsidian
+ * lifecycle — the real Modal base class is mocked in `tests/__mocks__/obsidian.ts`.
+ */
+
+describe("DryRunReportModal", () => {
+  let mockApp: any;
+
+  beforeEach(() => {
+    mockApp = {};
+  });
+
+  it("renders a row for every outcome including zero-buckets", () => {
+    const recorder = new DryRunRecorder();
+    recorder.record({ outcome: "would-create", path: "Notes/a.md" });
+
+    const modal = new DryRunReportModal(
+      mockApp,
+      recorder,
+      new Date("2026-05-22T20:00:00Z"),
+      new Date("2026-05-22T20:00:02Z")
+    );
+    modal.contentEl = document.createElement("div") as any;
+    // Patch createEl helpers that Obsidian adds to HTMLElement
+    patchObsidianDom(modal.contentEl);
+
+    modal.onOpen();
+
+    const items = modal.contentEl.querySelectorAll("li");
+    expect(items.length).toBe(7); // 7 outcome rows, zero-buckets included
+
+    const text = (modal.contentEl as HTMLElement).innerText ?? modal.contentEl.textContent ?? "";
+    expect(text).toContain("Would create");
+    expect(text).toContain("Would modify frontmatter");
+    expect(text).toContain("Skip (body writes disabled)");
+  });
+
+  it("shows a row in the details table for each record", () => {
+    const recorder = new DryRunRecorder();
+    recorder.record({ outcome: "would-create", path: "Notes/a.md" });
+    recorder.record({
+      outcome: "would-modify",
+      path: "Notes/b.md",
+      granolaId: "uuid-b",
+      reason: "remote newer",
+    });
+    recorder.record({
+      outcome: "would-rename",
+      path: "Notes/c.md",
+      toPath: "Notes/c-renamed.md",
+    });
+
+    const modal = new DryRunReportModal(
+      mockApp,
+      recorder,
+      new Date("2026-05-22T20:00:00Z"),
+      new Date("2026-05-22T20:00:02Z")
+    );
+    modal.contentEl = document.createElement("div") as any;
+    patchObsidianDom(modal.contentEl);
+
+    modal.onOpen();
+
+    const rows = modal.contentEl.querySelectorAll("tbody tr");
+    expect(rows.length).toBe(3);
+
+    const text = (modal.contentEl as HTMLElement).innerText ?? modal.contentEl.textContent ?? "";
+    expect(text).toContain("Notes/a.md");
+    expect(text).toContain("Notes/b.md");
+    expect(text).toContain("granolaId=uuid-b");
+    expect(text).toContain("remote newer");
+    expect(text).toContain("Notes/c.md → Notes/c-renamed.md");
+  });
+
+  it("renders an empty-state when no records were captured", () => {
+    const recorder = new DryRunRecorder();
+    const modal = new DryRunReportModal(
+      mockApp,
+      recorder,
+      new Date("2026-05-22T20:00:00Z"),
+      new Date("2026-05-22T20:00:02Z")
+    );
+    modal.contentEl = document.createElement("div") as any;
+    patchObsidianDom(modal.contentEl);
+
+    modal.onOpen();
+
+    expect(modal.contentEl.querySelector("tbody")).toBeNull();
+    const text = modal.contentEl.textContent ?? "";
+    expect(text).toContain("No changes would be made");
+  });
+
+  it("includes the elapsed-time hint with seconds rounded to one decimal", () => {
+    const recorder = new DryRunRecorder();
+    const modal = new DryRunReportModal(
+      mockApp,
+      recorder,
+      new Date("2026-05-22T20:00:00Z"),
+      new Date("2026-05-22T20:00:02.500Z")
+    );
+    modal.contentEl = document.createElement("div") as any;
+    patchObsidianDom(modal.contentEl);
+
+    modal.onOpen();
+
+    const text = modal.contentEl.textContent ?? "";
+    expect(text).toContain("took 2.5s");
+    expect(text).toContain("No files were modified");
+  });
+});
+
+/**
+ * Adds Obsidian's `createEl` / `appendText` / `setText` / `empty` /
+ * `addClass` helpers to a plain HTMLElement so tests can exercise the
+ * modal's DOM construction code without dragging in the full Obsidian
+ * runtime. Matches the surface used by the modal under test.
+ */
+function patchObsidianDom(root: HTMLElement): void {
+  const addHelpers = (el: HTMLElement) => {
+    const helpers = el as HTMLElement & {
+      createEl: (
+        tag: string,
+        opts?: { text?: string; cls?: string }
+      ) => HTMLElement;
+      appendText: (s: string) => void;
+      setText: (s: string) => void;
+      empty: () => void;
+      addClass: (s: string) => void;
+    };
+    if (typeof helpers.createEl !== "function") {
+      helpers.createEl = (tag, opts) => {
+        const child = document.createElement(tag);
+        if (opts?.text) child.textContent = opts.text;
+        if (opts?.cls) child.className = opts.cls;
+        el.appendChild(child);
+        addHelpers(child as HTMLElement);
+        return child as HTMLElement;
+      };
+    }
+    if (typeof helpers.appendText !== "function") {
+      helpers.appendText = (s) => {
+        el.appendChild(document.createTextNode(s));
+      };
+    }
+    if (typeof helpers.setText !== "function") {
+      helpers.setText = (s) => {
+        el.textContent = s;
+      };
+    }
+    if (typeof helpers.empty !== "function") {
+      helpers.empty = () => {
+        while (el.firstChild) el.removeChild(el.firstChild);
+      };
+    }
+    if (typeof helpers.addClass !== "function") {
+      helpers.addClass = (s) => el.classList.add(s);
+    }
+  };
+  addHelpers(root);
+}

--- a/tests/unit/fileSyncService.test.ts
+++ b/tests/unit/fileSyncService.test.ts
@@ -98,6 +98,41 @@ describe("FileSyncService", () => {
       expect(fileSyncService.findByGranolaId("id-2")).toBe(mockFile2);
     });
 
+    it("should bridge from granola_public_id to the legacy granola_id (API-key dedup)", async () => {
+      const mockFile = { path: "hopo.md" } as TFile;
+      mockApp.vault.getMarkdownFiles.mockReturnValue([mockFile]);
+      mockApp.metadataCache.getFileCache.mockReturnValueOnce({
+        frontmatter: {
+          granola_id: "00000000-0000-0000-0000-000000000001",
+          granola_public_id: "not_AAAAAAAAAAAAAA",
+        },
+      } as any);
+
+      await fileSyncService.buildCache();
+
+      expect(
+        fileSyncService.findByGranolaId("00000000-0000-0000-0000-000000000001")
+      ).toBe(mockFile);
+      // Lookup by the public id resolves via the bridge.
+      expect(fileSyncService.findByGranolaId("not_AAAAAAAAAAAAAA")).toBe(
+        mockFile
+      );
+    });
+
+    it("recordPublicIdBridge adds an alias without rewriting frontmatter", async () => {
+      const mockFile = { path: "hopo.md" } as TFile;
+      mockApp.vault.getMarkdownFiles.mockReturnValue([mockFile]);
+      mockApp.metadataCache.getFileCache.mockReturnValueOnce({
+        frontmatter: { granola_id: "uuid-1" },
+      } as any);
+
+      await fileSyncService.buildCache();
+      expect(fileSyncService.findByGranolaId("not_X")).toBeNull();
+
+      fileSyncService.recordPublicIdBridge("not_X", "uuid-1", "note");
+      expect(fileSyncService.findByGranolaId("not_X")).toBe(mockFile);
+    });
+
     it("should skip files without granola_id frontmatter", async () => {
       const mockFile1 = { path: "note1.md" } as TFile;
       const mockFile2 = { path: "note2.md" } as TFile;
@@ -299,6 +334,44 @@ describe("FileSyncService", () => {
       );
 
       expect(result).toBe(false);
+    });
+
+    it("treats a remote that is <60s newer as up-to-date (frontmatter parity buffer)", () => {
+      const mockFile = { path: "note.md" } as TFile;
+      fileSyncService.updateCache("test-id", mockFile, "note");
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: {
+          granola_id: "test-id",
+          updated: "2024-01-15T12:00:00.000Z",
+        },
+      } as any);
+
+      const result = fileSyncService.isRemoteNewer(
+        "test-id",
+        "2024-01-15T12:00:42.000Z", // 42s newer — inside buffer
+        "note"
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it("still reports newer when the delta is >=60s", () => {
+      const mockFile = { path: "note.md" } as TFile;
+      fileSyncService.updateCache("test-id", mockFile, "note");
+      mockApp.metadataCache.getFileCache.mockReturnValue({
+        frontmatter: {
+          granola_id: "test-id",
+          updated: "2024-01-15T12:00:00.000Z",
+        },
+      } as any);
+
+      const result = fileSyncService.isRemoteNewer(
+        "test-id",
+        "2024-01-15T12:01:30.000Z", // 90s newer
+        "note"
+      );
+
+      expect(result).toBe(true);
     });
 
     it("should return false when timestamps are equal", () => {

--- a/tests/unit/granolaDocAdapter.test.ts
+++ b/tests/unit/granolaDocAdapter.test.ts
@@ -1,0 +1,252 @@
+import fs from "fs";
+import path from "path";
+import {
+  adaptPublicNoteToGranolaDoc,
+  adaptPublicNoteSummary,
+  adaptTranscript,
+  extractFoldersFromMembership,
+  extractLegacyIdFromWebUrl,
+  membershipToFolderPaths,
+} from "../../src/services/granolaDocAdapter";
+import type {
+  PublicNote,
+  PublicNoteSummary,
+} from "../../src/services/publicApiSchemas";
+
+function loadFixture<T>(name: string): T {
+  const p = path.join(__dirname, "..", "fixtures", "public-api", name);
+  return JSON.parse(fs.readFileSync(p, "utf-8")) as T;
+}
+
+describe("granolaDocAdapter — extractLegacyIdFromWebUrl", () => {
+  it("returns the UUID from a Granola web URL", () => {
+    expect(
+      extractLegacyIdFromWebUrl(
+        "https://notes.granola.ai/d/00000000-0000-0000-0000-000000000001"
+      )
+    ).toBe("00000000-0000-0000-0000-000000000001");
+  });
+
+  it("accepts a URL with trailing path / query", () => {
+    expect(
+      extractLegacyIdFromWebUrl(
+        "https://notes.granola.ai/d/00000000-0000-0000-0000-000000000001?ref=share"
+      )
+    ).toBe("00000000-0000-0000-0000-000000000001");
+  });
+
+  it("returns null for nullish / empty input", () => {
+    expect(extractLegacyIdFromWebUrl(null)).toBeNull();
+    expect(extractLegacyIdFromWebUrl(undefined)).toBeNull();
+    expect(extractLegacyIdFromWebUrl("")).toBeNull();
+  });
+
+  it("returns null when the URL doesn't contain a UUID", () => {
+    expect(
+      extractLegacyIdFromWebUrl("https://notes.granola.ai/d/not_AAAAAAAAAAAAAA")
+    ).toBeNull();
+    expect(
+      extractLegacyIdFromWebUrl("https://example.com/some-other-path")
+    ).toBeNull();
+  });
+});
+
+describe("granolaDocAdapter — membershipToFolderPaths", () => {
+  it("returns empty array for no membership", () => {
+    expect(membershipToFolderPaths(undefined)).toEqual([]);
+    expect(membershipToFolderPaths([])).toEqual([]);
+  });
+
+  it("walks parent_folder_id to build slashed paths", () => {
+    const paths = membershipToFolderPaths([
+      { id: "a", name: "Strategy", parent_folder_id: null },
+      { id: "b", name: "Subteam", parent_folder_id: "a" },
+    ]);
+    // Sorted deterministically — Subteam is a child of Strategy
+    expect(paths).toEqual(["Strategy", "Strategy/Subteam"]);
+  });
+
+  it("dedupes identical paths", () => {
+    const paths = membershipToFolderPaths([
+      { id: "a", name: "Same", parent_folder_id: null },
+      { id: "b", name: "Same", parent_folder_id: null },
+    ]);
+    expect(paths).toEqual(["Same"]);
+  });
+
+  it("treats a node with a missing parent as a root rather than looping", () => {
+    const paths = membershipToFolderPaths([
+      {
+        id: "a",
+        name: "Orphan",
+        parent_folder_id: "missing-parent",
+      },
+    ]);
+    expect(paths).toEqual(["Orphan"]);
+  });
+
+  it("does not infinite-loop on cycles", () => {
+    const paths = membershipToFolderPaths([
+      { id: "a", name: "A", parent_folder_id: "b" },
+      { id: "b", name: "B", parent_folder_id: "a" },
+    ]);
+    // We just want this to terminate; the exact path order isn't critical.
+    expect(paths.length).toBeGreaterThan(0);
+  });
+
+  it("produces deterministic (sorted) output for byte-stable frontmatter", () => {
+    const a = membershipToFolderPaths([
+      { id: "1", name: "Zeta", parent_folder_id: null },
+      { id: "2", name: "Alpha", parent_folder_id: null },
+    ]);
+    const b = membershipToFolderPaths([
+      { id: "2", name: "Alpha", parent_folder_id: null },
+      { id: "1", name: "Zeta", parent_folder_id: null },
+    ]);
+    expect(a).toEqual(b);
+  });
+});
+
+describe("granolaDocAdapter — adaptPublicNoteToGranolaDoc", () => {
+  it("maps the get-note fixture into a GranolaDoc keyed by the legacy UUID", () => {
+    const fixture = loadFixture<PublicNote>("get-note.json");
+    const doc = adaptPublicNoteToGranolaDoc(fixture);
+
+    expect(doc.id).toBe("00000000-0000-0000-0000-000000000001");
+    expect(doc._publicId).toBe("not_AAAAAAAAAAAAAA");
+    expect(doc._webUrl).toBe(fixture.web_url);
+    expect(doc.title).toBe("Quarterly Strategy Sync");
+    expect(doc.created_at).toBe("2026-05-21T15:00:00.000Z");
+    expect(doc.updated_at).toBe("2026-05-21T15:42:13.000Z");
+    expect(doc.last_viewed_panel?.content).toBe(fixture.summary_markdown);
+    expect(doc.last_viewed_panel?.updated_at).toBe(fixture.updated_at);
+  });
+
+  it("flattens folder_membership into slashed paths", () => {
+    const fixture = loadFixture<PublicNote>("get-note.json");
+    expect(extractFoldersFromMembership(fixture)).toEqual([
+      "Strategy",
+      "Strategy/Subteam",
+    ]);
+  });
+
+  it("ignores unknown extra fields on membership entries (e.g. object discriminator)", () => {
+    expect(
+      membershipToFolderPaths([
+        { id: "a", name: "Labs", parent_folder_id: null, object: "folder" } as any,
+      ])
+    ).toEqual(["Labs"]);
+  });
+
+  it("falls back to the not_ id when web_url is missing", () => {
+    const fixture = loadFixture<PublicNote>("get-note.json");
+    const without = { ...fixture, web_url: null };
+    const doc = adaptPublicNoteToGranolaDoc(without);
+    expect(doc.id).toBe(fixture.id);
+  });
+
+  it("uses summary_text when summary_markdown is missing", () => {
+    const fixture = loadFixture<PublicNote>("get-note.json");
+    const note = {
+      ...fixture,
+      summary_markdown: null,
+      summary_text: "Plain text fallback",
+    };
+    const doc = adaptPublicNoteToGranolaDoc(note);
+    expect(doc.last_viewed_panel?.content).toBe("Plain text fallback");
+  });
+
+  it("returns last_viewed_panel: null when no summary is available", () => {
+    const fixture = loadFixture<PublicNote>("get-note.json");
+    const note = { ...fixture, summary_markdown: null, summary_text: null };
+    const doc = adaptPublicNoteToGranolaDoc(note);
+    expect(doc.last_viewed_panel).toBeNull();
+  });
+
+  it("maps attendees into people.attendees", () => {
+    const fixture = loadFixture<PublicNote>("get-note.json");
+    const doc = adaptPublicNoteToGranolaDoc(fixture);
+    expect(doc.people?.attendees).toEqual([
+      { name: "Alice Example", email: "alice@example.com" },
+      { name: "Bob Example", email: "bob@example.com" },
+    ]);
+  });
+});
+
+describe("granolaDocAdapter — adaptPublicNoteSummary", () => {
+  /**
+   * The spec's NoteSummary does NOT include `web_url`, so the list endpoint
+   * can't drive the legacy-UUID bridge on its own — only Get Note can. This
+   * test locks that: summary adaptation always uses `not_*` as the id.
+   */
+  it("uses the not_ id as the canonical id (list endpoint has no web_url)", () => {
+    const summary: PublicNoteSummary = {
+      id: "not_AAAAAAAAAAAAAA",
+      title: "Subteam",
+      created_at: "2026-05-21T15:00:00.000Z",
+      updated_at: "2026-05-21T15:42:13.000Z",
+      owner: null,
+    };
+    const doc = adaptPublicNoteSummary(summary);
+    expect(doc.id).toBe("not_AAAAAAAAAAAAAA");
+    expect(doc._publicId).toBe(summary.id);
+    expect(doc._webUrl).toBeNull();
+  });
+});
+
+describe("granolaDocAdapter — adaptTranscript", () => {
+  it("maps the get-note-with-transcript fixture into internal TranscriptEntry[]", () => {
+    const fixture = loadFixture<PublicNote>("get-note-with-transcript.json");
+    const doc = adaptPublicNoteToGranolaDoc(fixture);
+    const transcript = adaptTranscript(doc.id, fixture.transcript);
+
+    expect(transcript).toHaveLength(2);
+    expect(transcript[0]).toEqual({
+      id: "trn_1",
+      document_id: doc.id,
+      // Real API uses `start_time` / `end_time`; the adapter copies them into
+      // the internal `start_timestamp` / `end_timestamp` field names the
+      // transcript formatter consumes.
+      start_timestamp: "2026-05-21T15:00:05.000Z",
+      end_timestamp: "2026-05-21T15:00:09.000Z",
+      text: "Hello, welcome to the example meeting.",
+      // public "speaker" (other party via device speakers) → passes through;
+      // the formatter renders anything other than "microphone" as "Guest".
+      source: "speaker",
+      is_final: true,
+    });
+    expect(transcript[1].source).toBe("microphone");
+  });
+
+  it("returns [] when no transcript provided", () => {
+    expect(adaptTranscript("doc", undefined)).toEqual([]);
+    expect(adaptTranscript("doc", [])).toEqual([]);
+  });
+
+  it("drops empty-text entries", () => {
+    const result = adaptTranscript("doc", [
+      { text: "" },
+      { text: "   " },
+      { text: "real", speaker: { source: "microphone" } },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("real");
+  });
+
+  it("synthesizes an id when public transcript entry lacks one", () => {
+    const result = adaptTranscript("doc-abc", [
+      { text: "hi", speaker: { source: "microphone" } },
+    ]);
+    expect(result[0].id).toBe("doc-abc-0");
+  });
+
+  it("preserves the documented `me` source as `microphone` for forward-compat", () => {
+    // Granola's docs imply `me`/`them`, but the live API actually emits
+    // `microphone`/`speaker`. We accept both to avoid breaking on future
+    // server-side changes that revert to the documented values.
+    const result = adaptTranscript("doc", [
+      { text: "hi", speaker: { source: "me" } },
+    ]);
+    expect(result[0].source).toBe("microphone");
+  });
+});

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -90,6 +90,8 @@ describe("GranolaSync", () => {
       saveNoteToDisk: jest.fn().mockResolvedValue({ saved: true, path: "Notes/test-note.md" }),
       saveTranscriptToDisk: jest.fn().mockResolvedValue({ saved: true, path: "Transcripts/test-transcript.md" }),
       saveCombinedNoteToDisk: jest.fn().mockResolvedValue({ saved: true, path: "Notes/test-note.md" }),
+      setDryRunRecorder: jest.fn(),
+      recordPublicIdBridge: jest.fn(),
     } as any;
 
     mockDocumentProcessor = {
@@ -105,6 +107,7 @@ describe("GranolaSync", () => {
       buildDailyNoteSectionContent: jest.fn(),
       updateDailyNoteSection: jest.fn(),
       addLinksToDailyNotes: jest.fn(),
+      setDryRunRecorder: jest.fn(),
     } as any;
 
     mockPathResolver = {
@@ -479,14 +482,16 @@ describe("GranolaSync", () => {
 
       expect((plugin as any).syncTranscripts).toHaveBeenCalledWith(
         [mockDoc],
-        mockAccessToken,
-        false
+        { method: "desktop", token: mockAccessToken },
+        false,
+        new Map()
       );
       expect((plugin as any).syncNotes).toHaveBeenCalledWith(
         [mockDoc],
         false,
         mockTranscriptMap,
-        {}
+        {},
+        { skipExistingBodies: false }
       );
       expect((plugin as any).updateCrossLinks).toHaveBeenCalledWith([mockDoc]);
     });
@@ -508,14 +513,16 @@ describe("GranolaSync", () => {
 
       expect((plugin as any).syncTranscripts).toHaveBeenCalledWith(
         [mockDoc],
-        mockAccessToken,
-        true
+        { method: "desktop", token: mockAccessToken },
+        true,
+        new Map()
       );
       expect((plugin as any).syncNotes).toHaveBeenCalledWith(
         [mockDoc],
         true,
         mockTranscriptMap,
-        {}
+        {},
+        { skipExistingBodies: false }
       );
     });
 

--- a/tests/unit/publicGranolaApi.test.ts
+++ b/tests/unit/publicGranolaApi.test.ts
@@ -1,0 +1,290 @@
+import fs from "fs";
+import path from "path";
+import { requestUrl } from "obsidian";
+import {
+  listNotes,
+  listAllNotes,
+  getNote,
+  listFolders,
+  listAllFolders,
+  setMinRequestSpacingMs,
+  PublicApiError,
+} from "../../src/services/publicGranolaApi";
+
+jest.mock("obsidian");
+jest.mock("../../src/utils/logger", () => ({
+  log: {
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+(global as any).PLUGIN_VERSION = "1.0.0-test";
+
+function loadFixture(name: string): unknown {
+  const p = path.join(__dirname, "..", "fixtures", "public-api", name);
+  return JSON.parse(fs.readFileSync(p, "utf-8"));
+}
+
+const mockRequestUrl = requestUrl as jest.Mock;
+
+describe("publicGranolaApi", () => {
+  beforeAll(() => {
+    setMinRequestSpacingMs(0);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("listNotes", () => {
+    it("returns the parsed page using the real API field names (cursor / hasMore)", async () => {
+      // Spec uses camelCase `hasMore` and bare `cursor`, not snake_case.
+      // Locking the contract so a future schema typo doesn't silently break
+      // pagination.
+      mockRequestUrl.mockResolvedValueOnce({
+        status: 200,
+        json: {
+          notes: [
+            {
+              id: "not_AAAAAAAAAAAAAA",
+              object: "note",
+              title: "Subteam",
+              owner: { name: "Tristan", email: "t@example.com" },
+              created_at: "2026-05-21T15:00:00.000Z",
+              updated_at: "2026-05-21T15:42:13.000Z",
+            },
+          ],
+          cursor: "eyJjcmVkZW50aWFsfQ==",
+          hasMore: true,
+        },
+        headers: {},
+      });
+
+      const result = await listNotes("grn_test", { pageSize: 30 });
+
+      expect(result.notes).toHaveLength(1);
+      expect(result.hasMore).toBe(true);
+      expect(result.cursor).toBe("eyJjcmVkZW50aWFsfQ==");
+    });
+
+    it("sends the API key as a Bearer token and the expected query params", async () => {
+      mockRequestUrl.mockResolvedValueOnce({
+        status: 200,
+        json: { notes: [], has_more: false },
+        headers: {},
+      });
+
+      await listNotes("grn_test", {
+        updatedAfter: "2026-05-01T00:00:00.000Z",
+        cursor: "abc",
+        pageSize: 25,
+      });
+
+      const call = mockRequestUrl.mock.calls[0][0];
+      expect(call.headers.Authorization).toBe("Bearer grn_test");
+      expect(call.method).toBe("GET");
+      const url = new URL(call.url);
+      expect(url.origin + url.pathname).toBe(
+        "https://public-api.granola.ai/v1/notes"
+      );
+      expect(url.searchParams.get("updated_after")).toBe(
+        "2026-05-01T00:00:00.000Z"
+      );
+      expect(url.searchParams.get("cursor")).toBe("abc");
+      expect(url.searchParams.get("page_size")).toBe("25");
+    });
+  });
+
+  describe("listAllNotes", () => {
+    it("follows the cursor across pages", async () => {
+      const first = loadFixture("list-notes-page.json");
+      const last = loadFixture("list-notes-last-page.json");
+
+      mockRequestUrl
+        .mockResolvedValueOnce({ status: 200, json: first, headers: {} })
+        .mockResolvedValueOnce({ status: 200, json: last, headers: {} });
+
+      const notes = await listAllNotes("grn_test");
+
+      expect(notes).toHaveLength(4);
+      expect(mockRequestUrl).toHaveBeenCalledTimes(2);
+
+      const secondCall = mockRequestUrl.mock.calls[1][0];
+      const url = new URL(secondCall.url);
+      expect(url.searchParams.get("cursor")).toBeTruthy();
+    });
+
+    it("stops paginating once hasMore is false", async () => {
+      const last = loadFixture("list-notes-last-page.json");
+      mockRequestUrl.mockResolvedValueOnce({
+        status: 200,
+        json: last,
+        headers: {},
+      });
+
+      await listAllNotes("grn_test");
+      expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("getNote", () => {
+    it("requests transcript when includeTranscript=true", async () => {
+      const fixture = loadFixture("get-note-with-transcript.json");
+      mockRequestUrl.mockResolvedValueOnce({
+        status: 200,
+        json: fixture,
+        headers: {},
+      });
+
+      const note = await getNote("grn_test", "not_AAAAAAAAAAAAAA", {
+        includeTranscript: true,
+      });
+
+      const call = mockRequestUrl.mock.calls[0][0];
+      const url = new URL(call.url);
+      expect(url.pathname).toBe("/v1/notes/not_AAAAAAAAAAAAAA");
+      expect(url.searchParams.get("include")).toBe("transcript");
+      expect(note.transcript).toHaveLength(2);
+    });
+
+    it("does not set include=transcript by default", async () => {
+      const fixture = loadFixture("get-note.json");
+      mockRequestUrl.mockResolvedValueOnce({
+        status: 200,
+        json: fixture,
+        headers: {},
+      });
+
+      await getNote("grn_test", "not_AAAAAAAAAAAAAA");
+
+      const call = mockRequestUrl.mock.calls[0][0];
+      const url = new URL(call.url);
+      expect(url.searchParams.has("include")).toBe(false);
+    });
+  });
+
+  describe("listFolders", () => {
+    it("parses a folders response using the real `parent_folder_id` field name", async () => {
+      mockRequestUrl.mockResolvedValueOnce({
+        status: 200,
+        json: {
+          folders: [
+            { id: "fol_a", object: "folder", name: "Strategy", parent_folder_id: null },
+            { id: "fol_b", object: "folder", name: "Subteam", parent_folder_id: "fol_a" },
+          ],
+          cursor: null,
+          hasMore: false,
+        },
+        headers: {},
+      });
+
+      const result = await listFolders("grn_test");
+      expect(result.folders).toHaveLength(2);
+      expect(result.folders[1].parent_folder_id).toBe("fol_a");
+      expect(result.hasMore).toBe(false);
+    });
+  });
+
+  describe("listAllFolders", () => {
+    it("follows the cursor across pages and returns the flattened list", async () => {
+      mockRequestUrl
+        .mockResolvedValueOnce({
+          status: 200,
+          json: {
+            folders: [
+              { id: "fol_a", object: "folder", name: "A", parent_folder_id: null },
+              { id: "fol_b", object: "folder", name: "B", parent_folder_id: null },
+            ],
+            cursor: "cur1",
+            hasMore: true,
+          },
+          headers: {},
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          json: {
+            folders: [
+              { id: "fol_c", object: "folder", name: "C", parent_folder_id: "fol_a" },
+            ],
+            cursor: null,
+            hasMore: false,
+          },
+          headers: {},
+        });
+
+      const folders = await listAllFolders("grn_test");
+
+      expect(folders.map((f) => f.id)).toEqual(["fol_a", "fol_b", "fol_c"]);
+      expect(mockRequestUrl).toHaveBeenCalledTimes(2);
+
+      const secondCallUrl = new URL(mockRequestUrl.mock.calls[1][0].url);
+      expect(secondCallUrl.searchParams.get("cursor")).toBe("cur1");
+    });
+
+    it("stops at one page when hasMore is false on the first response", async () => {
+      mockRequestUrl.mockResolvedValueOnce({
+        status: 200,
+        json: {
+          folders: [
+            { id: "fol_a", object: "folder", name: "A", parent_folder_id: null },
+          ],
+          cursor: null,
+          hasMore: false,
+        },
+        headers: {},
+      });
+
+      const folders = await listAllFolders("grn_test");
+      expect(folders).toHaveLength(1);
+      expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("error handling", () => {
+    it("throws PublicApiError on 401 with the granola-request-id header", async () => {
+      mockRequestUrl.mockResolvedValueOnce({
+        status: 401,
+        json: { error: "unauthorized" },
+        headers: { "granola-request-id": "req_abc" },
+      });
+
+      await expect(listNotes("grn_revoked")).rejects.toMatchObject({
+        name: "PublicApiError",
+        status: 401,
+        requestId: "req_abc",
+      });
+    });
+
+    it("throws PublicApiError on 429", async () => {
+      mockRequestUrl.mockResolvedValueOnce({
+        status: 429,
+        json: {},
+        headers: {},
+      });
+
+      let caught: unknown;
+      try {
+        await getNote("grn_test", "not_x");
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(PublicApiError);
+      expect((caught as PublicApiError).status).toBe(429);
+    });
+
+    it("throws on schema validation failure", async () => {
+      mockRequestUrl.mockResolvedValueOnce({
+        status: 200,
+        json: { unexpected: "shape" },
+        headers: {},
+      });
+
+      await expect(listNotes("grn_test")).rejects.toThrow(
+        "Invalid response from Granola public API"
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add opt-in API key authentication against Granola's official [Public API](https://docs.granola.ai/introduction) (`public-api.granola.ai`). Desktop credentials remain the default and unchanged for existing users.
- Targets Granola **Business / Enterprise** users who have a `grn_*` key, as a durable alternative to reading the desktop credentials file.
- Includes a `Granola: Dry-run sync` command + Advanced settings button + report modal as the safety net for users adopting API auth on an existing vault.

## Architecture

- `resolveAuth()` facade — rest of sync pipeline is auth-agnostic
- `publicGranolaApi.ts` — paginated client (`cursor` / `hasMore`), ~4.5 req/s throttle, `PublicApiError` carries HTTP status + `granola-request-id` header
- `granolaDocAdapter.ts` — maps `PublicNote` → internal `GranolaDoc`; `web_url` UUID dedupes against existing desktop-synced files (no frontmatter rewrites)
- `documentFetcher.ts` — facade routing desktop vs API; incremental `updated_after` window + per-list `updated_at` gating Get Note calls
- `apiFolderSnapshot.ts` — stable folder IDs + parent-walk diff; 24h periodic `listAllFolders` refresh catches renames in folders whose notes didn't appear in the incremental window

## Sync behaviour in API mode

- **Default `apiSyncBodyMode: refresh-transcripts-only`** preserves note bodies on EXISTING files (don't clobber desktop ProseMirror) but creates missing notes. Resolves "race orphans" where desktop sync caught the transcript before Granola finished the AI summary.
- `force-refresh-all` one-shot body refresh; auto-reverts to `refresh-transcripts-only` after a successful sync.
- Daily-notes mode in `refresh-transcripts-only` keeps existing all-or-nothing skip with a `log.warn`; per-section orphan-fix is a deliberate follow-up.

## Dry-run

- `DryRunRecorder` intercepts every vault/network/saveData side-channel: `vault.create/modify/rename/createFolder/createBinary`, `processFrontMatter`, `createDailyNote`, `updateSection`, `saveData(settings)`. Image attachments skip the network call too.
- In-memory settings snapshot/restore so back-to-back dry-runs are idempotent within an Obsidian session.
- Inline `DryRunReportModal` shows counts + per-record details + copy-to-clipboard.

## Test plan

- [x] `npm test` — 594 passed (478 existing + 116 new)
- [x] `npm run lint` — clean
- [x] `npm run build` — production succeeds
- [x] Schema validation against real Public API responses (caught + fixed `next_cursor`→`cursor`, `parent_id`→`parent_folder_id`, transcript field name mismatches)
- [x] Manual: side-by-side dev install on a real vault. Multiple dry-runs produced idempotent counts. Live sync created the expected 9 notes + 9 transcripts; daily-note sections rendered correctly. `data.json` and vault file mtimes confirmed unchanged across dry-runs.

## Notes for review

- Independent of the desktop band-aid in #N (different files; either PR can merge first).
- Open to splitting the dry-run feature into a follow-up PR if you'd prefer this PR be only about API key auth — it's bundled because it's the safety mechanism that made API mode comfortable to ship.
- See [`README.md`](README.md) and [`docs/sync-process.md`](docs/sync-process.md) for user-facing documentation.

Related to #126