### PR TITLE
feat: add toggle to silence sync notifications (#133)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { moment } from "./utils/moment";
 import { getDailyNote, getAllDailyNotes } from "obsidian-daily-notes-interface";
 import { getTitleOrDefault } from "./utils/filenameUtils";
+import { notifySync } from "./utils/notify";
 import { getNoteDate, getEffectiveUpdatedAt } from "./utils/dateUtils";
 import {
   GranolaSyncSettings,
@@ -77,9 +78,15 @@ export default class GranolaSync extends Plugin {
       id: "sync-granola",
       name: "Sync from Granola",
       callback: async () => {
-        new Notice("Granola sync: Starting manual sync.");
+        notifySync(
+          this.settings.showSyncNotifications,
+          "Granola sync: Starting manual sync."
+        );
         await this.sync();
-        new Notice("Granola sync: Manual sync complete.");
+        notifySync(
+          this.settings.showSyncNotifications,
+          "Granola sync: Manual sync complete."
+        );
 
         if (!this.settings.syncNotes && !this.settings.syncTranscripts) {
           new Notice(
@@ -513,7 +520,8 @@ export default class GranolaSync extends Plugin {
     );
 
     if (documents.length === 0) {
-      new Notice(
+      notifySync(
+        this.settings.showSyncNotifications,
         mode === "full"
           ? "Granola sync: No documents returned from Granola API."
           : `Granola sync: No documents found within the last ${this.settings.syncDaysBack} days.`,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,5 @@
 import { App, PluginSettingTab, Setting, Notice } from "obsidian";
+import { notifySync } from "./utils/notify";
 import type GranolaSync from "./main";
 import type { FolderMapData } from "./services/folderMapBuilder";
 import bmcButtonSvg from "../assets/bmc-button.svg";
@@ -114,6 +115,7 @@ export type GranolaSyncSettings = NoteSettings &
   AutomaticSyncSettings &
   FilterSettings & {
     enableDebugLogging: boolean;
+    showSyncNotifications: boolean;
     // Persisted folder map for detecting renames across syncs
     _folderMapCache?: FolderMapData;
     // Legacy settings preserved for potential rollback
@@ -149,6 +151,8 @@ export const DEFAULT_SETTINGS: GranolaSyncSettings = {
   transcriptFilenamePattern: "{title}-transcript",
   // Debug / diagnostics
   enableDebugLogging: false,
+  // Notifications
+  showSyncNotifications: true,
 };
 
 /**
@@ -314,6 +318,20 @@ export class GranolaSyncSettingTab extends PluginSettingTab {
             this.plugin.settings.syncTranscripts = value;
             await this.plugin.saveSettings();
             this.display();
+          })
+      );
+
+    new Setting(containerEl)
+      .setName("Show sync notifications")
+      .setDesc(
+        "Show a notice when a sync starts or finishes. Errors are always shown."
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.showSyncNotifications)
+          .onChange(async (value) => {
+            this.plugin.settings.showSyncNotifications = value;
+            await this.plugin.saveSettings();
           })
       );
 
@@ -637,9 +655,10 @@ export class GranolaSyncSettingTab extends PluginSettingTab {
             .setButtonText("Full sync")
             .setCta()
             .onClick(async () => {
-              new Notice("Granola sync: Starting full sync.");
+              const showNotices = this.plugin.settings.showSyncNotifications;
+              notifySync(showNotices, "Granola sync: Starting full sync.");
               await this.plugin.sync({ mode: "full" });
-              new Notice("Granola sync: Full sync complete.");
+              notifySync(showNotices, "Granola sync: Full sync complete.");
             })
         );
 

--- a/src/utils/notify.ts
+++ b/src/utils/notify.ts
@@ -1,0 +1,22 @@
+import { Notice } from "obsidian";
+
+/**
+ * Centralised wrapper around Obsidian's `Notice` for routine sync-status
+ * messages (sync started/complete, no documents found).
+ *
+ * These notices are shown only when the user has sync notifications enabled.
+ * Error notices should NOT use this helper - they call `new Notice(...)`
+ * directly so they always surface regardless of the user's setting.
+ *
+ * @param show - Whether sync notifications are enabled (`settings.showSyncNotifications`).
+ * @param message - The notice text to display.
+ * @param timeout - Optional display duration in milliseconds.
+ * @returns The created `Notice`, or `null` when notifications are disabled.
+ */
+export function notifySync(
+  show: boolean,
+  message: string,
+  timeout?: number
+): Notice | null {
+  return show ? new Notice(message, timeout) : null;
+}

--- a/tests/unit/notify.test.ts
+++ b/tests/unit/notify.test.ts
@@ -1,0 +1,43 @@
+import { Notice } from "obsidian";
+import { notifySync } from "../../src/utils/notify";
+
+// `Notice` is the manual mock from tests/__mocks__/obsidian.ts (a jest.fn()).
+const NoticeMock = Notice as unknown as jest.Mock;
+
+describe("notifySync", () => {
+  beforeEach(() => {
+    NoticeMock.mockClear();
+  });
+
+  it("shows a notice when sync notifications are enabled", () => {
+    notifySync(true, "Granola sync: Manual sync complete.");
+
+    expect(NoticeMock).toHaveBeenCalledTimes(1);
+    expect(NoticeMock).toHaveBeenCalledWith(
+      "Granola sync: Manual sync complete.",
+      undefined
+    );
+  });
+
+  it("forwards the timeout argument to Notice", () => {
+    notifySync(true, "Granola sync: No documents found.", 5000);
+
+    expect(NoticeMock).toHaveBeenCalledWith(
+      "Granola sync: No documents found.",
+      5000
+    );
+  });
+
+  it("returns the created Notice when enabled", () => {
+    const result = notifySync(true, "Granola sync: Starting manual sync.");
+
+    expect(result).not.toBeNull();
+  });
+
+  it("suppresses the notice when sync notifications are disabled", () => {
+    const result = notifySync(false, "Granola sync: Manual sync complete.");
+
+    expect(NoticeMock).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #133.

Adds a single **Show sync notifications** toggle (General section, default ON, so no behavior change for existing users). When off, routine sync notices are suppressed; error notices always show.

Per your suggestion I added a tiny wrapper, `notifySync()` (`src/utils/notify.ts`), around `Notice` to centralise the show/hide logic, and routed the routine "Granola sync:" start/complete/no-documents notices through it. Errors keep calling `new Notice` directly so they always surface regardless of the setting.

**Gated by the toggle (routine status):**
- manual sync start + complete
- full sync start + complete
- "No documents found / No documents returned"

**Always shown (unchanged):** all error notices (credential/API/transcript/file-save), the "no sync options enabled" config warning, and command feedback (debug logs, clipboard, input validation).

Scope note: I left the folder-error and daily-note section notices on plain `new Notice` since they report real problems rather than routine sync status. Happy to fold any of those under the toggle if you'd prefer.

Added unit tests for `notifySync` (on/off behavior + timeout passthrough). `tsc`, `eslint`, and the full jest suite pass locally.