### PR TITLE
fix: resolve transcript filename collisions on create (#61)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -808,7 +808,6 @@ export default class GranolaSync extends Plugin {
             doc,
             this.documentProcessor,
             forceOverwrite,
-            undefined,
             folders
           );
           if (result.saved) {
@@ -823,7 +822,6 @@ export default class GranolaSync extends Plugin {
           doc,
           this.documentProcessor,
           forceOverwrite,
-          undefined,
           folders
         );
         if (result.saved) {

--- a/src/services/documentProcessor.ts
+++ b/src/services/documentProcessor.ts
@@ -141,15 +141,17 @@ export class DocumentProcessor {
   }
 
   /**
-   * Prepares a note document for saving, including frontmatter and optional transcript links.
+   * Prepares a note document for saving, including frontmatter.
+   *
+   * The transcript link is not set here: for separate-file transcripts it is
+   * written post-hoc by updateCrossLinks() using the actual on-disk path (which
+   * may differ from the computed path after collision resolution).
    *
    * @param doc - The Granola document to process
-   * @param transcriptPath - Optional resolved transcript path (with collision detection) to include in frontmatter
    * @returns Object containing the filename and full markdown content
    */
   prepareNote(
     doc: GranolaDoc,
-    transcriptPath?: string,
     folders?: string[]
   ): { filename: string; content: string } | null {
     // Build body first — if there's no parseable content, bail out early
@@ -161,7 +163,6 @@ export class DocumentProcessor {
     // Build metadata using shared builder
     const metadata = this.buildNoteMetadata(doc, {
       type: "note",
-      transcriptPath,
       folders,
     });
 

--- a/src/services/fileSyncService.ts
+++ b/src/services/fileSyncService.ts
@@ -189,6 +189,7 @@ export class FileSyncService {
    * @param granolaId - Granola ID for caching and deduplication
    * @param type - Optional type ('note', 'transcript', or 'combined'). Defaults to 'note' for backward compatibility
    * @param forceOverwrite - If true, always writes the file even if content is unchanged
+   * @param noteDate - Used to build a collision-resolved filename if the target path is already taken
    * @returns True if the file was created or modified, false if no change or error
    */
   async saveFile(
@@ -196,7 +197,8 @@ export class FileSyncService {
     content: string,
     granolaId: string,
     type: "note" | "transcript" | "combined" = "note",
-    forceOverwrite: boolean = false
+    forceOverwrite: boolean = false,
+    noteDate: Date = new Date()
   ): Promise<boolean> {
     const normalizedPath = normalizePath(filePath);
     const existingFile = this.findByGranolaId(granolaId, type);
@@ -207,7 +209,8 @@ export class FileSyncService {
           normalizedPath,
           content,
           granolaId,
-          type
+          type,
+          noteDate
         );
       }
 
@@ -238,18 +241,74 @@ export class FileSyncService {
   }
 
   /**
-   * Creates a new file at the specified path.
+   * Creates a new file, recovering from path collisions.
+   *
+   * The filesystem is the source of truth: we attempt `vault.create` and, if it
+   * reports the path is already taken, retry under a collision-resolved name
+   * (date suffix, then a numeric counter). This is robust on case-insensitive
+   * filesystems where a path pre-check via getAbstractFileByPath can miss a
+   * case/normalization variant that `create` then collides with.
    */
   private async createNewFile(
     normalizedPath: string,
     content: string,
     granolaId: string,
-    type: "note" | "transcript" | "combined"
+    type: "note" | "transcript" | "combined",
+    noteDate: Date
   ): Promise<boolean> {
-    const newFile = await this.app.vault.create(normalizedPath, content);
-    this.updateCache(granolaId, newFile, type);
-    log.debug(`Created ${type} file: ${normalizedPath} (granolaId=${granolaId})`);
-    return true;
+    const maxAttempts = 20;
+    let candidate = normalizedPath;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        const newFile = await this.app.vault.create(candidate, content);
+        this.updateCache(granolaId, newFile, type);
+        if (candidate === normalizedPath) {
+          log.debug(`Created ${type} file: ${candidate} (granolaId=${granolaId})`);
+        } else {
+          log.debug(`Created ${type} file under collision-resolved name: ${candidate} (granolaId=${granolaId})`);
+        }
+        return true;
+      } catch (e) {
+        if (!this.isFileAlreadyExistsError(e)) {
+          throw e;
+        }
+        candidate = this.buildCollisionCandidate(
+          normalizedPath,
+          noteDate,
+          attempt + 1
+        );
+        log.debug(`Filename collision at ${normalizedPath} — retrying as ${candidate} (granolaId=${granolaId})`);
+      }
+    }
+
+    throw new Error(
+      `Could not find an available filename for ${normalizedPath} after ${maxAttempts} attempts`
+    );
+  }
+
+  /**
+   * Returns true if an error from `vault.create`/`vault.rename` indicates the
+   * target path is already occupied (as opposed to a real I/O failure).
+   */
+  private isFileAlreadyExistsError(e: unknown): boolean {
+    const message = e instanceof Error ? e.message : String(e);
+    return /already exists/i.test(message);
+  }
+
+  /**
+   * Builds a collision-resolved candidate path by appending a date suffix and,
+   * for repeated collisions, a numeric counter to the base filename.
+   */
+  private buildCollisionCandidate(
+    basePath: string,
+    noteDate: Date,
+    n: number
+  ): string {
+    const stem = basePath.replace(/\.md$/, "");
+    const dateSuffix = formatDateForFilename(noteDate).replace(/\s+/g, "_");
+    const suffix = n <= 1 ? `-${dateSuffix}` : `-${dateSuffix}-${n}`;
+    return normalizePath(`${stem}${suffix}.md`);
   }
 
   /**
@@ -307,20 +366,21 @@ export class FileSyncService {
   }
 
   /**
-   * Resolves the final file path for a note or transcript, accounting for filename collisions.
-   * If there is a filename collision (different Granola ID but same filename),
-   * the file is renamed to include a date/timestamp suffix.
+   * Resolves the ideal (collision-free) file path for a note or transcript.
+   *
+   * Collision handling is no longer done here: `createNewFile` treats the
+   * filesystem as the source of truth and resolves collisions on `create`,
+   * which is correct on case-insensitive filesystems where a path pre-check
+   * can miss a case/normalization variant.
    *
    * @param filename - The base filename (e.g., "Note.md")
-   * @param noteDate - The date of the note
-   * @param granolaId - The Granola document ID
+   * @param noteDate - The date of the note (determines the target folder)
    * @param isTranscript - Whether this is a transcript file
    * @returns The resolved file path, or null if folder path cannot be resolved
    */
   resolveFilePath(
     filename: string,
     noteDate: Date,
-    granolaId: string,
     isTranscript: boolean = false
   ): string | null {
     const folderPath = this.resolveFolderPath(noteDate, isTranscript);
@@ -328,22 +388,7 @@ export class FileSyncService {
       return null;
     }
 
-    const type = isTranscript ? "transcript" : "note";
-    let resolvedFilename = filename;
-    let filePath = normalizePath(`${folderPath}/${resolvedFilename}`);
-
-    if (!this.findByGranolaId(granolaId, type)) {
-      const existingFile = this.app.vault.getAbstractFileByPath(filePath);
-      if (existingFile instanceof TFile) {
-        const filenameWithoutExtension = resolvedFilename.replace(/\.md$/, "");
-        const dateSuffix = formatDateForFilename(noteDate).replace(/\s+/g, "_");
-        resolvedFilename = `${filenameWithoutExtension}-${dateSuffix}.md`;
-        log.debug(`Filename collision for granolaId=${granolaId} at ${filePath} — using suffix: ${resolvedFilename}`);
-        filePath = normalizePath(`${folderPath}/${resolvedFilename}`);
-      }
-    }
-
-    return filePath;
+    return normalizePath(`${folderPath}/${filename}`);
   }
 
   /**
@@ -374,19 +419,21 @@ export class FileSyncService {
       return false;
     }
 
-    const filePath = this.resolveFilePath(
-      filename,
-      noteDate,
-      granolaId,
-      isTranscript
-    );
+    const filePath = this.resolveFilePath(filename, noteDate, isTranscript);
     if (!filePath) {
       log.debug(`Cannot resolve file path for ${filename} (granolaId=${granolaId})`);
       return false;
     }
 
     const type = isTranscript ? "transcript" : "note";
-    return this.saveFile(filePath, content, granolaId, type, forceOverwrite);
+    return this.saveFile(
+      filePath,
+      content,
+      granolaId,
+      type,
+      forceOverwrite,
+      noteDate
+    );
   }
 
   /**
@@ -452,7 +499,7 @@ export class FileSyncService {
       return { saved: false, path: null };
     }
 
-    const filePath = this.resolveFilePath(filename, noteDate, doc.id, false);
+    const filePath = this.resolveFilePath(filename, noteDate, false);
     if (!filePath) {
       return { saved: false, path: null };
     }
@@ -469,7 +516,8 @@ export class FileSyncService {
       contentWithAttachments,
       doc.id,
       "combined",
-      forceOverwrite
+      forceOverwrite,
+      noteDate
     );
 
     // Return the actual on-disk path. When we try to rename to the "ideal"
@@ -489,18 +537,13 @@ export class FileSyncService {
     doc: GranolaDoc,
     documentProcessor: DocumentProcessor,
     forceOverwrite: boolean = false,
-    transcriptPath?: string,
     folders?: string[]
   ): Promise<{ saved: boolean; path: string | null }> {
     if (!doc.id) {
       log.error("Document missing required id field:", doc);
       return { saved: false, path: null };
     }
-    const prepared = documentProcessor.prepareNote(
-      doc,
-      transcriptPath,
-      folders
-    );
+    const prepared = documentProcessor.prepareNote(doc, folders);
     if (!prepared) {
       log.debug(`Skipping doc ${doc.id} — no parseable content`);
       return { saved: false, path: null };
@@ -521,7 +564,7 @@ export class FileSyncService {
       return { saved: false, path: null };
     }
 
-    const filePath = this.resolveFilePath(filename, noteDate, doc.id, false);
+    const filePath = this.resolveFilePath(filename, noteDate, false);
     if (!filePath) {
       return { saved: false, path: null };
     }
@@ -537,7 +580,8 @@ export class FileSyncService {
       contentWithAttachments,
       doc.id,
       "note",
-      forceOverwrite
+      forceOverwrite,
+      noteDate
     );
 
     // Return the actual on-disk path. When we try to rename to the "ideal"
@@ -584,7 +628,7 @@ export class FileSyncService {
       return { saved: false, path: null };
     }
 
-    const filePath = this.resolveFilePath(filename, noteDate, doc.id, true);
+    const filePath = this.resolveFilePath(filename, noteDate, true);
     if (!filePath) {
       log.debug(`Cannot resolve file path for ${filename} (granolaId=${doc.id})`);
       return { saved: false, path: null };
@@ -595,7 +639,8 @@ export class FileSyncService {
       content,
       doc.id,
       "transcript",
-      forceOverwrite
+      forceOverwrite,
+      noteDate
     );
 
     // Return the actual on-disk path. When we try to rename to the "ideal"

--- a/tests/unit/documentProcessor.test.ts
+++ b/tests/unit/documentProcessor.test.ts
@@ -155,37 +155,6 @@ describe("DocumentProcessor", () => {
       expect(titleLine).not.toMatch(/title:.*\n.*\n/);
     });
 
-    it("should add transcript field to frontmatter when transcripts enabled and path provided", () => {
-      documentProcessor = new DocumentProcessor(
-        {
-          syncTranscripts: true,
-        },
-        mockPathResolver
-      );
-
-      const doc: GranolaDoc = {
-        id: "doc-123",
-        title: "Test Note",
-        created_at: "2024-01-15T10:00:00Z",
-        last_viewed_panel: {
-          content: {
-            type: "doc",
-            content: [],
-          },
-        },
-      };
-
-      const result = documentProcessor.prepareNote(
-        doc,
-        "Transcripts/Test Note-transcript.md"
-      );
-
-      expect(result.content).toContain(
-        'transcript: "[[Transcripts/Test Note-transcript.md]]"'
-      );
-      expect(result.content).not.toContain("[Transcript]");
-    });
-
     it("should not add transcript field when path not provided", () => {
       documentProcessor = new DocumentProcessor(
         {
@@ -229,66 +198,6 @@ describe("DocumentProcessor", () => {
 
       expect(result.content).not.toContain("[Transcript]");
       expect(result.content).not.toContain("[[");
-    });
-
-    it("should use wiki-style links for transcript paths in frontmatter", () => {
-      documentProcessor = new DocumentProcessor(
-        {
-          syncTranscripts: true,
-        },
-        mockPathResolver
-      );
-
-      const doc: GranolaDoc = {
-        id: "doc-123",
-        title: "Test Note",
-        created_at: "2024-01-15T10:00:00Z",
-        last_viewed_panel: {
-          content: {
-            type: "doc",
-            content: [],
-          },
-        },
-      };
-
-      const result = documentProcessor.prepareNote(
-        doc,
-        "Transcripts/My Meeting Transcript.md"
-      );
-
-      expect(result.content).toContain(
-        'transcript: "[[Transcripts/My Meeting Transcript.md]]"'
-      );
-    });
-
-    it("should use wiki-style links for transcript paths without spaces in frontmatter", () => {
-      documentProcessor = new DocumentProcessor(
-        {
-          syncTranscripts: true,
-        },
-        mockPathResolver
-      );
-
-      const doc: GranolaDoc = {
-        id: "doc-123",
-        title: "Test Note",
-        created_at: "2024-01-15T10:00:00Z",
-        last_viewed_panel: {
-          content: {
-            type: "doc",
-            content: [],
-          },
-        },
-      };
-
-      const result = documentProcessor.prepareNote(
-        doc,
-        "Transcripts/TestNote-transcript.md"
-      );
-
-      expect(result.content).toContain(
-        'transcript: "[[Transcripts/TestNote-transcript.md]]"'
-      );
     });
 
     it("should use default title when title is missing", () => {

--- a/tests/unit/fileSyncService.test.ts
+++ b/tests/unit/fileSyncService.test.ts
@@ -473,55 +473,16 @@ describe("FileSyncService", () => {
       const result = fileSyncService.resolveFilePath(
         "note.md",
         new Date(),
-        "doc-1",
         false
       );
 
       expect(result).toBeNull();
     });
 
-    it("should return resolved path when no conflicts", () => {
-      mockApp.vault.getAbstractFileByPath.mockReturnValue(null);
-
+    it("should return the resolved path", () => {
       const result = fileSyncService.resolveFilePath(
         "note.md",
         new Date(),
-        "doc-1",
-        false
-      );
-
-      expect(result).toBe("granola-folder/note.md");
-    });
-
-    it("should append date suffix when filename collision exists", () => {
-      const existingFile = new TFile("granola-folder/note.md");
-      mockApp.vault.getAbstractFileByPath.mockReturnValue(existingFile);
-      jest
-        .spyOn(dateUtils, "formatDateForFilename")
-        .mockReturnValue("2024-01-01 10-30-00");
-
-      const noteDate = new Date("2024-01-01T10:30:00Z");
-      const result = fileSyncService.resolveFilePath(
-        "note.md",
-        noteDate,
-        "doc-1",
-        false
-      );
-
-      expect(result).toBe("granola-folder/note-2024-01-01_10-30-00.md");
-    });
-
-    it("should not append date suffix when file exists with same granola_id", async () => {
-      const existingFile = new TFile("granola-folder/note.md");
-      mockApp.vault.getAbstractFileByPath.mockReturnValue(existingFile);
-      
-      // Pre-populate cache with same granola_id
-      fileSyncService.updateCache("doc-1", existingFile, "note");
-
-      const result = fileSyncService.resolveFilePath(
-        "note.md",
-        new Date(),
-        "doc-1",
         false
       );
 
@@ -529,12 +490,9 @@ describe("FileSyncService", () => {
     });
 
     it("should handle transcript files", () => {
-      mockApp.vault.getAbstractFileByPath.mockReturnValue(null);
-
       const result = fileSyncService.resolveFilePath(
         "note-transcript.md",
         new Date(),
-        "doc-1",
         true
       );
 
@@ -582,11 +540,12 @@ describe("FileSyncService", () => {
         "content",
         "doc-1",
         "note",
-        false
+        false,
+        expect.any(Date)
       );
     });
 
-    it("should use resolveFilePath for collision detection", async () => {
+    it("should use resolveFilePath to resolve the target path", async () => {
       jest.spyOn(fileSyncService, "ensureFolder").mockResolvedValue(true);
       const resolveFilePathSpy = jest
         .spyOn(fileSyncService, "resolveFilePath")
@@ -605,7 +564,6 @@ describe("FileSyncService", () => {
       expect(resolveFilePathSpy).toHaveBeenCalledWith(
         "note.md",
         expect.any(Date),
-        "doc-1",
         false
       );
       expect(saveFileSpy).toHaveBeenCalledWith(
@@ -613,7 +571,8 @@ describe("FileSyncService", () => {
         "content",
         "doc-1",
         "note",
-        false
+        false,
+        expect.any(Date)
       );
     });
 
@@ -761,7 +720,6 @@ describe("FileSyncService", () => {
       expect(result.saved).toBe(true);
       expect(mockDocumentProcessor.prepareNote).toHaveBeenCalledWith(
         doc,
-        undefined,
         undefined
       );
       expect(saveFileSpy).toHaveBeenCalledWith(
@@ -769,32 +727,8 @@ describe("FileSyncService", () => {
         expect.any(String),
         "doc-1",
         "note",
-        false
-      );
-    });
-
-    it("should pass transcriptPath to prepareNote when provided", async () => {
-      const doc = { id: "doc-1" } as GranolaDoc;
-      const noteDate = new Date("2024-01-02T12:00:00Z");
-      mockDocumentProcessor.prepareNote.mockReturnValue({
-        filename: "note.md",
-        content: "content",
-      });
-      jest.spyOn(dateUtils, "getNoteDate").mockReturnValue(noteDate);
-      jest.spyOn(fileSyncService, "saveFile" as any).mockResolvedValue(true);
-
-      const result = await fileSyncService.saveNoteToDisk(
-        doc,
-        mockDocumentProcessor,
         false,
-        "Transcripts/note-transcript.md"
-      );
-
-      expect(result.saved).toBe(true);
-      expect(mockDocumentProcessor.prepareNote).toHaveBeenCalledWith(
-        doc,
-        "Transcripts/note-transcript.md",
-        undefined
+        expect.any(Date)
       );
     });
 
@@ -842,16 +776,10 @@ describe("FileSyncService", () => {
           }
         );
 
-      await fileSyncService.saveNoteToDisk(
-        doc,
-        mockDocumentProcessor,
-        false,
-        undefined
-      );
+      await fileSyncService.saveNoteToDisk(doc, mockDocumentProcessor, false);
 
       expect(mockDocumentProcessor.prepareNote).toHaveBeenCalledWith(
         doc,
-        undefined,
         undefined
       );
       expect(requestUrlSpy).toHaveBeenCalledTimes(1);
@@ -1697,6 +1625,115 @@ describe("FileSyncService", () => {
     });
   });
 
+  describe("createNewFile collision recovery (issue #61)", () => {
+    it("recovers from a create collision by saving under a date-suffixed name", async () => {
+      jest
+        .spyOn(dateUtils, "formatDateForFilename")
+        .mockReturnValue("2024-01-01 10-30-00");
+      const suffixedPath = "granola-folder/note-2024-01-01_10-30-00.md";
+      const createdFile = new TFile(suffixedPath);
+      mockApp.vault.create
+        .mockRejectedValueOnce(new Error("File already exists."))
+        .mockResolvedValueOnce(createdFile);
+
+      const result = await fileSyncService.saveFile(
+        "granola-folder/note.md",
+        "content",
+        "id-1",
+        "note",
+        false,
+        new Date("2024-01-01T10:30:00Z")
+      );
+
+      expect(result).toBe(true);
+      expect(mockApp.vault.create).toHaveBeenNthCalledWith(
+        1,
+        "granola-folder/note.md",
+        "content"
+      );
+      expect(mockApp.vault.create).toHaveBeenNthCalledWith(
+        2,
+        suffixedPath,
+        "content"
+      );
+      // Cache points at the file that was actually created on disk.
+      expect(fileSyncService.findByGranolaId("id-1", "note")).toBe(createdFile);
+    });
+
+    it("appends a numeric counter when the date-suffixed name also collides", async () => {
+      jest
+        .spyOn(dateUtils, "formatDateForFilename")
+        .mockReturnValue("2024-01-01 10-30-00");
+      const finalPath = "granola-folder/note-2024-01-01_10-30-00-2.md";
+      mockApp.vault.create
+        .mockRejectedValueOnce(new Error("File already exists."))
+        .mockRejectedValueOnce(new Error("File already exists."))
+        .mockResolvedValueOnce(new TFile(finalPath));
+
+      const result = await fileSyncService.saveFile(
+        "granola-folder/note.md",
+        "content",
+        "id-1",
+        "note",
+        false,
+        new Date("2024-01-01T10:30:00Z")
+      );
+
+      expect(result).toBe(true);
+      expect(mockApp.vault.create).toHaveBeenNthCalledWith(
+        3,
+        finalPath,
+        "content"
+      );
+    });
+
+    it("saves under a suffix when getAbstractFileByPath misses but create collides (case-insensitive FS)", async () => {
+      // The in-memory index lookup is case-sensitive and misses the existing
+      // case variant on disk...
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(null);
+      jest
+        .spyOn(dateUtils, "formatDateForFilename")
+        .mockReturnValue("2024-01-01 10-30-00");
+      // ...but the case-insensitive filesystem rejects the first create.
+      const suffixedPath =
+        "granola-transcripts/Instance AI standup-transcript-2024-01-01_10-30-00.md";
+      const createdFile = new TFile(suffixedPath);
+      mockApp.vault.create
+        .mockRejectedValueOnce(new Error("File already exists."))
+        .mockResolvedValueOnce(createdFile);
+
+      const result = await fileSyncService.saveFile(
+        "granola-transcripts/Instance AI standup-transcript.md",
+        "transcript content",
+        "e7b12999",
+        "transcript",
+        false,
+        new Date("2024-01-01T10:30:00Z")
+      );
+
+      expect(result).toBe(true);
+      expect(fileSyncService.findByGranolaId("e7b12999", "transcript")).toBe(
+        createdFile
+      );
+    });
+
+    it("does not retry on a non-collision error", async () => {
+      mockApp.vault.create.mockRejectedValue(new Error("Disk full"));
+
+      const result = await fileSyncService.saveFile(
+        "granola-folder/note.md",
+        "content",
+        "id-1",
+        "note",
+        false,
+        new Date()
+      );
+
+      expect(result).toBe(false);
+      expect(mockApp.vault.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("clearCache and getCacheSize", () => {
     it("should clear the cache", async () => {
       const mockFile = { path: "note.md" } as TFile;
@@ -1773,7 +1810,8 @@ describe("FileSyncService", () => {
         "content",
         "doc-1",
         "note",
-        true // forceOverwrite should be passed through
+        true, // forceOverwrite should be passed through
+        expect.any(Date)
       );
     });
 
@@ -1801,7 +1839,8 @@ describe("FileSyncService", () => {
         expect.any(String),
         "doc-1",
         "note",
-        true // forceOverwrite should be passed through
+        true, // forceOverwrite should be passed through
+        expect.any(Date)
       );
     });
 
@@ -1834,7 +1873,8 @@ describe("FileSyncService", () => {
         "transcript content",
         "doc-1",
         "transcript",
-        true // forceOverwrite should be passed through
+        true, // forceOverwrite should be passed through
+        expect.any(Date)
       );
     });
   });

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -609,7 +609,6 @@ describe("GranolaSync", () => {
         docWithContent,
         mockDocumentProcessor,
         true,
-        undefined,
         undefined
       );
     });


### PR DESCRIPTION
## Summary
Fixes #61 — transcripts/notes for recurring meetings were intermittently dropped with `Error saving file to disk: File already exists.`

Recurring meetings share a title (e.g. "Instance AI standup"), so each occurrence's transcript resolves to the same path. The collision pre-check in `resolveFilePath` used `vault.getAbstractFileByPath` — a **case-sensitive** in-memory index lookup. On case-insensitive filesystems (macOS/Windows) it misses a case/normalization variant already on disk, so no date suffix was added, and the subsequent `vault.create` collided and threw — silently dropping the file.

### Changes
- **`createNewFile` treats the filesystem as the source of truth.** It catches the "already exists" error from `vault.create` and retries under a date suffix (`…-{date}.md`), then a numeric counter (`…-{date}-2.md`), caching the file actually written. Genuine errors (e.g. "Disk full") are rethrown unchanged.
- **Dropped the fragile `resolveFilePath` pre-check** and its now-unused `granolaId` param; it just returns the ideal path.
- **Removed `prepareNote`'s vestigial `transcriptPath` param.** Separate-file cross-links are already written post-hoc by `updateCrossLinks` using real on-disk paths; combined mode is unaffected.

### Why catch-on-create instead of a better pre-check
`adapter.exists()` would match filesystem semantics, but any check-then-create is racy (TOCTOU). Letting `create` be the authority is both correct on case-insensitive volumes and race-free.

> Note: the owner-side case drift (a case-only `vault.rename` that fails silently in `attemptRename` when a meeting title's casing changes) is what *produces* the colliding variant. This PR stops new docs being dropped; recasing the existing owner file is a separable follow-up.

## Test plan
- [x] `eslint src` clean
- [x] `tsc -noEmit` clean
- [x] `jest` — 506 passing (+4 new regression tests, incl. the issue #61 case-insensitive scenario: index miss + create collision now saves under a suffix)
- [x] `npm run build` succeeds
- [ ] Manual: re-sync a vault with multiple same-titled recurring-meeting transcripts and confirm each is saved (date-suffixed) with no "File already exists" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)