### PR TITLE
Fix YAML frontmatter generation for multi-line titles (issue #139)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,11 @@ process.env.TZ = "UTC";
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "jsdom",
+  // Resolve dual CJS/ESM packages (e.g. `yaml`) to their Node/CommonJS build.
+  // jsdom otherwise selects the "browser" ESM entry, which Jest can't parse.
+  testEnvironmentOptions: {
+    customExportConditions: ["node", "node-addons"],
+  },
   roots: ["<rootDir>/tests"],
   testMatch: ["**/*.test.ts"],
   moduleFileExtensions: ["ts", "js", "json", "node"],

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "tslib": "2.4.1",
     "tsx": "^4.7.0",
     "typescript": "5.2.2",
-    "typescript-eslint": "^8.47.0"
+    "typescript-eslint": "^8.47.0",
+    "yaml": "2.9.0"
   },
   "dependencies": {
     "@napi-rs/keyring": "^1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       typescript-eslint:
         specifier: ^8.47.0
         version: 8.47.0(eslint@9.39.1)(typescript@5.2.2)
+      yaml:
+        specifier: 2.9.0
+        version: 2.9.0
 
 packages:
 

--- a/src/services/documentProcessor.ts
+++ b/src/services/documentProcessor.ts
@@ -1,4 +1,3 @@
-import { stringifyYaml } from "obsidian";
 import { GranolaDoc } from "./granolaApi";
 import { convertProsemirrorToMarkdown } from "./prosemirrorMarkdown";
 import { convertHtmlToMarkdown } from "./htmlMarkdown";
@@ -9,6 +8,7 @@ import {
 import { getEffectiveUpdatedAt } from "../utils/dateUtils";
 import { PathResolver } from "./pathResolver";
 import {
+  buildTitleYaml,
   formatAttendeesAsYaml,
   formatStringListAsYaml,
 } from "../utils/yamlUtils";
@@ -170,7 +170,7 @@ export class DocumentProcessor {
     const frontmatterLines = [
       "---",
       `granola_id: ${metadata.granolaId}`,
-      `title: ${stringifyYaml(metadata.title).trim()}`,
+      buildTitleYaml(metadata.title),
       `type: ${metadata.type}`,
     ];
     if (metadata.createdAt) frontmatterLines.push(`created: ${metadata.createdAt}`);
@@ -243,7 +243,7 @@ export class DocumentProcessor {
     const frontmatterLines = [
       "---",
       `granola_id: ${metadata.granolaId}`,
-      `title: ${stringifyYaml(metadata.title).trim()}`,
+      buildTitleYaml(metadata.title),
       `type: ${metadata.type}`,
     ];
     if (metadata.createdAt) frontmatterLines.push(`created: ${metadata.createdAt}`);

--- a/src/services/transcriptFormatter.ts
+++ b/src/services/transcriptFormatter.ts
@@ -1,6 +1,5 @@
-import { stringifyYaml } from "obsidian";
 import { TranscriptEntry } from "./granolaApi";
-import { formatAttendeesAsYaml } from "../utils/yamlUtils";
+import { buildTitleYaml, formatAttendeesAsYaml } from "../utils/yamlUtils";
 
 /**
  * Formats transcript body content into markdown, grouped by speaker.
@@ -87,7 +86,7 @@ export function formatTranscriptBySpeaker(
   const frontmatterLines = [
     "---",
     `granola_id: ${granolaId}`,
-    `title: ${stringifyYaml(`${title} - Transcript`).trim()}`,
+    buildTitleYaml(`${title} - Transcript`),
     `type: transcript`,
   ];
   if (createdAt) frontmatterLines.push(`created: ${createdAt}`);

--- a/src/utils/yamlUtils.ts
+++ b/src/utils/yamlUtils.ts
@@ -1,6 +1,26 @@
 import { stringifyYaml } from "obsidian";
 
 /**
+ * Builds the `title:` frontmatter line(s) for a note.
+ *
+ * The title is serialized by stringifying a single-key object rather than the
+ * bare string. This matters for multi-line titles: Obsidian's `stringifyYaml`
+ * (eemeli/yaml) renders a multi-line string as a block scalar, and only the
+ * object form indents the continuation lines correctly. Serializing the bare
+ * string and concatenating after `title: ` leaves continuation lines flush
+ * against column 0, which is invalid YAML — Obsidian's metadataCache then
+ * fails to parse the whole frontmatter, hiding `granola_id` and breaking
+ * deduplication (see issue #139).
+ *
+ * @param title - The note title (may contain newlines or YAML-special characters)
+ * @returns A valid YAML fragment, e.g. `title: Weekly Sync` or an indented
+ *   `title: |-` block scalar, with no trailing newline.
+ */
+export function buildTitleYaml(title: string): string {
+  return stringifyYaml({ title }).trimEnd();
+}
+
+/**
  * Formats an array of strings as a YAML list value.
  * Each item is properly escaped and formatted with proper indentation.
  *

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -1,3 +1,5 @@
+import { stringify as yamlStringify, parse as yamlParse } from "yaml";
+
 export const requestUrl = jest.fn();
 export const normalizePath = (path: string) => path.replace(/\\/g, "/");
 export const App = jest.fn();
@@ -70,29 +72,18 @@ export const Platform = {
 };
 
 /**
- * Mock implementation of Obsidian's stringifyYaml function
- * Converts a JavaScript value to YAML format
+ * Mock of Obsidian's stringifyYaml / parseYaml.
  *
- * Note: We assume Obsidian's stringifyYaml handles proper escaping of special characters.
- * This mock approximates real behavior: quotes strings containing special YAML
- * characters and replaces newlines, and always appends a trailing newline.
+ * Obsidian's YAML helpers wrap the eemeli `yaml` library. We delegate to that
+ * same library (pinned in devDependencies) instead of approximating it, so
+ * tests exercise real YAML serialization — block scalars, quoting, escaping —
+ * and can catch invalid output such as the unindented block scalar behind
+ * issue #139. A hand-rolled approximation previously masked that bug.
  */
 export function stringifyYaml(value: unknown): string {
-  if (typeof value === "string") {
-    // Approximate real YAML: quote if the string contains special characters
-    const needsQuoting = /["'\n\r:#{}[\],&*?|>!%@`]/.test(value);
-    if (needsQuoting) {
-      const escaped = value
-        .replace(/\\/g, "\\\\")
-        .replace(/"/g, '\\"')
-        .replace(/\n/g, "\\n")
-        .replace(/\r/g, "\\r");
-      return `"${escaped}"\n`;
-    }
-    return `${value}\n`;
-  }
+  return yamlStringify(value);
+}
 
-  // For arrays, objects, etc., use JSON stringification as a simple mock
-  // In real Obsidian, this would use a proper YAML library
-  return JSON.stringify(value) + "\n";
+export function parseYaml(value: string): unknown {
+  return yamlParse(value);
 }

--- a/tests/helpers/frontmatter.ts
+++ b/tests/helpers/frontmatter.ts
@@ -1,0 +1,35 @@
+import { parseYaml } from "obsidian";
+
+/**
+ * Extracts and parses the YAML frontmatter block from generated note content,
+ * mirroring how Obsidian's metadataCache reads it.
+ *
+ * Throws if the frontmatter is missing or invalid YAML — which is precisely the
+ * failure mode behind issue #139: a multi-line title serialized as an
+ * unindented block scalar makes the whole frontmatter unparseable, so
+ * `granola_id` becomes invisible to the metadata cache and deduplication
+ * breaks. Tests assert against the parsed object so that any regression to
+ * invalid YAML surfaces as a thrown error rather than passing silently.
+ */
+export function parseFrontmatter(content: string): Record<string, unknown> {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) {
+    throw new Error("No YAML frontmatter block found in content");
+  }
+  return (parseYaml(match[1]) ?? {}) as Record<string, unknown>;
+}
+
+/**
+ * Titles that previously produced invalid YAML frontmatter (issue #139) or that
+ * exercise YAML-special characters. Each entry is [description, rawTitle].
+ */
+export const TRICKY_TITLES: ReadonlyArray<readonly [string, string]> = [
+  ["mid-line newline (#139)", "WPT Leads IP Sprint Alignment\n — cycle planning with Lindsay"],
+  ["leading newline", "\nMeeting Title With Leading Newline"],
+  ["CRLF newline", "Line one\r\nLine two"],
+  ["multiple blank lines", "Foo\n\n\nbar"],
+  ["colon", "Project: Kickoff"],
+  ["double quotes", 'Note with "quotes"'],
+  ["leading dash", "- bullet-looking title"],
+  ["leading hash", "#standup notes"],
+];

--- a/tests/unit/documentProcessor.test.ts
+++ b/tests/unit/documentProcessor.test.ts
@@ -1,6 +1,7 @@
 import { DocumentProcessor } from "../../src/services/documentProcessor";
 import { GranolaDoc } from "../../src/services/granolaApi";
 import { PathResolver } from "../../src/services/pathResolver";
+import { parseFrontmatter, TRICKY_TITLES } from "../helpers/frontmatter";
 
 // Mock convertProsemirrorToMarkdown: While this is a pure function, we mock it to
 // isolate DocumentProcessor's logic (frontmatter generation, formatting) from
@@ -130,30 +131,30 @@ describe("DocumentProcessor", () => {
 
       const result = documentProcessor.prepareNote(doc);
 
-      expect(result.content).toContain('title: "Note with \\"quotes\\""');
+      // Frontmatter must be valid YAML and round-trip the title exactly.
+      const fm = parseFrontmatter(result.content);
+      expect(fm.title).toBe('Note with "quotes"');
     });
 
-    it("should sanitize newlines in titles for YAML frontmatter", () => {
-      const doc: GranolaDoc = {
-        id: "doc-newline",
-        title: "\nMeeting Title With Leading Newline",
-        last_viewed_panel: {
-          content: {
-            type: "doc",
-            content: [],
-          },
-        },
-      };
+    it.each(TRICKY_TITLES)(
+      "should write valid YAML frontmatter for a title with %s (issue #139)",
+      (_label, title) => {
+        const doc: GranolaDoc = {
+          id: "doc-tricky",
+          title,
+          last_viewed_panel: { content: { type: "doc", content: [] } },
+        };
 
-      const result = documentProcessor.prepareNote(doc);
+        const result = documentProcessor.prepareNote(doc);
 
-      // Title should be on a single line — no raw newlines breaking YAML
-      const frontmatter = result.content.split("---")[1];
-      const titleLine = frontmatter.split("\n").find((l: string) => l.startsWith("title:"));
-      expect(titleLine).toBeDefined();
-      // The title value should not contain a raw newline
-      expect(titleLine).not.toMatch(/title:.*\n.*\n/);
-    });
+        // parseFrontmatter throws on invalid YAML — the #139 failure mode.
+        const fm = parseFrontmatter(result.content);
+        // granola_id must remain readable so deduplication keeps working.
+        expect(fm.granola_id).toBe("doc-tricky");
+        // The (multi-line) title is preserved exactly through the round-trip.
+        expect(fm.title).toBe(title);
+      }
+    );
 
     it("should not add transcript field when path not provided", () => {
       documentProcessor = new DocumentProcessor(
@@ -571,33 +572,31 @@ describe("DocumentProcessor", () => {
         transcriptContent
       );
 
-      expect(result.content).toContain('title: "Note with \\"quotes\\""');
+      const fm = parseFrontmatter(result.content);
+      expect(fm.title).toBe('Note with "quotes"');
     });
 
-    it("should sanitize newlines in titles for YAML frontmatter", () => {
-      const doc: GranolaDoc = {
-        id: "doc-newline",
-        title: "\nMeeting Title With Leading Newline",
-        last_viewed_panel: {
-          content: {
-            type: "doc",
-            content: [],
-          },
-        },
-      };
+    it.each(TRICKY_TITLES)(
+      "should write valid YAML frontmatter for a title with %s (issue #139)",
+      (_label, title) => {
+        const doc: GranolaDoc = {
+          id: "doc-tricky",
+          title,
+          last_viewed_panel: { content: { type: "doc", content: [] } },
+        };
 
-      const transcriptContent = "## You (00:00:01)\n\nTest.\n\n";
+        const transcriptContent = "## You (00:00:01)\n\nTest.\n\n";
 
-      const result = documentProcessor.prepareCombinedNote(
-        doc,
-        transcriptContent
-      );
+        const result = documentProcessor.prepareCombinedNote(
+          doc,
+          transcriptContent
+        );
 
-      const frontmatter = result.content.split("---")[1];
-      const titleLine = frontmatter.split("\n").find((l: string) => l.startsWith("title:"));
-      expect(titleLine).toBeDefined();
-      expect(titleLine).not.toMatch(/title:.*\n.*\n/);
-    });
+        const fm = parseFrontmatter(result.content);
+        expect(fm.granola_id).toBe("doc-tricky");
+        expect(fm.title).toBe(title);
+      }
+    );
 
     it("should place transcript content after note content", () => {
       const doc: GranolaDoc = {

--- a/tests/unit/transcriptFormatter.test.ts
+++ b/tests/unit/transcriptFormatter.test.ts
@@ -3,6 +3,19 @@ import {
   formatTranscriptBody,
 } from "../../src/services/transcriptFormatter";
 import { TranscriptEntry } from "../../src/services/granolaApi";
+import { parseFrontmatter, TRICKY_TITLES } from "../helpers/frontmatter";
+
+const SINGLE_ENTRY: TranscriptEntry[] = [
+  {
+    document_id: "doc1",
+    start_timestamp: "00:00:01",
+    end_timestamp: "00:00:05",
+    text: "Test text",
+    source: "microphone",
+    id: "entry1",
+    is_final: true,
+  },
+];
 
 describe("formatTranscriptBySpeaker", () => {
   beforeEach(() => {
@@ -118,53 +131,29 @@ describe("formatTranscriptBySpeaker", () => {
   });
 
   it("should escape quotes in title for YAML frontmatter", () => {
-    const transcriptData: TranscriptEntry[] = [
-      {
-        document_id: "doc1",
-        start_timestamp: "00:00:01",
-        end_timestamp: "00:00:05",
-        text: "Test text",
-        source: "microphone",
-        id: "entry1",
-        is_final: true,
-      },
-    ];
-
     const result = formatTranscriptBySpeaker(
-      transcriptData,
+      SINGLE_ENTRY,
       'Meeting "Project Alpha"',
       "test-id"
     );
 
-    expect(result).toContain(
-      'title: "Meeting \\"Project Alpha\\" - Transcript"'
-    );
+    const fm = parseFrontmatter(result);
+    expect(fm.title).toBe('Meeting "Project Alpha" - Transcript');
   });
 
-  it("should sanitize newlines in title for YAML frontmatter", () => {
-    const transcriptData: TranscriptEntry[] = [
-      {
-        document_id: "doc1",
-        start_timestamp: "00:00:01",
-        end_timestamp: "00:00:05",
-        text: "Test text",
-        source: "microphone",
-        id: "entry1",
-        is_final: true,
-      },
-    ];
+  it.each(TRICKY_TITLES)(
+    "should write valid YAML frontmatter for a title with %s (issue #139)",
+    (_label, title) => {
+      const result = formatTranscriptBySpeaker(SINGLE_ENTRY, title, "test-id");
 
-    const result = formatTranscriptBySpeaker(
-      transcriptData,
-      "\nMeeting With Newline",
-      "test-id"
-    );
-
-    const frontmatter = result.split("---")[1];
-    const titleLine = frontmatter.split("\n").find((l: string) => l.startsWith("title:"));
-    expect(titleLine).toBeDefined();
-    expect(titleLine).not.toMatch(/title:.*\n.*\n/);
-  });
+      // parseFrontmatter throws on invalid YAML — the #139 failure mode.
+      const fm = parseFrontmatter(result);
+      // granola_id must remain readable so transcript dedup keeps working.
+      expect(fm.granola_id).toBe("test-id");
+      // Title is preserved exactly, with the " - Transcript" suffix appended.
+      expect(fm.title).toBe(`${title} - Transcript`);
+    }
+  );
 
   it("should distinguish between microphone and speaker sources", () => {
     const transcriptData: TranscriptEntry[] = [

--- a/tests/unit/yamlUtils.test.ts
+++ b/tests/unit/yamlUtils.test.ts
@@ -1,7 +1,37 @@
-import { formatAttendeesAsYaml } from "../../src/utils/yamlUtils";
+import { parseYaml } from "obsidian";
+import {
+  buildTitleYaml,
+  formatAttendeesAsYaml,
+} from "../../src/utils/yamlUtils";
+import { TRICKY_TITLES } from "../helpers/frontmatter";
 
-// Note: We assume Obsidian's stringifyYaml handles proper escaping of special characters.
-// These tests focus on the formatting logic (newlines, indentation, list structure).
+// Note: stringifyYaml/parseYaml are backed by the real `yaml` library in tests
+// (see tests/__mocks__/obsidian.ts), so these exercise real YAML serialization.
+
+describe("buildTitleYaml", () => {
+  it("emits a plain scalar for a simple single-line title", () => {
+    expect(buildTitleYaml("Weekly Sync")).toBe("title: Weekly Sync");
+  });
+
+  it("indents a multi-line title as a block scalar (issue #139)", () => {
+    const out = buildTitleYaml("Foo\n — bar");
+    // The fix: continuation lines are indented under the key, not flush-left.
+    // The old `title: ${stringifyYaml(t).trim()}` produced a flush-left block
+    // scalar, which is invalid YAML.
+    expect(out).toBe("title: |-\n  Foo\n   — bar");
+    out.split("\n").slice(1).forEach((line) => {
+      expect(line.startsWith("  ")).toBe(true);
+    });
+  });
+
+  it.each(TRICKY_TITLES)(
+    "round-trips a title with %s through a YAML parse",
+    (_label, title) => {
+      const parsed = parseYaml(buildTitleYaml(title)) as { title: string };
+      expect(parsed.title).toBe(title);
+    }
+  );
+});
 
 describe("formatAttendeesAsYaml", () => {
   it("should format a single attendee with leading newline", () => {


### PR DESCRIPTION
## Description

Fixes invalid YAML frontmatter generation when note titles contain newlines or other special characters. Previously, multi-line titles were serialized as unindented block scalars, making the entire frontmatter unparseable by Obsidian's metadata cache. This broke deduplication because `granola_id` became invisible.

### Root Cause
The old code concatenated `title: ` with the result of `stringifyYaml(title).trim()`. When `stringifyYaml` produces a block scalar for multi-line strings, the continuation lines are flush-left, which is invalid YAML syntax.

### Solution
Introduced `buildTitleYaml()` helper that serializes the title as part of an object (`{ title }`) rather than as a bare string. This ensures Obsidian's YAML library (eemeli/yaml) indents continuation lines correctly under the key.

### Changes
- **src/utils/yamlUtils.ts**: Added `buildTitleYaml()` function with detailed documentation
- **src/services/documentProcessor.ts**: Updated `prepareNote()` and `prepareCombinedNote()` to use `buildTitleYaml()`
- **src/services/transcriptFormatter.ts**: Updated `formatTranscriptBySpeaker()` to use `buildTitleYaml()`
- **tests/helpers/frontmatter.ts**: New helper module with `parseFrontmatter()` and `TRICKY_TITLES` test data
- **tests/unit/yamlUtils.test.ts**: Added comprehensive tests for `buildTitleYaml()` including multi-line and special-character cases
- **tests/unit/documentProcessor.test.ts**: Refactored title tests to use `parseFrontmatter()` and parameterized test cases
- **tests/unit/transcriptFormatter.test.ts**: Refactored title tests similarly
- **tests/__mocks__/obsidian.ts**: Replaced hand-rolled YAML mock with real `yaml` library to catch invalid output
- **jest.config.js**: Added `customExportConditions` to resolve dual CJS/ESM packages correctly

## Testing
- Added unit tests covering multi-line titles, YAML-special characters (colons, quotes, dashes, hashes), and CRLF newlines
- Tests now parse generated frontmatter and verify round-trip correctness, catching invalid YAML as thrown errors
- All existing tests pass with the new implementation
- Real YAML library used in tests ensures no regressions to invalid syntax

## Checklist
- [x] Self-review completed
- [x] Tests added/updated (comprehensive coverage of edge cases)
- [x] All tests pass
- [x] No new warnings introduced

https://claude.ai/code/session_01N7UdjqX1WfqsCQqZ4mBKMX

closes #139 