### PR TITLE
fix: chunk get-documents-batch requests to 50 IDs so shared notes sync

### DIFF
--- a/src/services/granolaApi.ts
+++ b/src/services/granolaApi.ts
@@ -349,16 +349,20 @@ export async function fetchDocumentSet(
 }
 
 /**
- * Fetches full document data for a batch of document IDs.
+ * Maximum number of document IDs the v1/get-documents-batch endpoint accepts per
+ * request. The API returns 400 ("Bad Request") for any request with more than 50
+ * IDs, so larger requests must be split into chunks.
+ */
+const DOCUMENTS_BATCH_SIZE = 50;
+
+/**
+ * Fetches full document data for a single chunk of document IDs (≤ DOCUMENTS_BATCH_SIZE).
  * Uses the v1/get-documents-batch endpoint.
  */
-export async function fetchDocumentsBatch(
+async function fetchDocumentsBatchChunk(
   accessToken: string,
   documentIds: string[]
 ): Promise<GranolaDoc[]> {
-  if (documentIds.length === 0) return [];
-
-  log.debug(`Fetching documents batch — ${documentIds.length} ID(s)`);
   const response = await requestUrl({
     url: "https://api.granola.ai/v1/get-documents-batch",
     method: "POST",
@@ -380,8 +384,42 @@ export async function fetchDocumentsBatch(
     throw new Error("Invalid response from Granola API (DocumentsBatchResponseSchema)");
   }
 
-  log.debug(`Fetched ${result.output.docs.length} document(s) in batch`);
   return result.output.docs as GranolaDoc[];
+}
+
+/**
+ * Fetches full document data for a batch of document IDs.
+ * Uses the v1/get-documents-batch endpoint.
+ *
+ * The endpoint accepts at most DOCUMENTS_BATCH_SIZE (50) IDs per request — larger
+ * requests return 400. IDs are therefore split into chunks of ≤ DOCUMENTS_BATCH_SIZE
+ * and fetched with one request per chunk, concatenating the results. A failing chunk
+ * is logged and skipped so that documents fetched in other chunks are not discarded.
+ */
+export async function fetchDocumentsBatch(
+  accessToken: string,
+  documentIds: string[]
+): Promise<GranolaDoc[]> {
+  if (documentIds.length === 0) return [];
+
+  log.debug(`Fetching documents batch — ${documentIds.length} ID(s)`);
+
+  const docs: GranolaDoc[] = [];
+  for (let i = 0; i < documentIds.length; i += DOCUMENTS_BATCH_SIZE) {
+    const chunk = documentIds.slice(i, i + DOCUMENTS_BATCH_SIZE);
+    try {
+      const chunkDocs = await fetchDocumentsBatchChunk(accessToken, chunk);
+      docs.push(...chunkDocs);
+    } catch (error) {
+      log.error(
+        `Failed to fetch documents batch chunk (IDs ${i}–${i + chunk.length - 1} of ${documentIds.length}), continuing with remaining chunks:`,
+        error
+      );
+    }
+  }
+
+  log.debug(`Fetched ${docs.length} document(s) in batch`);
+  return docs;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/granolaApi.test.ts
+++ b/tests/unit/granolaApi.test.ts
@@ -704,14 +704,99 @@ describe("fetchDocumentsBatch", () => {
     );
   });
 
-  it("should throw on invalid response", async () => {
+  it("should skip and log a chunk with an invalid response instead of throwing", async () => {
     (requestUrl as jest.Mock).mockResolvedValue({
       json: { not_docs: [] },
     });
 
-    await expect(
-      fetchDocumentsBatch(mockAccessToken, ["doc-1"])
-    ).rejects.toThrow("Invalid response from Granola API (DocumentsBatchResponseSchema)");
+    const result = await fetchDocumentsBatch(mockAccessToken, ["doc-1"]);
+
+    expect(result).toEqual([]);
+    expect(log.error).toHaveBeenCalled();
+  });
+
+  it("should send all IDs in a single request when at the 50-ID limit", async () => {
+    const ids = Array.from({ length: 50 }, (_, i) => `doc-${i}`);
+    (requestUrl as jest.Mock).mockResolvedValue({
+      json: { docs: ids.map((id) => ({ id, title: id })) },
+    });
+
+    const result = await fetchDocumentsBatch(mockAccessToken, ids);
+
+    expect(result).toHaveLength(50);
+    expect(requestUrl).toHaveBeenCalledTimes(1);
+    expect(requestUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: JSON.stringify({ document_ids: ids }),
+      })
+    );
+  });
+
+  it("should split into multiple chunks when over the 50-ID limit and merge all docs", async () => {
+    const ids = Array.from({ length: 51 }, (_, i) => `doc-${i}`);
+    (requestUrl as jest.Mock).mockImplementation(({ body }: { body: string }) => {
+      const { document_ids } = JSON.parse(body) as { document_ids: string[] };
+      return Promise.resolve({
+        json: { docs: document_ids.map((id) => ({ id, title: id })) },
+      });
+    });
+
+    const result = await fetchDocumentsBatch(mockAccessToken, ids);
+
+    expect(requestUrl).toHaveBeenCalledTimes(2);
+    expect(result).toHaveLength(51);
+    expect(result.map((d) => d.id).sort((a, b) => a.localeCompare(b))).toEqual(
+      [...ids].sort((a, b) => a.localeCompare(b))
+    );
+    // First chunk has 50 IDs, second chunk has the remaining 1
+    const firstChunk = JSON.parse(
+      (requestUrl as jest.Mock).mock.calls[0][0].body
+    ).document_ids;
+    const secondChunk = JSON.parse(
+      (requestUrl as jest.Mock).mock.calls[1][0].body
+    ).document_ids;
+    expect(firstChunk).toHaveLength(50);
+    expect(secondChunk).toHaveLength(1);
+  });
+
+  it("should chunk a large set of IDs into requests of at most 50", async () => {
+    const ids = Array.from({ length: 361 }, (_, i) => `doc-${i}`);
+    (requestUrl as jest.Mock).mockImplementation(({ body }: { body: string }) => {
+      const { document_ids } = JSON.parse(body) as { document_ids: string[] };
+      return Promise.resolve({
+        json: { docs: document_ids.map((id) => ({ id, title: id })) },
+      });
+    });
+
+    const result = await fetchDocumentsBatch(mockAccessToken, ids);
+
+    expect(result).toHaveLength(361);
+    expect(requestUrl).toHaveBeenCalledTimes(8); // ceil(361 / 50)
+    for (const call of (requestUrl as jest.Mock).mock.calls) {
+      const { document_ids } = JSON.parse(call[0].body) as { document_ids: string[] };
+      expect(document_ids.length).toBeLessThanOrEqual(50);
+    }
+  });
+
+  it("should keep docs from successful chunks when one chunk fails", async () => {
+    const ids = Array.from({ length: 100 }, (_, i) => `doc-${i}`);
+    (requestUrl as jest.Mock)
+      // First chunk (50 IDs) succeeds
+      .mockImplementationOnce(({ body }: { body: string }) => {
+        const { document_ids } = JSON.parse(body) as { document_ids: string[] };
+        return Promise.resolve({
+          json: { docs: document_ids.map((id) => ({ id, title: id })) },
+        });
+      })
+      // Second chunk fails (simulates a 400)
+      .mockRejectedValueOnce(new Error("Bad Request"));
+
+    const result = await fetchDocumentsBatch(mockAccessToken, ids);
+
+    expect(requestUrl).toHaveBeenCalledTimes(2);
+    expect(result).toHaveLength(50);
+    expect(result.every((d) => d.id.startsWith("doc-"))).toBe(true);
+    expect(log.error).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes shared notes silently failing to sync for accounts with many documents.

The Granola `v1/get-documents-batch` endpoint accepts a **maximum of 50 document IDs per request** — 51+ IDs return `400 {"message":"Bad Request"}`. `fetchDocumentsBatch` previously sent *all* missing/shared IDs in a single unbounded request. When more than 50 docs were missing from the owned set, the request 400'd, the catch in `mergeSharedDocuments` logged *"Failed to fetch shared documents batch, continuing with owned docs only"*, and **every** shared note was dropped. This is why cache-clearing and reauth didn't help — it was request size, not credentials.

## Changes

- **`src/services/granolaApi.ts`**
  - Added a `DOCUMENTS_BATCH_SIZE = 50` constant.
  - Extracted the single-request logic into `fetchDocumentsBatchChunk` (keeps the existing `DocumentsBatchResponseSchema` validation per chunk).
  - `fetchDocumentsBatch` now splits `documentIds` into chunks of ≤50, issues one request per chunk, and concatenates `docs`.
  - **Per-chunk error isolation**: a failing chunk is logged and skipped so that docs already fetched in other chunks are retained. The `mergeSharedDocuments` catch is now a true last-resort fallback rather than the common path.

## Tests

Added unit tests in `tests/unit/granolaApi.test.ts` covering:
- ≤50 IDs → single request
- 51 IDs → 2 chunks (50 + 1), all docs merged
- 361 IDs → 8 chunks, each ≤50, all 361 docs returned
- One chunk failing does not discard docs from successful chunks
- An invalid-response chunk is logged and skipped instead of throwing

All `granolaApi.test.ts` tests pass (43/43).

> Note: the full test suite could not be run end-to-end in this environment because two `github:` dependencies (`@tomelliot/obsidian-logger`, `obsidian-daily-notes-interface`) are blocked by the session's egress policy (403). Six unrelated suites fail solely on those missing modules; the `granolaApi` suite relevant to this change runs and passes.

Closes #138
Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sgERR7yaSSMbmtihQADk4

---
_Generated by [Claude Code](https://claude.ai/code/session_015sgERR7yaSSMbmtihQADk4)_